### PR TITLE
Fixes hotslogs

### DIFF
--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -1526,17 +1526,32 @@ Object.defineProperty(window, 'is_block_adb_enabled', { value: false });
 d3pkae9owd2lcf.cloudfront.net/mb105.js application/javascript
 (function() {
 	var noopfn = function(){};
+
+	var i = 0;
+	function rand() {
+		return ++i;
+	}
+	
 	window.pbjs = { libLoaded: true };
-	window.MonkeyBroker = window.MonkeyBroker || {
-		addAttribute: noopfn,
-		addSlot: noopfn,
-		defineSlot: noopfn,
+	var mb = window.MonkeyBroker = window.MonkeyBroker || {
+		atts: {},
+		addAttribute: function(k,v){mb.atts[k]=encodeURIComponent(v)};,
+		addSlot: function(v){return mb.defineSlot(v);};
+		defineSlot: function(v){
+	  		if(typeof(v.size)!=="undefined"){v.sizes=[v.size];delete v.size;}
+	  		if(typeof(v.slot)==="undefined"){var s="_dynamic_"+rand();v.slot=s;}
+	  		mb.regSlots.push(v);
+	  		mb.regSlotsMap[v.slot]=v;
+	  		return v.slot;
+		},
 		fillSlot: noopfn,
 		go: noopfn,
 		inventoryConditionalPlacement: noopfn,
 		registerSizeCallback: noopfn,
 		registerSlotCallback: noopfn,
-		slots: {}
+		slots: {},
+		regSlots: [],
+		regSlotsMap: {}
 	};
 })();
 


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.hotslogs.com/Sitewide/HeroAndMapStatistics`

### Describe the issue

There are additional MonkeyBroker checks that I missed in my first pass of fixes

### Screenshot(s)

### Versions

- Browser/version: Chrome 57
- uBlock Origin version: 1.11.4

### Settings

- None

### Notes

Hotslogs uses `regSlotsMap` directly, so I've copy/pasted the logic from MonkeyBroker and then mocked some of it out. This should make it slightly more robust for anti-uBlock checks.