### PR TITLE
uMatrix Recipe: Soundcloud

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -125,6 +125,13 @@ Proton
 		_ 1st-party xhr
     no-workers: _ false
 
+Soundcloud
+	soundcloud.com *
+		_ 1st-party script
+		_ sndcdn.com *
+		_ sndcdn.com script
+		_ sndcdn.com xhr
+
 Steam
 	steampowered.com *
 		_ 1st-party script


### PR DESCRIPTION
Example URL: https://soundcloud.com/stream

The requests used to stream songs are `xhr`, there's apparently no need to whitelist `media`.