### PR TITLE
Add dnsleaktest.net to badware list

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -162,3 +162,6 @@ upload4earn.org##+js(remove-attr.js, checked)
 
 ! com-guest.info badware
 ||com-guest.info^$document
+
+! dnsleaktest.net badware
+||dnsleaktest.net^$document


### PR DESCRIPTION
The URL http://dnsleaktest.net/ is a look alike of http://dnsleaktest.com/ however instead of providing a website that looks up your current DNS Resolver it redirects you to malware pages trying to get you to install a fake adobe flash player update.