### PR TITLE
fix #4178

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -13927,7 +13927,7 @@ fin24.com##+js(abort-on-property-read.js, admiral)
 dexterclearance.com##.adsbygoogle:style(max-height: 1px !important;)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4178
-channel24.co.za,fin24.com,health24.com,parent24.com,traveller24.com,wheels24.co.za,w24.co.za##+js(abort-on-property-read.js, admiral)
+sport24.co.za,channel24.co.za,fin24.com,health24.com,parent24.com,traveller24.com,wheels24.co.za,w24.co.za##+js(abort-on-property-read.js, admiral)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/9ztarl/123freenet_pop_up/
 123free.net##+js(abort-on-property-read.js, zfgloadedpopup)


### PR DESCRIPTION
Referring to #4178, sport24.co.za does also work with `sport24.co.za##+js(abort-on-property-read.js, admiral)` 