### PR TITLE
Service workers for Gitlab IDE

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -95,6 +95,8 @@ Gitlab
 		_ 1st-party script
 		_ gitlab-static.net *
 		_ gitlab-static.net script
+		! required for gitlab IDE
+		no-workers: _ false
 
 Google account sign in
 	accounts.google.com *


### PR DESCRIPTION
Without service workers whitelisted, it looks like this:

![screenshot_2018-12-18 ide](https://user-images.githubusercontent.com/5832930/50139661-fafb9b80-02aa-11e9-9e58-719d7c0131ad.png)

devtools console:

![screenshot_20181218_095538](https://user-images.githubusercontent.com/5832930/50139708-1c5c8780-02ab-11e9-996d-17bfb3adc6af.png)
