### PR TITLE
streamable.com ad player rule

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -13482,3 +13482,6 @@ mycartoonvideo.net##+js(setTimeout-defuser.js, (), 1000)
 ! https://forums.lanik.us/viewtopic.php?f=62&t=41532
 upload4earn.org##+js(abort-on-property-write.js, Fingerprint2)
 ||lh3.googleusercontent.com^$image,domain=upload4earn.org
+
+! https://www.wykop.pl/wpis/31080707/ (polish)
+streamable.com##.stm-ad-player


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.wykop.pl/wpis/36381407/golgif/`
`https://www.wykop.pl/wpis/36279229/crystal-palace-1-1-arsenal-g-xhaka-no-i-kolejny-%CA%96/`
`https://www.wykop.pl/wpis/36155025/kolejna-kolejka-kolejny-swietny-gol-arsenalu-%CA%96-go/`

### Describe the issue

Never-ending loading screen without this rule

### Screenshot(s)

![](https://user-images.githubusercontent.com/11798442/48290614-d0305300-e473-11e8-81b3-14bc396968fb.png)

### Versions

- Browser/version: Firefox 61.0.1
- uBlock Origin version: v1.17.2

### Settings

No changes from default

### Notes


