### PR TITLE
Add remove-frame-content.js scriptlet

### DIFF
--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -2046,3 +2046,70 @@ set-constant.js application/javascript
 		}
 	});
 })();
+
+
+# This removes BODY & HEAD elements if run inside framed content.
+remove-frame-content.js application/javascript
+(function() {
+	var log = console.log.bind(console);
+	var removedHead = {
+		async: false,
+		result: false
+	};
+	var removedBody = {
+		async: false,
+		result: false
+	};
+	var url = 'unknown';
+	try {
+		url = window.location.href || url;
+	} catch (e) {};
+	function inIframe() {
+		try {
+			return window.self !== window.top;
+		} catch (e) {};
+		return true;
+	}
+	function removeHead() {
+		try {
+			// This is sometimes causing 100% CPU usage.
+			// Using innerHTML fixes this issue in Chrome.
+			//document.head.parentNode.removeChild(document.head);
+			document.head.innerHTML = '';
+			return true;
+		} catch (e) {};
+		return false;
+	}
+	function removeBody() {
+		try {
+			document.body.parentNode.removeChild(document.body);
+			return true;
+		} catch (e) {};
+		return false;
+	}
+	if (inIframe()) {
+		if (document.head) {
+			removedHead.result = removeHead();
+		} else {
+			setTimeout(function() {
+				removedHead.async = true;
+				removedHead.result = removeHead();
+			}, 0);
+		}
+		if (document.body) {
+			removedBody.result = removeBody();
+		} else {
+			setTimeout(function() {
+				removedBody.async = true;
+				removedBody.result = removeBody();
+			}, 0);
+		}
+		setTimeout(function() {
+			log('uBO> Removed frame content [HEAD:%s] [BODY:%s] [URL:%s]',
+				removedHead.result + (removedHead.async ? ',async' : ''),
+				removedBody.result + (removedBody.async ? ',async' : ''),
+				url
+			);
+		}, 10);
+	}
+})();


### PR DESCRIPTION
I use this scriptlet to remove some ads on `novinky.cz` and `aktualne.cz`. Problem with these sites is that their CSS is loaded from an iframe so it is not possible to block ads which are loaded into iframes with rules like:

```
||novinky.cz$subdocument
novinky.cz##iframe
```

This script removes `<head>` & `<body>` elements if it detects that it is run inside an iframe (tested on Chrome 62 / Win10 and FF 57 / Linux).

I hope this can help on other sites too. Please comment.

Thanks!