### PR TITLE
fixes google analytics dashboard

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -289,6 +289,7 @@ phoronix.com#@#div[style^="text-align: center;"]
 # https://twitter.com/mtarnovan/status/713088377994682368
 # This counters `analytics.google.com` in Peter Lowe's
 @@||analytics.google.com^$first-party
+@@||ssl.gstatic.com$domain=analytics.google.com
 
 # This unbreaks video playback on weather.com
 # To counter `||analytics.edgekey.net^` in EasyPrivacy.


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://analytics.google.com`

### Describe the issue

Google Analytics Dashboard doesn't load without disabling filters because of the static filter `/web/analytics.$script` found in EasyPrivacy as it prevents the script below resulting with white screen.

`/web/analytics.$script	--	script	https://ssl.gstatic.com/analytics/*/web/analytics.js` where asterisk is the latest version's timestamp (For instance: 20171205-00)

Other people reporting this issue can be found on twitter too.

https://twitter.com/WebAsh/status/912801093800878080
https://twitter.com/benmeier_/status/875715468962791424
https://twitter.com/marvinpinto/status/842380667069599745

### Versions

- Browser/version: Google Chrome 62.0.3202.94
- uBlock Origin version: 1.14.20

### Settings

- None