### PR TITLE
Prevent exception if eval called with non-string argument in bab-defuser

### DIFF
--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -768,7 +768,7 @@ bab-defuser.js application/javascript
 	};
 	var realEval = window.eval;
 	window.eval = function(a) {
-		if ( typeof a !== "string" || !check(a) ) {
+		if ( typeof a !== 'string' || !check(a) ) {
 			return realEval(a);
 		}
 		var el = document.body;

--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -768,7 +768,7 @@ bab-defuser.js application/javascript
 	};
 	var realEval = window.eval;
 	window.eval = function(a) {
-		if ( !check(a) ) {
+		if ( typeof a !== "string" || !check(a) ) {
 			return realEval(a);
 		}
 		var el = document.body;


### PR DESCRIPTION
From [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval):
>If the argument of eval() is not a string, eval() returns the argument unchanged.

But `eval` wrapper in `bab-defuser` violates this contract: site's scripts get exceptions from `check` function if pass numbers or functions to eval:
```
Uncaught TypeError: s.indexOf is not a function
    at check (<anonymous>:23:57)
```

This pull request adds cheking of argument type.