### PR TITLE
remove wired.com from fuckadblock injection

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -81,7 +81,7 @@
 free18.net,gadgetlove.com,nrc.gov,onbeing.org,rapgenius.com,tmz.com#@#.addthis_toolbox
 
 ! Foil blocker-sniffer code on Condé Nast sites.
-architecturaldigest.com,arstechnica.com,bonappetit.com,brides.com,cntraveler.com,details.com,epicurious.com,gq.com,golfdigest.com,newyorker.com,pitchfork.com,self.com,teenvogue.com,thescene.com,vanityfair.com,vogue.com,wired.com,wmagazine.com##script:inject(fuckadblock.js-3.2.0)
+architecturaldigest.com,arstechnica.com,bonappetit.com,brides.com,cntraveler.com,details.com,epicurious.com,gq.com,golfdigest.com,newyorker.com,pitchfork.com,self.com,teenvogue.com,thescene.com,vanityfair.com,vogue.com,wmagazine.com##script:inject(fuckadblock.js-3.2.0)
 
 ! Examples of what is fixed by even an unfilled dummy API:
 ! https://twitter.com/kenn_butler/status/709163241021317120


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.wired.com/2016/12/secure-news-grades-media-sites-https-fail/`

### Describe the issue

Recently (yesterday, I believe), Wired.com's anti-adblocker message started getting through again. Per [this issue](https://github.com/reek/anti-adblock-killer/issues/2541), I traced it back to the uAssets privacy filter. By removing wired.com from the fuckadblock injection, I am now no longer seeing Wired's anti-adblock message. I am not sure if fuckadblock should be updated, or what. But, simply by not injecting it on Wired, I do not see their paywall anymore (for now).

### Versions

- Browser/version: Chrome 55 (x64) Windows 7
- uBlock Origin version: 1.10.2

### Settings

-  I use uBlock's [hard mode](https://github.com/gorhill/uBlock/wiki/Blocking-mode:-hard-mode), many of the default filter lists, and Reek's AAK userscript. I do not have any custom rules/filters that would apply to Wired other than the blanket 3rd-party blocks recommended in the Wiki for "Hard Mode".

### Notes

I am not a frequent contributor. So, I hope I did everything right, didn't miss an already open related issue, etc. Let me know if more research/etc. needs to be done.