### PR TITLE
pcworld.com - Amazon leftover

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -4941,3 +4941,6 @@ gratismas.org##script:inject(bab-defuser.js)
 adshorte.com##script:inject(abort-on-property-write.js, Fingerprint2)
 ||dailymotion.com^$subdocument,domain=adshorte.com
 ||megapeliculas.net^$subdocument,domain=adshorte.com
+
+! 
+pcworld.com###amazon-bottom-widget


### PR DESCRIPTION
### URL(s) where the issue occurs

https://www.pcworld.com/article/3081525/software-productivity/how-to-organize-your-gmail-using-mulitple-inboxes.html

### Describe the issue

"Shop Tech Products at Amazon" leftover header at the end of the article. Users may mistakenly think the the recommended articles are from Amazon.

### Versions

- Browser/version: Firefox 58.0.1
- uBlock Origin version: 1.15.4