### PR TITLE
Calling callback if provided for google analytics mock

### DIFF
--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -376,6 +376,12 @@ google-analytics.com/analytics.js application/javascript
 			return;
 		}
 		var f = arguments[len-1];
+		if ( typeof f === 'function' ) {
+			try {
+				f(new Tracker());
+			} catch (ex) {
+			}
+		}
 		if ( typeof f !== 'object' || f === null || typeof f.hitCallback !== 'function' ) {
 			return;
 		}


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.cars45.com/`

### Describe the issue

According to google analytics calling ga with a function as the first argument will call that callback with tracker.
https://developers.google.com/analytics/devguides/collection/analyticsjs/command-queue-reference

ga(function(tracker) {
  console.log(tracker); // Logs `undefined`.
});

Adding this behaviour to uBlock

### Versions

- Browser/version: [Chrome Version 70.0.3538.102 (Official Build) (64-bit)]
- uBlock Origin version: [uBlock origin 1.17.0]


### Notes
Added callback behaviour to mocked ga as well.