### PR TITLE
Delete redundant filters in resource-abuse.txt

### DIFF
--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -162,7 +162,6 @@ csgoconfigs.com##+js(abort-current-inline-script.js, m, CH.Anonymous)
 ||cloudcoins.co^$third-party
 ||coinhive-manager.com^$third-party
 ||coinhive-proxy.party^$third-party
-||coinhive.com^$third-party
 ||coinlab.biz^$third-party
 ||coinminerz.com^$third-party
 ||cookiescript.info^$third-party
@@ -182,7 +181,6 @@ csgoconfigs.com##+js(abort-current-inline-script.js, m, CH.Anonymous)
 ||jroqvbvw.info^$third-party
 ||jyhfuqoh.info^$third-party
 ||kdowqlpt.info^$third-party
-||kiwifarms.net/js/Jawsh/xmr/xmr.min.js
 ||megabanners.cf^$third-party
 ||megabanners.cf^$websocket
 ||minecrunch.co^$third-party


### PR DESCRIPTION
"||coinhive.com^$third-party" at line 165 is a duplicate of the exact same filter at line 13. "||kiwifarms.net/js/Jawsh/xmr/xmr.min.js" at line 185 is redundant with "/xmr.min.js" at line 126.