### PR TITLE
Fix for #2107

### DIFF
--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -392,6 +392,8 @@ google-analytics.com/analytics.js application/javascript
 		return [];
 	};
 	ga.remove = noopfn;
+	// https://github.com/uBlockOrigin/uAssets/issues/2107
+	ga.loaded = true;
 	w[gaName] = ga;
 	// https://github.com/gorhill/uBlock/issues/3075
 	var dl = w.dataLayer;

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -1045,3 +1045,9 @@ the4thofficial.net#@#[style] > [scrolling]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/2101
 ||vidtech.cbsinteractive.com/*/tracking/comscore/comscore.streaming.$script,redirect=noopjs,domain=zdnet.com
+
+! https://github.com/uBlockOrigin/uAssets/issues/2107
+@@||cdn.assets.cyclingnews.com^$script
+cyclingnews.com##script:inject(abort-on-property-read.js, MONETIZER101.init)
+cyclingnews.com##script:inject(nano-setTimeout-booster.js, /outboundLink/)
+cyclingnews.com##.global-banner


### PR DESCRIPTION
#2107 
`http://www.cyclingnews.com/races/tour-de-romandie-2018/stage-3/results/`

### Issue and Findings
The disqus comments were being packed in a first party script that was being blocked. However, that included `MONEITIZER101` which pulled in "Daily Deals". This also re-broke navigation because it was checking if `ga.loaded === true` before forwarding to the intended URL. Finally, there was a 1 second delay before the forward would take place (to ensure the click was tracked by google analytics), so I sped that up.

### Notes
I added `ga.loaded = true` to the google-analytics.js redirect.