### PR TITLE
Update annoyances for bluma

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -278,3 +278,6 @@ new.torrnado.win##script:inject(set-constant.js, block, false)
 
 ! https://github.com/NanoAdblocker/NanoFilters/issues/65
 ekb.dk.ru##script:inject(setTimeout-defuser.js, myBox, 3000)
+
+! 08/05/2018, 11:42:07 https://bulma.io/documentation/components/navbar/
+bulma.io##.is-fortyfour.bd-banner


### PR DESCRIPTION
Added book banner on bulma.io

Replace the bracketed [...] placeholders with your own information.

### URL(s) where the issue occurs

`https://bulma.io/documentation/components/navbar/`

### Describe the issue

Large book banner

### Screenshot(s)

![annoying af](https://i.imgur.com/D4CHNW3.png)

### Versions

- Browser/version: Google Chrome 66.0
- uBlock Origin version: uBlock Origin v1.16.4

### Notes

They also have a 'sponsor' banner. I'm not sure if it fits into annoyances or filters.
```
! 08/05/2018, 11:42:00 https://bulma.io/documentation/components/navbar/
bulma.io##.bd-side-sponsors
```

![sponser banner](https://i.imgur.com/TKECvWR.png)