### PR TITLE
ruleset.txt: [GitHub] Add host for uploading files in releases

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -55,6 +55,8 @@ Github
 		_ github-production-user-asset-6210df.s3.amazonaws.com xhr
 		! Required for uploading other files in comments
 		_ github-production-repository-file-5c1aeb.s3.amazonaws.com xhr
+		! Required for uploading files in releases
+		_ github-production-release-asset-2e65be.s3.amazonaws.com xhr
 
 Gitlab
 	gitlab.com *


### PR DESCRIPTION
### URL(s) where the issue occurs

* https://github.com/

### Describe the issue

Without this patch/rule uploading files(tarballs and gpg-signatures in my case) fails.
### Versions

- Browser/version: Chromium 66.0.3359.139
- uBlock Origin version: 1.16.5.3
- uMatrix version: 1.3.8

### Settings

for uMatrix:
```
https-strict: * true
no-workers: * true
noscript-spoof: * true
referrer-spoof: * true
* * * block
* * cookie block
* * other block
* 1st-party css allow
* 1st-party image allow
```

### Notes

xhr is blocked by default on your minimal ruleset too, so I upstreamed it from [my rulesets repository](https://hacktivis.me/git/umatrix-rulesets/) (which is for my even more hardcore/minimalist ruleset).