### PR TITLE
fix #1278: sponsored products on Amazon

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -793,6 +793,8 @@ icefilms.info##body > div:matches-css(z-index: 999999)
 
 ! https://forums.lanik.us/viewtopic.php?p=102620#p102620
 amazon.*###s-results-list-atf > .s-result-item:has(:scope > .s-item-container h5.s-sponsored-list-header)
+! https://github.com/uBlockOrigin/uAssets/issues/1278
+amazon.*###s-results-list-atf > .s-result-item:has(:scope > .s-item-container h5.s-sponsored-header)
 ! https://github.com/uBlockOrigin/uAssets/issues/399
 amazon.*##.s-result-item:has(:scope > .s-item-container > h5 .s-sponsored-info-icon)
 


### PR DESCRIPTION
### URL(s) where the issue occurs

In order to test that, you'll need to set up an Amazon customer ID. Here's a guide how to do that: https://loothootsupport.zendesk.com/hc/en-us/articles/221110488-How-to-find-your-Amazon-Customer-Public-Profile-ID

When you provided it to me, you'll be able to see the issue described below in pretty much any amazon search. Some examples would be

https://www.amazon.com/s/ref=nb_sb_noss_2?url=search-alias%3Daps&field-keywords=socks
https://www.amazon.com/s/ref=nb_sb_noss_2?url=search-alias%3Daps&field-keywords=iphone+case
https://www.amazon.com/s/ref=nb_sb_noss_1?url=search-alias%3Daps&field-keywords=tea+bags&rh=i%3Aaps%2Ck%3Atea+bags

### Describe the issue

There are existing filters
`amazon.*###s-results-list-atf > .s-result-item:has(:scope > .s-item-container h5.s-sponsored-list-header)`
`amazon.*##.s-result-item:has(:scope > .s-item-container > h5 .s-sponsored-info-icon)`

However, they don't cover everything. Sometimes, there are elements without `.s-sponsored-info-icon` and `.s-sponsored-list-header`, indeed they have `.s-sponsored-header` class. The proposed solution is to add this filter:

`amazon.*###s-results-list-atf > .s-result-item:has(:scope > .s-item-container h5.s-sponsored-header)`

I have tested it and it works fine

### Screenshot(s)

<img width="1311" alt="screen shot 2018-01-11 at 3 01 17 pm" src="https://user-images.githubusercontent.com/35361531/34897362-80590890-f7a2-11e7-8307-870e5832ea87.png">

### Versions

- Browser/version: reproduces consistently in all browsers and various versions. 
- uBlock Origin version: uBlock Origin 1.14.22

### Settings

`amazon.*###s-results-list-atf > .s-result-item:has(:scope > .s-item-container h5.s-sponsored-header)` — this fixed the issue

### Note
This rule can actually replace 2 other rules for Amazon search

