### PR TITLE
Remove ppoi.org & projectpoi.com from the resource abuse list

### DIFF
--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -33,10 +33,6 @@
 ! https://github.com/uBlockOrigin/uAssets/issues/746
 ||2giga.link^*hive$script
 
-! https://github.com/hoshsadiq/adblock-nocoin-list/issues/32
-||ppoi.org^$third-party
-||projectpoi.com^$third-party
-
 ! https://github.com/uBlockOrigin/uAssets/pull/748
 ||webmine.cz^$third-party
 


### PR DESCRIPTION
This pull request removes ppoi.org and projectpoi.com from the resource abuse list. Both names are now defunct and display a parked or domain for sale page and no longer need to be included. Thoughts?