### PR TITLE
fix #719 twitch.tv video ads

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -6631,3 +6631,6 @@ yourlust.com##iframe[src="/im/footer.html"]
 ! https://github.com/uBlockOrigin/uAssets/issues/1970
 audioz.cc##script:inject(abort-current-inline-script.js, document.getElementById, adblockplus)
 audioz.cc##script:inject(bab-defuser.js)
+
+! https://github.com/uBlockOrigin/uAssets/issues/719
+twitch.tv##script:inject(twitch-videoad.js)

--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -2314,15 +2314,14 @@ damoh-defuser.js application/javascript
 
 twitch-videoad.js application/javascript
 (function() {
-	var ourMediaPlayer = undefined;
+	var ourMediaPlayer;
 	Object.defineProperty(window, 'MediaPlayer', {
 		set: function(newMediaPlayer) {
-			if (typeof(ourMediaPlayer) !== 'undefined')
-				return;
+			if ( ourMediaPlayer !== undefined ) { return; }
 			var oldLoad = newMediaPlayer.MediaPlayer.prototype.load;
 			newMediaPlayer.MediaPlayer.prototype.load = function(e) {
 				try {
-					if (e.startsWith('https://usher.ttvnw.net/api/channel/hls/')) {
+					if ( e.startsWith('https://usher.ttvnw.net/api/channel/hls/') ) {
 						var url = new URL(e);
 						url.searchParams.delete('baking_bread');
 						url.searchParams.delete('baking_brownies');
@@ -2330,7 +2329,7 @@ twitch-videoad.js application/javascript
 						e = url.href;
 					}
 				} catch (err) {
-					console.error('Failed to bypass Twitch livestream ad');
+					//console.error('Failed to bypass Twitch livestream ad');
 				}
 				return oldLoad.call(this, e);
 			};

--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -2310,3 +2310,34 @@ damoh-defuser.js application/javascript
     var observer = new MutationObserver(cleanVideoAsync);
     observer.observe(document.documentElement, { childList: true, subtree: true });
 })();
+
+
+twitch-videoad.js application/javascript
+(function() {
+	var ourMediaPlayer = undefined;
+	Object.defineProperty(window, 'MediaPlayer', {
+		set: function(newMediaPlayer) {
+			if (typeof(ourMediaPlayer) !== 'undefined')
+				return;
+			var oldLoad = newMediaPlayer.MediaPlayer.prototype.load;
+			newMediaPlayer.MediaPlayer.prototype.load = function(e) {
+				try {
+					if (e.startsWith('https://usher.ttvnw.net/api/channel/hls/')) {
+						var url = new URL(e);
+						url.searchParams.delete('baking_bread');
+						url.searchParams.delete('baking_brownies');
+						url.searchParams.delete('baking_brownies_timeout');
+						e = url.href;
+					}
+				} catch (err) {
+					console.error('Failed to bypass Twitch livestream ad');
+				}
+				return oldLoad.call(this, e);
+			};
+			ourMediaPlayer = newMediaPlayer;
+		},
+		get: function() {
+			return ourMediaPlayer;
+		}
+	});
+})();


### PR DESCRIPTION
### URL(s) where the issue occurs / Describe the issue

The issue affects video ads playing when loading a livestream on twitch.tv. These kinds of ads are not very reproducible, whether or not and when Twitch injects ads appears to be almost random. However, when Twitch decides that I'm to be targeted with video ads on some specific livestream, I can often F5 dozens of times and the ad will still always try to load (I never watched an ad to the end, I suppose it lets you watch the stream then and maybe the ad will not be shown anymore after F5). Note that these kinds of ads might only appear on "partnered" livestreams. Also, they're only appearing when the stream is actually running and not when it's offline. I'm including some random livestream I found where I could reproduce ads *and* my fix:

`https://www.twitch.tv/xchocobars`

Twitch's ad targeting is really weird, e.g. right now I can easily reproduce ads in above-mentioned livestream in Firefox (I have reloaded that tab dozens of times), even when starting new incognito sessions, but I do not get any ads in Chromium right now.

Twitch performs Fetch requests to URLs like `https://usher.ttvnw.net/api/channel/hls/xchocobars.m3u8?allow_source=true&baking_bread=true&baking_brownies=true&baking_brownies_timeout=1050&fast_bread=true&p=4237533&player_backend=mediaplayer&rtqos=control&sig=...&token=...` to retrieve a playlist. As @pixeltris found out and used in their webextension https://github.com/pixeltris/TwitchAdBlock, the `baking` parameters seem to be responsible for showing the pre-livestream video ads. Note that the presence of them does not indicate whether or not you will be delivered ads, but *without* their presence you won't get ads from my tests. With the above-mentioned livestream, I got video ads in Firefox pretty much every time reloading that page, and they always went away when adding my `inject` rule, and came back when removing it. I have reproduced that dozens of times.

Note that beside the video ads that appear when loading the stream, "partnered" Twitch streamers have the ability to press a button and show ads for presumably all/most viewers. I do not know whether my pull request fixes these ads as well, as this situation is not easy to encounter/reproduce.

My script hooks into the function of the Twitch player that loads the playlist from a URL that is passed as the first and only parameter and removes the `baking` parameters. I'm using [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) to manipulate the URL, which is [not yet available in M$ Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8993198/), however according to that bug report it is assumed to be included in its next release, and since that issue should be covered by my try-catch block, I do not see the need to change my usage of `URLSearchParams`.

### Screenshot(s)

[Screenshot of (paused) video ad](https://user-images.githubusercontent.com/1506734/38775116-4cde873a-407a-11e8-8796-220e1295930b.png)

### Versions

- Browser/version: Firefox 59.0.2, Chromium 65.0.3325.181
- uBlock Origin version: 1.15.24 on both browsers

### Settings

Nothing that should affect my PR. On Firefox I made a clean install of uBO and only changed the selection of lists, activated all the privacy features and enabled advanced user mode to add my own resources file.

### Notes

For people who want to test my PR: Enable [advanced mode](https://github.com/gorhill/uBlock/wiki/Advanced-user-features) and change the [`userResourcesLocation`](https://github.com/gorhill/uBlock/wiki/Advanced-settings#userresourceslocation) directive in the advanced mode configuration to:  
```
       userResourcesLocation https://gist.githubusercontent.com/pcworld/c3e36195f533ee0f32deec66d10bce76/raw/dd9e3dd17e1f1dcc3468c1088261a187c36b5f30/resources.txt
```
Note that by doing that you trust GitHub not to manipulate the code in there.
Then add the following line to the "My filters" tab of the dashboard and press "Apply changes":
```
twitch.tv##script:inject(twitch-videoad.js)
```
The linked resources file includes an additional log line. When you have configured everything correctly, when loading a livestream the F12 console should print "Removing ad parameters from playlist request". Though note that doesn't mean that Twitch would have played an ad otherwise. To test whether my PR works for you, you need to make sure that you are consistently delivered ads by Twitch (you should probably F5 or pause the ad before it finishes playing), *only then* enable the inject filter, reload the page a few times to ensure that you don't get ads anymore, disable the filter and then verify that you're getting ads again. If you have performed these steps it would probably be helpful if you post a comment on this PR whether this has worked for you.