### PR TITLE
Update filters.txt to include new Reddit ads

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -6506,6 +6506,9 @@ downloadpirate.com##A[href$=".html"][rel="nofollow norefferer noopener"]
 reddit.com##.size-compact.Post:has([class*=promoted])
 reddit.com##.vuIDB
 
+! https://www.reddit.com/r/uBlockOrigin/comments/96gk1q/ublock_origin_is_working_perfectly_fine_but_ads/e40dd3o/
+reddit.com##div.spacer > .native-sidebar-ad.native-ad-container
+
 ! https://forums.lanik.us/viewtopic.php?f=62&t=40330
 toyoheadquarters.com##script:inject(abort-current-inline-script.js, AdBlockDetectorWorkaround)
 


### PR DESCRIPTION
/u/Wargazm provided a filter that hid the new Reddit ads that were leaking through, see:
https://www.reddit.com/r/uBlockOrigin/comments/96gk1q/ublock_origin_is_working_perfectly_fine_but_ads/e40dd3o/

### URL(s) where the issue occurs

You can see the ad here: https://reddit.com



### Describe the issue

Ads are showing on Reddit's homepage.

### Screenshot(s)

Screenshot: https://imgur.com/a/R0bNXld

### Versions

- Browser/version: Any (Firefox 61, Chrome 68 for example)
- uBlock Origin version: any (1.16.14 for example)

### Settings

No changes to settings, just to filter. 

### Notes

Most of the work was done for me, I just made the pull request. 

See: 

https://www.reddit.com/r/uBlockOrigin/comments/97fivj/a_couple_adds_appearing_on_popularfront_page_of/

https://www.reddit.com/r/uBlockOrigin/comments/96gk1q/ublock_origin_is_working_perfectly_fine_but_ads/