### PR TITLE
fix prismamedia.com sites

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -4376,7 +4376,7 @@ tv-en-vivo.org##[id^=floatLayer]
 
 ! https://forums.lanik.us/viewtopic.php?f=91&t=39633
 ! https://github.com/uBlockOrigin/uAssets/pull/1248
-capital.fr,femmeactuelle.fr,gala.fr##script:inject(setTimeout-defuser.js, checkPub, 6000)
+businessinsider.fr,caminteresse.fr,capital.fr,cuisineactuelle.fr,femmeactuelle.fr,gala.fr,gentside.com,geo.fr,hbrfrance.fr,nationalgeographic.fr,neonmag.fr,ohmymag.com,prima.fr,programme-tv.net,programme.tv,serengo.net,voici.fr,vsd.fr##script:inject(setTimeout-defuser.js, checkPub, 6000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/1247
 wi.cr##script:inject(abort-on-property-read.js, app_vars.force_disable_adblock)


### PR DESCRIPTION
```
http://photo.businessinsider.fr/
http://photo.caminteresse.fr/
http://photo.capital.fr/
http://photo.cuisineactuelle.fr/
http://photo.femmeactuelle.fr/
http://photo.gala.fr/
http://photo.gentside.com/
http://photo.geo.fr/
http://photo.hbrfrance.fr/
http://photo.nationalgeographic.fr/
http://photo.neonmag.fr/
http://photo.ohmymag.com/
http://photo.prima.fr/
http://photo.programme-tv.net/
http://photo.programme.tv/
http://photo.serengo.net/
http://photo.voici.fr/
http://photo.vsd.fr/
```