### PR TITLE
Adding changes for times of India home page to block some ads

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -523,6 +523,7 @@ mumbaimirror.indiatimes.com###container:style(opacity: 1 !important;)
 mumbaimirror.indiatimes.com###blcontent
 mumbaimirror.indiatimes.com###blwrapper
 timesofindia.indiatimes.com##:xpath(//p[contains(text(),"Ad ")]/../..)
+timesofindia.indiatimes.com##.clearfix.hm_adlist.colombia
 economictimes.indiatimes.com##.active > ul > li:has-text(Ad:)
 
 ! https://github.com/gorhill/uBlock/issues/1789


### PR DESCRIPTION
### URL(s) where the issue occurs
`https://timesofindia.indiatimes.com/`

### Describe the issue
The advertisement occurs on the homepage of times of india, I remove these ads personally by using this script, it will be nice to include it by default.

### Screenshot(s)

https://imgur.com/a/cvJ22pl