### PR TITLE
Fix for additional MonkeyBroker checks

### DIFF
--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -1516,6 +1516,7 @@ Object.defineProperty(window, 'is_block_adb_enabled', { value: false });
 d3pkae9owd2lcf.cloudfront.net/mb105.js application/javascript
 (function() {
 	var noopfn = function(){};
+	window.pbjs = { libLoaded: true };
 	window.MonkeyBroker = window.MonkeyBroker || {
 		addAttribute: noopfn,
 		addSlot: noopfn,
@@ -1524,7 +1525,8 @@ d3pkae9owd2lcf.cloudfront.net/mb105.js application/javascript
 		go: noopfn,
 		inventoryConditionalPlacement: noopfn,
 		registerSizeCallback: noopfn,
-		registerSlotCallback: noopfn
+		registerSlotCallback: noopfn,
+		slots: {}
 	};
 })();
 


### PR DESCRIPTION
At least one site is using the pbjs variable as another means of checking for MonkeyBroker

Replace the bracketed [...] placeholders with your own information.

### URL(s) where the issue occurs

`https://www.hotslogs.com/Sitewide/HeroAndMapStatistics`

### Describe the issue

The below code is ran to stop uBlock and other blockers
```js
                function j14a0039a(source) {
                    
                    if (true)
                        window.location = "/Info/AdBloc" + "k?Source=" + source;
                    else
                        ga("send", "event", "AdFillMonkeyBroker", "Ad Blocked Acceptably", { nonInteraction: true });
                }

				try {
					var monkeyBrokerTemp = MonkeyBroker;
                }
            	catch(error) {
					j14a0039a("JavaScript Exception");
                }

            	if (typeof MonkeyBroker === "undefined")
                    j14a0039a("MonkeyBroker Undefined");
            	else if (typeof MonkeyBroker.regSlotsMap === "undefined")
					j14a0039a("regSlotsMap Undefined");
            	else if (typeof MonkeyBroker.defineSlot === "undefined")
					j14a0039a("defineSlot Undefined");
                else
                {
                    
                    var isAdExperienceLight = false;

                    try {
                        $(window).on("load", function(e) {
                        	if (typeof pbjs === "undefined" || pbjs.libLoaded !== true)
								j14a0039a("pbjs Undefined");
                            else if ($(".advertisementBannerMonkeyBrokerTop").height() === 0)
                                j14a0039a("Height 0");
                            else
                                setTimeout(function(){ if (typeof MonkeyBroker.slots === "undefined") j14a0039a("Slots Undefined"); }, 10000);
                                
                                
                        });

                        if (typeof MonkeyBroker !== "object" || typeof MonkeyBroker.addSlot === "undefined" || MonkeyBroker.addSlot.toString() === "function () {}")
                            j14a0039a("addSlot Undefined");
                        else if (!isAdExperienceLight)
                            ga("send", "event", "AdFillMonkeyBroker", "Ad Displayed", { nonInteraction: true });
                        else
                            ga("send", "event", "AdFillMonkeyBroker", "Ad Displayed Light", { nonInteraction: true });
                    }
            		catch(error) {
						j14a0039a("JavaScript Exception");
                    }
```
You'll be redirect away after 10s to a specific AdBlock page.

### Screenshot(s)

### Versions

- Browser/version: Chrome 56
- uBlock Origin version: 1.11.4

### Settings

- None

### Notes

hotslogs has been aggressively fighting blockers with multiple passes at stopping them and the latest either require firefox or cosmetic workarounds. Sit on the page for 10s at least before the redirect occurs.
