### PR TITLE
Added links to extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # uAssets
-Resources for uBlock Origin ("uBO"), uMatrix: static filter lists, ready-to-use rulesets, etc.
+Resources for [uBlock Origin](https://github.com/gorhill/uBlock) ("uBO"), [uMatrix](https://github.com/gorhill/uMatrix/): static filter lists, ready-to-use rulesets, etc.
 
 The goal of this repository is to receive all the reports for the need of new filters, or reports of web pages broken by existing filters, and will be open for people to contribute (those who have proven to be valuable contributors will be given write permissions on the project). Ideally I wish eventually there will be a small army of volunteers dedicated to deal with filter issues.
 


### PR DESCRIPTION
"uBlock Origin" and "uMatrix" weren't linked to their respective repositories.