### PR TITLE
uMatrix Recipes: Popular 3rd-party CDNs

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -22,6 +22,16 @@ Ars Technica
 		_ d2c8v52ll5s99u.cloudfront.net script
 		_ dp8hsntg6do36.cloudfront.net *
 
+Baidu CDN as 3rd-party
+	* libs.baidu.com
+		* libs.baidu.com *
+		* libs.baidu.com script
+
+Cloudflare CDN as 3rd-party
+	* cdnjs.cloudflare.com
+		* cdnjs.cloudflare.com *
+		* cdnjs.cloudflare.com script
+
 Dailymotion
 	dailymotion.com *
 		_ 1st-party script
@@ -68,6 +78,11 @@ Google account sign in
 		_ gstatic.com *
 		_ gstatic.com script
 
+Google CDN as 3rd-party
+	* ajax.googleapis.com
+		* ajax.googleapis.com *
+		* ajax.googleapis.com script
+
 Google Maps
 	google.* *
 		_ 1st-party script
@@ -88,6 +103,11 @@ IMDb
 		! required to upload images
 		_ 1st-party frame
 		_ amazonaws.com script
+
+jsDelivr CDN as 3rd-party
+	* cdn.jsdelivr.net
+		* cdn.jsdelivr.net *
+		* cdn.jsdelivr.net script
 		
 JSFiddle
 	jsfiddle.net *
@@ -95,6 +115,19 @@ JSFiddle
 		_ jshell.net *
 		_ jshell.net script
 		_ jshell.net frame
+
+jQuery CDN as 3rd-party
+	* code.jquery.com
+		* code.jquery.com *
+		* code.jquery.com script
+
+Microsoft CDN as 3rd-party
+	* ajax.aspnetcdn.com
+		* ajax.aspnetcdn.com *
+		* ajax.aspnetcdn.com script
+	* ajax.microsoft.com
+		* ajax.microsoft.com *
+		* ajax.microsoft.com script
 
 Netflix
 	netflix.com *
@@ -129,6 +162,11 @@ Proton
 	protonmail.com *
 		_ 1st-party script
     		no-workers: _ false
+
+SinaApp CDN as 3rd-party
+	* lib.sinaapp.com
+		* lib.sinaapp.com *
+		* lib.sinaapp.com script
 
 Soundcloud
 	soundcloud.com *
@@ -171,7 +209,12 @@ Twitter with account
 		_ 1st-party script
 		_ twimg.com *
 		_ twimg.com script
-		
+
+UpCDN CDN as 3rd-party
+	* upcdn.b0.upaiyun.com
+		* upcdn.b0.upaiyun.com *
+		* upcdn.b0.upaiyun.com script
+
 Wikia
 	wikia.com *
 		! wikis are displayed as text-only without this 
@@ -196,6 +239,14 @@ Yahoo Mail
 		_ 1st-party script
 		_ yimg.com image
 		_ yimg.com xhr
+
+Yandex CDN as 3rd-party
+	* yastatic.net
+		* yastatic.net *
+		* yastatic.net script
+	* yandex.st
+		* yandex.st *
+		* yandex.st script
 
 Youtube no account
 	youtube.com *


### PR DESCRIPTION
This is a work in progress. I'm opening the pull request now to get feedback on how these recipes should be properly implemented, if at all. These CDNs were pulled directly from the [Decentraleyes wiki](https://github.com/Synzvato/decentraleyes/wiki/Frequently-Asked-Questions#for-umatrix-and-ublock-origin-non-easy-mode-users), and @pwd-github has also expressed interest for these recipes in gorhill/uMatrix#30.

How should CDNs that have multiple domains (see Microsoft and Yandex) be implemented? I can separate them into multiple recipe blocks, but it seems keeping them together makes the most sense (in this case).

I could also use help finding real-world example websites that use these CDNs.

Thanks!