### PR TITLE
uMatrix: Add reCaptcha recipe

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -78,7 +78,15 @@ Google Maps
 		_ maps.googleapis.com script
 		! needed for satellite view
 		no-workers: _ false
-		
+
+Google reCaptcha
+	* www.google.com
+		_ www.google.com *
+		_ www.google.com script
+		_ www.google.com frame
+		_ www.gstatic.com *
+		_ www.gstatic.com script
+
 IMDb
 	imdb.com *
 		_ 1st-party script


### PR DESCRIPTION
Note, I did explicitly use `www.` subdomains to avoid pulling in the unnecessary cookie from `google.com`. No worker allowed, in my experience even when there is one it is not necessary to allow it for reCaptcha to actually work.