### PR TITLE
Add recipe for Slack.

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -146,8 +146,10 @@ Slack
 	slack.com *
 		_ 1st-party script
 		_ slack-edge.com *
+		_ slack-edge.com script
 		_ slack-imgs.com image
 		_ slack-msgs.com *
+
 
 Soundcloud
 	soundcloud.com *

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -144,12 +144,12 @@ Proton
 
 Slack
 	slack.com *
+		_ 1st-party *
 		_ 1st-party script
 		_ slack-edge.com *
 		_ slack-edge.com script
 		_ slack-imgs.com image
 		_ slack-msgs.com *
-
 
 Soundcloud
 	soundcloud.com *

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -132,6 +132,13 @@ Proton
 		_ 1st-party script
     		no-workers: _ false
 
+Slack
+	slack.com *
+		_ 1st-party script
+		_ slack-edge.com *
+		_ slack-imgs.com image
+		_ slack-msgs.com *
+
 Soundcloud
 	soundcloud.com *
 		_ 1st-party script


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://slack.com/get-started`
`https://*.slack.com` where the `*` is any Slack workspace.

### Describe the issue

Many pages on `slack.com` either fail to load or only partially load.

For any subdomains where an Slack instance resides, the page displays an error on how it failed to load. This is what is shown in the screenshot below.

### Screenshot(s)

![screenshot](https://user-images.githubusercontent.com/9146157/38782021-8a1596f2-40bb-11e8-89d6-29337070ad8e.png)

### Versions

- Browser/version: Tested on Firefox 59.0.2 (64-bit) on Fedora Linux, but issue likely exists on all browsers.
- uMatrix Origin version: 1.3.6

### Settings

- None that should effect `*.slack.com`.

### Notes

`_ slack-edge.com *` is necessary for Slack pages to load at all.
`_ slack-imgs.com image` and `_ slack-msgs.com *` are needed for a Slack workspace to fully load and be functional.