### PR TITLE
Remove filter causing major JS crash on svd.se

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -5019,7 +5019,6 @@ pornqd.com##a[href*="redirect"]
 @@||streamxxx.tv^$generichide
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=39845
-svd.se##script:inject(abort-on-property-write.js, SvD)
 svd.se##[id^=AdWrapperInner]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/1423


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.svd.se`

### Describe the issue

The filter removed in this PR prevents updates from being written to the global SvD object. This object does partly seem to handle the site ads integration but it also seem to handle several other features on the site. By preventing data from being written to the SvD object, this causes a major JS crash, which breaks the site.

### Screenshot(s)

n/a

### Versions

- Browser/version: Chrome 66.0.3359.139
- uBlock Origin version: 1.16.4

### Settings

n/a

### Notes

n/a