### PR TITLE
Update Fingerprint2 stub

### DIFF
--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -1719,10 +1719,15 @@ twitch-videoad.js application/javascript
 fingerprint2.js application/javascript
 (function() {
 	let fp2 = function(){};
+	let browserId = '';
+	for (let i = 0; i < 32; i++) {
+		browserId += '0123456789abcdef'[(Math.random() * 16) | 0];
+	}
+	fp2.get = function(cb) {
+		setTimeout(function() { cb(browserId, []); }, 1);
+	}
 	fp2.prototype = {
-		get: function(cb) {
-			setTimeout(function() { cb('', []); }, 1);
-		}
+		get: fp2.get
 	};
 	window.Fingerprint2 = fp2;
 })();


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

http://www.realstream.space/en/player/5c6d0b214cae2605560650/33/227/5c6d95a2d996b.801925/FCSevilla-SSLazio/960/540

### Describe the issue

Fingerprint2 has been updated and [its .get() method is now static](https://github.com/Valve/fingerprintjs2#usage). The web site in the example also requires the function to return something:
```javascript
<script>var cF = function(result) {location.replace('http://www.realstream.space/en/player/5c6d0b214cae2605560650/33/227/5c6dc08cac816/' + result);};Fingerprint2.get(function(components) {var h = Fingerprint2.x64hash128(components.map(function (pair) { return pair.value }).join(), 31);cF(h); });</script><br>&nbsp;&nbsp;&nbsp;Loading...</body></html>
```
If result is an empty string (thus the location is http://www.realstream.space/en/player/5c6d0b214cae2605560650/33/227/5c6dc08cac816/), the web site redirects to http://www.realstream.space/blocked instead of the expected stream.

### Versions

- Browser/version: Firefox 65.0.1
- uBlock Origin version: 1.18.4

### Settings

- N/A

### Notes

N/A
