### PR TITLE
Add recipes for 4chan

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -9,6 +9,20 @@
 ! Please contribute ruleset recipes for the benefit of all other users:
 ! https://github.com/uBlockOrigin/uAssets/tree/master/recipes
 
+4Chan with reCaptcha
+	4chan.org *
+		_ a.4cdn.org xhr
+		_ s.4cdn.org script
+		! reCaptcha isn't detected by the recipe things so we add it here too
+		_ www.google.com script
+		_ www.google.com frame
+		_ www.gstatic.com script
+
+4Chan without reCaptcha
+	4chan.org *
+		_ a.4cdn.org xhr
+		_ s.4cdn.org script
+
 Ars Technica
 	arstechnica.com *
 		_ 1st-party script


### PR DESCRIPTION
### URL(s) where the issue occurs

https://www.4chan.org/

### Describe the issue

Makes 4chan work (Quoted posts, posting, general browsing).
reCaptcha isn't detected on 4chan, so there are two recipes: with and without reCaptcha.

### Screenshot(s)

n/a

### Versions

- Browser/version: Firefox 59.0.2
- uBlock Origin version: 1.16.0

### Settings

n/a

### Notes

n/a
