### PR TITLE
Remove CoinHive Domains

### DIFF
--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -13,11 +13,6 @@
 ||edgeno.de^$script,third-party,domain=~edgemesh.com
 /edgemesh.*.js$script,domain=~edgemesh.com|~edgeno.de
 
-! https://github.com/uBlockOrigin/uAssets/issues/690
-||coin-hive.com^$third-party
-||coinhive.com^$third-party
-||cnhv.co^$third-party
-
 ! https://github.com/uBlockOrigin/uAssets/pull/706
 ||jsecoin.com^$third-party
 


### PR DESCRIPTION
This pull request removes CoinHive's Domain Names from the Resource Abuse List. The service CoinHive shutsdown their mining platform on March 8th (See: https://coinhive.com/blog/en/discontinuation-of-coinhive), likewise inclusion of CoinHive Domain Names in the Resource Abuse list is no longer necessary. Thoughts?

**EDIT:** This is just a quick clarification that this pull request should not be merged until at least March 8th, 2019.