### PR TITLE
Added cnhv.co, a mirror of coinhive.com and coin-hive.com.

### DIFF
--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -11,6 +11,7 @@
 ! https://github.com/uBlockOrigin/uAssets/issues/690
 ||coin-hive.com^$third-party
 ||coinhive.com^$third-party
+||cnhv.co^$third-party
 
 ! https://github.com/uBlockOrigin/uAssets/pull/706
 ||jsecoin.com^$third-party


### PR DESCRIPTION
### URL(s) where the issue occurs

`cnhv.co`

### Describe the issue

Added `cnhv.co`, a mirror of `coinhive.com` and `coin-hive.com`. Please see the `Proof of Work Shortlinks` section on the [Coinhive website](https://coinhive.com/#shortlinks) ([Internet Archive link](http://web.archive.org/web/20171104075048/https://coinhive.com/) as well) for their mention of using this domain for Coinhive shortlinks.

### Screenshot(s)

n/a

### Versions

- Browser/version: n/a
- uBlock Origin version: n/a

### Settings

n/a

### Notes

Related issue(s): #690 
Related pull request(s): #726 