### PR TITLE
Unbreak Slack download page

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -206,6 +206,7 @@ Slack
 		_ 1st-party script
 		_ slack-edge.com *
 		_ slack-edge.com script
+		_ slack-edge.com frame
 		_ slack-msgs.com *
 
 Soundcloud


### PR DESCRIPTION
this page requires frames to work: `https://slack.com/downloads/instructions/ubuntu`