### PR TITLE
uMatrix Recipe: Wikia

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -112,6 +112,12 @@ Twitter with account
 		_ 1st-party xhr
 		_ twimg.com *
 		_ twimg.com script
+		
+Wikia
+	wikia.com *
+		! wikis are displayed as text-only without this 
+		_ nocookie.net *
+		_ nocookie.net script
 
 Vimeo as 3rd-party
 	* player.vimeo.com


### PR DESCRIPTION
Wikis are displayed as text-only without this. 

Example: http://linux.wikia.com/wiki/Linux_Wiki