### PR TITLE
Stack Exchange

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -216,7 +216,7 @@ Soundcloud
 		_ sndcdn.com xhr
 
 Stack Exchange
-	_ cdn.sstatic.net
+	* cdn.sstatic.net
 		_ 1st-party script
 		_ cdn.sstatic.net *
 		_ cdn.sstatic.net script

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -215,6 +215,15 @@ Soundcloud
 		_ sndcdn.com script
 		_ sndcdn.com xhr
 
+Stack Exchange
+	_ cdn.sstatic.net
+		_ 1st-party script
+		_ cdn.sstatic.net *
+		_ cdn.sstatic.net script
+		_ cdn.sstatic.net frame
+		_ ajax.googleapis.com script
+		_ i.stack.imgur.com image
+
 Steam
 	steampowered.com *
 		_ 1st-party script


### PR DESCRIPTION
`cdn.sstatic.net` is used on every Stack Exchange site, like stackoverflow.com, askubuntu.com, *.stackexchange.com etc. to serve static resources, like scripts.