### PR TITLE
Stripe Recipe

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -188,11 +188,14 @@ Steam
 		
 Stripe as 3rd-party
 	* stripe.com
-		_ *.stripe.com *
+		_ stripe.com *
+		_ api.stripe.com *
 		_ api.stripe.com xhr
+		_ checkout.stripe.com *
 		_ checkout.stripe.com frame
 		_ checkout.stripe.com script
 		_ checkout.stripe.com xhr
+		_ js.stripe.com *
 		_ js.stripe.com frame
 		_ js.stripe.com script
 

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -189,21 +189,12 @@ Steam
 Stripe as 3rd-party
 	* stripe.com
 		_ stripe.com *
-		_ api.stripe.com *
 		_ api.stripe.com xhr
-		_ checkout.stripe.com *
 		_ checkout.stripe.com frame
 		_ checkout.stripe.com script
 		_ checkout.stripe.com xhr
-		_ js.stripe.com *
 		_ js.stripe.com frame
 		_ js.stripe.com script
-		_ q.stripe.com *
-		_ q.stripe.com image
-		_ stripe.network *
-		_ stripe.network image
-		_ m.stripe.network *
-		_ m.stripe.network frame
 
 Twitch
 	twitch.tv *

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -187,7 +187,7 @@ Steam
 		_ steamstatic.com script
 		
 Stripe as 3rd-party
-	* stripe.com
+	* *
 		_ stripe.com *
 		_ api.stripe.com *
 		_ api.stripe.com xhr

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -187,7 +187,8 @@ Steam
 		_ steamstatic.com script
 		
 Stripe as 3rd-party
-	* *
+	* stripe.com
+		_ 1st-party script
 		_ stripe.com *
 		_ api.stripe.com *
 		_ api.stripe.com xhr
@@ -198,6 +199,7 @@ Stripe as 3rd-party
 		_ js.stripe.com *
 		_ js.stripe.com frame
 		_ js.stripe.com script
+		_ q.stripe.com image
 
 Twitch
 	twitch.tv *

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -187,7 +187,7 @@ Steam
 		_ steamstatic.com script
 		
 Stripe as 3rd-party
-	* *.stripe.com
+	* js.stripe.com
 		_ 1st-party script
 		_ stripe.com *
 		_ api.stripe.com *

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -205,7 +205,6 @@ Stripe as 3rd-party
 		_ m.stripe.network *
 		_ m.stripe.network frame
 
-
 Twitch
 	twitch.tv *
 		no-workers: twitch.tv false

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -185,6 +185,16 @@ Steam
 		_ steamstatic.com *
 		_ steamstatic.com media
 		_ steamstatic.com script
+		
+Stripe as 3rd-party
+	* stripe.com
+		_ *.stripe.com *
+		_ api.stripe.com xhr
+		_ checkout.stripe.com frame
+		_ checkout.stripe.com script
+		_ checkout.stripe.com xhr
+		_ js.stripe.com frame
+		_ js.stripe.com script
 
 Twitch
 	twitch.tv *

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -187,7 +187,7 @@ Steam
 		_ steamstatic.com script
 		
 Stripe as 3rd-party
-	* js.stripe.com
+	stripe.com *
 		_ 1st-party script
 		_ stripe.com *
 		_ api.stripe.com *

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -187,8 +187,7 @@ Steam
 		_ steamstatic.com script
 		
 Stripe as 3rd-party
-	stripe.com *
-		_ 1st-party script
+	* stripe.com
 		_ stripe.com *
 		_ api.stripe.com *
 		_ api.stripe.com xhr
@@ -199,7 +198,13 @@ Stripe as 3rd-party
 		_ js.stripe.com *
 		_ js.stripe.com frame
 		_ js.stripe.com script
+		_ q.stripe.com *
 		_ q.stripe.com image
+		_ stripe.network *
+		_ stripe.network image
+		_ m.stripe.network *
+		_ m.stripe.network frame
+
 
 Twitch
 	twitch.tv *

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -189,10 +189,8 @@ Steam
 Stripe as 3rd-party
 	* stripe.com
 		_ stripe.com *
-		_ api.stripe.com xhr
 		_ checkout.stripe.com frame
 		_ checkout.stripe.com script
-		_ checkout.stripe.com xhr
 		_ js.stripe.com frame
 		_ js.stripe.com script
 

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -187,7 +187,7 @@ Steam
 		_ steamstatic.com script
 		
 Stripe as 3rd-party
-	* stripe.com
+	* *.stripe.com
 		_ 1st-party script
 		_ stripe.com *
 		_ api.stripe.com *


### PR DESCRIPTION
### URL(s) where the issue occurs
Stripe has three products (Stripe.js/v2, Stripe.js/v3, and Stripe Checkout, so I've written a recipe that hits all three.  These are hosted on JSFiddle and an exception was not written for their code.  You may need to include jquery or add an exception for scripts they host as well.

#### Stripe.js/v2
http://fiddle.jshell.net/yn56Lebv/2/show/

#### Stripe.js/v3
https://fiddle.jshell.net/ywain/8nobq41n/show/

#### Stripe Checkout
https://fiddle.jshell.net/ywain/1fvrtrdh/show/

### Describe the issue

Right now, uMatrix will break on any page that includes Stripe.  I wanted to write up a nice little recipe that will allow them to safely enable our scripts opportunistically.

### Notes

Please let me know if I did this wrong.  This is my first recipe!

fixes https://github.com/uBlockOrigin/uMatrix-issues/issues/32