### PR TITLE
Update Disqus ruleset

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -59,7 +59,9 @@ Disqus as 3rd-party
 	* disqus.com
 		_ disqus.com *
 		_ disqus.com frame
+		_ disqus.com script
 		_ disquscdn.com *
+		_ disquscdn.com script
 		
 Embedly as 3rd-party
 	* embedly.com


### PR DESCRIPTION
The scripts of Disqus should be enabled for stricter blocking modes. Without the scripts the Disqus comments are not displayed.

