### PR TITLE
Update for twitch ads #1971

### DIFF
--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -2345,10 +2345,10 @@ twitch-videoad.js application/javascript
 		}
 	});
 	var realFetch = window.fetch;
-	window.fetch = function() {		
-		if (JSON.stringify(arguments).includes("access_token"))
+	window.fetch = function(input, init) {
+		if (arguments.length >= 2 && typeof input === "string" && input.includes("/access_token"))
 		{
-			document.cookie = "unique_id=;expires=Thu, 01 Jan 1970 00:00:00 GMT;domain=.twitch.tv;";
+			init.credentials = "omit";
 		}
 		return realFetch.apply(this, arguments);
 	}

--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -2349,6 +2349,9 @@ twitch-videoad.js application/javascript
 		if (arguments.length >= 2 && typeof input === "string" && input.includes("/access_token"))
 		{
 			init.credentials = "omit";
+			var url = new URL(arguments[0]);
+			url.searchParams.delete('player_type');
+			arguments[0] = url.href;
 		}
 		return realFetch.apply(this, arguments);
 	}

--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -2348,7 +2348,7 @@ twitch-videoad.js application/javascript
 	window.fetch = function(input, init) {
 		if (arguments.length >= 2 && typeof input === "string" && input.includes("/access_token"))
 		{
-			init.credentials = "omit";
+			//init.credentials = "omit";
 			var url = new URL(arguments[0]);
 			url.searchParams.delete('player_type');
 			arguments[0] = url.href;

--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -2319,6 +2319,7 @@ damoh-defuser.js application/javascript
 
 twitch-videoad.js application/javascript
 (function() {
+	if ( /(^|\.)twitch\.tv$/.test(document.location.hostname) === false ) { return; }
 	var ourMediaPlayer;
 	Object.defineProperty(window, 'MediaPlayer', {
 		set: function(newMediaPlayer) {
@@ -2348,13 +2349,12 @@ twitch-videoad.js application/javascript
 	window.fetch = function(input, init) {
 		if (arguments.length >= 2 && typeof input === "string" && input.includes("/access_token"))
 		{
-			//init.credentials = "omit";
 			var url = new URL(arguments[0]);
 			url.searchParams.delete('player_type');
 			arguments[0] = url.href;
 		}
 		return realFetch.apply(this, arguments);
-	}
+	};
 })();
 
 

--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -2344,6 +2344,14 @@ twitch-videoad.js application/javascript
 			return ourMediaPlayer;
 		}
 	});
+	var realFetch = window.fetch;
+	window.fetch = function() {		
+		if (JSON.stringify(arguments).includes("access_token"))
+		{
+			document.cookie = "unique_id=;expires=Thu, 01 Jan 1970 00:00:00 GMT;domain=.twitch.tv;";
+		}
+		return realFetch.apply(this, arguments);
+	}
 })();
 
 


### PR DESCRIPTION
This removes the "unique_id" cookie (responsible for delivering twitch ads) before it is sent in the https://api.twitch.tv/api/channels/XXXXX/access_token request. This isn't the best fix as it hooks window.fetch but it works.