### PR TITLE
Added Tor entries to the main list

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -645,22 +645,22 @@ eurogamer.net##html:style(cursor: default !important;)
 ||bit.ly^$popup,domain=eurogamer.net
 
 ! https://github.com/uBlockOrigin/uAssets/issues/98
-facebook.com###stream_pagelet div[id^="hyperfeed_story_id_"]:has(a.uiStreamSponsoredLink)
+facebook.com,facebookcorewwwi.onion###stream_pagelet div[id^="hyperfeed_story_id_"]:has(a.uiStreamSponsoredLink)
 ! "People You May Know": EasyList tries to block these, might as well block them fully
-facebook.com###stream_pagelet div[id^="hyperfeed_story_id_"]:if(h6:has-text(People You May Know))
+facebook.com,facebookcorewwwi.onion###stream_pagelet div[id^="hyperfeed_story_id_"]:if(h6:has-text(People You May Know))
 m.facebook.com##article:has(footer > div > div > a[href^="/friends/center/?fb_ref="])
 ! https://www.reddit.com/r/uBlockOrigin/comments/58o3k6/facebook_ads_solution/
-facebook.com##.ego_section:has(a.adsCategoryTitleLink)
+facebook.com,facebookcorewwwi.onion##.ego_section:has(a.adsCategoryTitleLink)
 ! https://github.com/uBlockOrigin/uAssets/issues/507
-facebook.com###stream_pagelet [id^="hyperfeed_story_id_"]:has(span._4dcu)
+facebook.com,facebookcorewwwi.onion###stream_pagelet [id^="hyperfeed_story_id_"]:has(span._4dcu)
 ! https://github.com/uBlockOrigin/uAssets/issues/722
-facebook.com##.ego_column:if(a[href^="/campaign/landing"])
+facebook.com,facebookcorewwwi.onion##.ego_column:if(a[href^="/campaign/landing"])
 ! https://forums.lanik.us/viewtopic.php?p=128997#p128997
-facebook.com##[id^="hyperfeed_story_id_"]:if([id^="feed_subtitle_"] a[href]:matches-css-after(content:/Gesponsert|Sponsored|Sponsrad/))
-facebook.com##div[data-testid="fbfeed_story"]:if(a[href*="[is_sponsored]"])
-facebook.com##.ego_section:if(a[href^="/ad_campaign"])
-facebook.com##.userContentWrapper:has(a[href*="/ads/"])
-facebook.com##.userContentWrapper:has-text(/Suggested Post/i)
+facebook.com,facebookcorewwwi.onion##[id^="hyperfeed_story_id_"]:if([id^="feed_subtitle_"] a[href]:matches-css-after(content:/Gesponsert|Sponsored|Sponsrad/))
+facebook.com,facebookcorewwwi.onion##div[data-testid="fbfeed_story"]:if(a[href*="[is_sponsored]"])
+facebook.com,facebookcorewwwi.onion##.ego_section:if(a[href^="/ad_campaign"])
+facebook.com,facebookcorewwwi.onion##.userContentWrapper:has(a[href*="/ads/"])
+facebook.com,facebookcorewwwi.onion##.userContentWrapper:has-text(/Suggested Post/i)
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=32142
 ||ruiguozhi.cc^
@@ -2826,8 +2826,8 @@ aargauerzeitung.ch##+js(setTimeout-defuser.js, [native code], 3000)
 
 ! https://news.ycombinator.com/item?id=12654591
 ! https://forums.lanik.us/viewtopic.php?f=62&t=41501
-nytimes.com##article.story:style(opacity: 1.0 !important;)
-nytimes.com##:xpath(//div[starts-with(@id, "dfp-ad")]/../../..)
+nytimes.com,nytimes3xbfgragh.onion##article.story:style(opacity: 1.0 !important;)
+nytimes.com,nytimes3xbfgragh.onion##:xpath(//div[starts-with(@id, "dfp-ad")]/../../..)
 ! https://github.com/uBlockOrigin/uAssets/issues/816
 cooking.nytimes.com##[class^="nytc---modal-window"]
 cooking.nytimes.com##body:style(height: auto !important; overflow: auto !important)


### PR DESCRIPTION
As I have recently begun to experiment with .onion domains in Tor Browser (e.g. for the purposes of https://github.com/DandelionSprout/adfilt/blob/master/BrowseWebsitesWithoutLoggingIn.txt), I've learned that filter entries that apply to e.g. Facebook and NY Times, do not automatically apply to their .onion domains.

Since the .onion versions of websites use the same elements as their regular versions, it should usually be easy enough to e.g. convert these examples that I took from the main uAssets list:

```
facebook.com##.userContentWrapper:has(a[href*="/ads/"])
nytimes.com##:xpath(//div[starts-with(@id, "dfp-ad")]/../../..)
```

...to:

```
facebook.com,facebookcorewwwi.onion##.userContentWrapper:has(a[href*="/ads/"])
nytimes.com,nytimes3xbfgragh.onion##:xpath(//div[starts-with(@id, "dfp-ad")]/../../..)
```

I've added .onion domains to those entries that I could find, and I suggest that it could become some sort of policy to add .onion domains to any future additions to the uAssets lists.