### PR TITLE
Make Google reCaptcha less general

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -115,10 +115,9 @@ Google Maps
 
 Google reCaptcha
 	* www.google.com
-		_ www.google.com *
-		_ www.google.com script
 		_ www.google.com frame
-		_ www.gstatic.com *
+		_ www.google.com script
+		_ www.google.com xhr
 		_ www.gstatic.com script
 
 IMDb


### PR DESCRIPTION
The current scope is too broad, allowing cookies when it isn't needed.