### PR TITLE
Temporarily blocking Fosshub (Hacked)

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -51,3 +51,6 @@
 # https://github.com/uBlockOrigin/uAssets/issues/79
 ||flexytalk.net^
 ||quickdomainfwd.com^
+
+# http://www.classicshell.net/forum/viewtopic.php?f=12&t=6434#p27967
+||fosshub.com^


### PR DESCRIPTION
### URL(s) where the issue occurs

Fosshub.com

### Describe the issue

Fosshub.com is currently serving up a MBR-writing trojan.

### Screenshot(s)

![Malware Result](https://i.redd.it/eapszwznl2dx.jpg)

### Versions

Unknown, I have not encountered this myself.

### Notes

This should be lifted once they have resolved the issue.