### PR TITLE
This fixes #397

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -467,3 +467,7 @@ kinopoisk.ru###image:style(opacity: 1 !important;)
 
 ! https://github.com/gorhill/uBlock/issues/2568
 @@||googletagmanager.com/gtm.js$script,domain=bethesda.net
+
+!https://github.com/uBlockOrigin/uAssets/issues/397
+@@||assets.adobedtm.com$script,domain=redbull.tv
+@@||redbullmediahouse.hb.omtrdc.net$domain=redbull.tv


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.redbull.tv/tv`
`https://www.redbull.tv/live/AP-1PWUW9Y591W11/uci-mountain-bike-world-cup`

### Describe the issue

No videos play on redbull.tv

### Screenshot(s)
![redbull_tv_broken](https://cloud.githubusercontent.com/assets/915423/25873038/ba54fbfc-34c1-11e7-9c3e-4a4a34c3a599.png)

### Versions

- Browser/version: Version 57.0.2987.133 (64-bit)
- uBlock Origin version: 1.12.1

### Settings

- No changes

### Notes

Adding the following to filters fixes the playback:
@@||assets.adobedtm.com$script,domain=redbull.tv
@@||redbullmediahouse.hb.omtrdc.net$domain=redbull.tv
