### PR TITLE
Adds missing scripts for Yahoo Mail

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -298,6 +298,7 @@ Yahoo Mail
 		_ 1st-party script
 		_ yimg.com image
 		_ yimg.com xhr
+		_ s.yimg.com script allow
 
 Youtube no account
 	youtube.com *


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`mail.yahoo.com`

### Describe the issue
The webmailer only loads a few mails without these allowed scripts (currently only the first twelve mails are shown in my inbox)

### Screenshot(s)



### Versions

- Browser/version: Firefox 63.0 (64 Bit)
- uBlock Origin version: uMatrix 1.3.14

### Settings


### Notes
