### PR TITLE
Add foxload.com to badware list

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -165,3 +165,6 @@ upload4earn.org##+js(remove-attr.js, checked)
 
 ! dnsleaktest.net badware
 ||dnsleaktest.net^$document
+
+! foxload.com badware
+||foxload.com^$document


### PR DESCRIPTION
This is a bit tricky, the website foxload.com targets German internet users through Bing Advertisements. It offers downloads for a lot of popular software applications though their motivations are unclear, the binaries have likely been tampered with or have adware bundled in the installer.  Could someone look at this further and merge if they think this qualifies as crapware?