### PR TITLE
Updated rule for Twitch and Twitch as 3rd Party

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -184,6 +184,8 @@ Twitch
 		_ twitchcdn.net script
 		_ twitchsvc.net *
 		_ twitchsvc.net script
+		- akamaized.net *
+		- akamaized.net xhr
 
 Twitch as 3rd-party
 	* twitch.tv
@@ -196,6 +198,8 @@ Twitch as 3rd-party
 		_ ttvnw.net xhr
 		_ twitchcdn.net *
 		_ twitchcdn.net script
+		- akamaized.net *
+		- akamaized.net xhr
 
 Twitter no account
 	twitter.com *


### PR DESCRIPTION
Added akamaized.net (XHR) in the list of allowed rules.

### URL(s) where the issue occurs
https://www.twitch.tv/beyondthesummit
http://multitwitch.tv/beyondthesummit (for Twitch as 3rd party)