### PR TITLE
Remove hatevery.info

### DIFF
--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -64,12 +64,6 @@
 ||jsccnn.com^$third-party
 ||jscdndel.com^$third-party
 
-! https://www.bleepingcomputer.com/news/security/cryptojacking-script-found-in-live-help-widget-impacts-around-1-500-sites/
-! https://publicwww.com/websites/%22lhnhelpouttab-current.min.js%22/
-/lhnhelpouttab-current.min.js
-! https://blog.malwarebytes.com/cybercrime/2017/11/persistent-drive-by-cryptomining-coming-to-a-browser-near-you/
-||hatevery.info^$third-party
-
 ! https://github.com/hoshsadiq/adblock-nocoin-list/issues/59
 csgoconfigs.com##+js(abort-current-inline-script.js, m, CH.Anonymous)
 ||coinhiveproxy.com^$third-party

--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -64,6 +64,10 @@
 ||jsccnn.com^$third-party
 ||jscdndel.com^$third-party
 
+! https://www.bleepingcomputer.com/news/security/cryptojacking-script-found-in-live-help-widget-impacts-around-1-500-sites/
+! https://publicwww.com/websites/%22lhnhelpouttab-current.min.js%22/
+/lhnhelpouttab-current.min.js
+
 ! https://github.com/hoshsadiq/adblock-nocoin-list/issues/59
 csgoconfigs.com##+js(abort-current-inline-script.js, m, CH.Anonymous)
 ||coinhiveproxy.com^$third-party


### PR DESCRIPTION
The domain hatevery.info is no longer registered and can be removed from the list.