### PR TITLE
Rename Proton recipe to Protonmail

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -135,7 +135,7 @@ Outlook (Formerly Hotmail)
 		_ office365.com script
 		_ office365.com xhr
 
-Proton
+Protonmail
 	protonmail.com *
 		_ 1st-party script
 		no-workers: _ false


### PR DESCRIPTION
### URL(s) where the issue occurs

https://protonmail.com/

### Describe the issue

The uMatrix filter is incorrectly named "Proton" instead of "Protonmail".

### Screenshot(s)

n/a

### Versions

- Browser/version: Firefox 59.0.2
- uBlock Origin version: 1.16.0

### Settings

- n/a

### Notes

n/a
