### PR TITLE
Patch window.name to empty string instead of null

### DIFF
--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -874,7 +874,7 @@ widgets.outbrain.com/outbrain.js application/javascript
 # https://github.com/gorhill/uBlock/issues/1228
 window.name-defuser application/javascript
 if ( window === window.top ) {
-	window.name = null;
+	window.name = '';
 }
 
 


### PR DESCRIPTION
Because `window.name` converts all assigned values to string representation.
