### PR TITLE
Aliexpres sponsored item filter

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -1288,3 +1288,5 @@ vivo.sx##script:inject(abort-on-property-write.js, _0x773d)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/345
 math-aids.com##script:inject(abort-on-property-write.js, __drizzleSettings)
+
+aliexpress.com##.util-clearfix.list-item:has(.sponsored)


### PR DESCRIPTION
There is an new annoying "sponsored item" in the Aliexpress results-list that is most of the time not what you're looking for. I.e the sponsored item doesn't have to match your filters you set when searching on Aliexpress (it could be more expensive than the max price you set, or have paid shipping when you turned on free shipping etc) In general it's quite confusing.

This filter blocks the sponsored items only, I didn't know where else to post it. Sorry if this is the wrong way, this is the first time I submit a filter.

![selectie_009](https://cloud.githubusercontent.com/assets/1212814/24585787/d0978e1c-1792-11e7-91f3-0e40c2cae772.png)