### PR TITLE
Remove kickass.cd

### DIFF
--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -247,9 +247,6 @@ vidzi.tv##+js(abort-on-property-write.js, decodeURIComponent)
 ||thepiratebay.cr^$csp=child-src 'none';frame-src *;worker-src 'none';
 *?proxy=$script
 
-! kickass mining
-||kickass.cd^$csp=child-src 'none';frame-src *;worker-src 'none';
-
 ! https://github.com/uBlockOrigin/uAssets/issues/986
 ||ddmix.net^$csp=child-src 'none';frame-src *;worker-src 'none';
 ||whathyx.com^


### PR DESCRIPTION
The domain kickass.cd is no longer registered and can be removed from the list.