### PR TITLE
Unbreak upvote buttons on devrant

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -1453,3 +1453,6 @@ deezer.com##.ads
 ! https://forums.lanik.us/viewtopic.php?f=64&t=41591
 /adsession.$badfilter
 /adsession.$domain=~adsession.com
+
+! unbreak upvote buttons on devrant, they have the class .plusone which is blocked by Fanboy's Social Blocking List
+devrant.com#@#.plusone


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://devrant.com/feed/algo`

### Describe the issue

The upvote buttons are hidden by Fanboy's Social Blocking List since they have the class `plusone`.

### Screenshot(s)

<img width="465" alt="image" src="https://user-images.githubusercontent.com/5678977/45126949-c8c69380-b12a-11e8-80f1-fadbdd72a2aa.png">

### Versions

- Browser/version: Safari 11.1.1
- uBlock Origin version: v1.16.0

### Settings

- Enabling advanced user mode