### PR TITLE
Fix Reddit embeds on uMatrix

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -164,6 +164,7 @@ Reddit
 		_ redditstatic.com *
 		_ redditstatic.com script
 		_ redditmedia.com *
+		_ redditmedia.com frame allow
 		! Necessary to unbreak ability to upload
 		_ reddit-uploaded-media.s3-accelerate.amazonaws.com xhr
 


### PR DESCRIPTION
### URL(s) where the issue occurs
`https://www.reddit.com/r/unixporn/comments/9bv2q0/oc_does_my_workstation_fit_in_here_too/`

### Screenshot
<img width="726" alt="screen shot 2018-08-31 at 19 43 18" src="https://user-images.githubusercontent.com/5832930/44925153-2dae7200-ad56-11e8-908a-4a975c049e90.png">

After addition of this rule, it shows Embedly (third-party service, #3378) iframe as blocked instead of redditmedia.com