### PR TITLE
Nukes skype from the internet

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -7170,3 +7170,6 @@ urls-short.com##script:inject(abort-on-property-read.js,app_vars.force_disable_a
 
 ! https://github.com/uBlockOrigin/uAssets/issues/2163
 pes-patch.com##script:inject(bab-defuser.js)
+
+! nukes skype from the internet
+||*skype*^$important


### PR DESCRIPTION
Microsoft is forcing skype integration in all of its services. Skype integration makes pages slow, and it is very annoying. This change nukes skype from the internet.
