### PR TITLE
Cloudflare Stream as 3rd-party

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -22,6 +22,11 @@ Ars Technica
 		_ d2c8v52ll5s99u.cloudfront.net script
 		_ dp8hsntg6do36.cloudfront.net *
 
+Cloudflare Stream as 3rd-party
+	* cloudflarestream.com
+		_ embed.cloudflarestream.com script allow
+		_ videodelivery.net xhr allow
+
 Dailymotion
 	dailymotion.com *
 		_ 1st-party script


### PR DESCRIPTION
### URL(s) where the issue occurs
`https://www.cloudflare.com/` -> "Learn how Cloudflare works" video uses Cloudflare Stream and this ruleset fixes it completely.