### PR TITLE
Add askia.co to badware list

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -172,4 +172,3 @@ upload4earn.org##+js(remove-attr.js, checked)
 ! aksia.co badware
 ! Ref: https://www.bleepingcomputer.com/news/security/phisher-announces-more-attacks-against-hedge-funds-and-financial-firms/
 ||aksia.co^$document
-||www.aksia.co^$document

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -172,4 +172,4 @@ upload4earn.org##+js(remove-attr.js, checked)
 ! aksia.co badware
 ! Ref: https://www.bleepingcomputer.com/news/security/phisher-announces-more-attacks-against-hedge-funds-and-financial-firms/
 ||aksia.co^$document
-||www.aksia.co
+||www.aksia.co^$document

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -168,3 +168,8 @@ upload4earn.org##+js(remove-attr.js, checked)
 
 ! foxload.com badware
 ||foxload.com^$document
+
+! aksia.co badware
+! Ref: https://www.bleepingcomputer.com/news/security/phisher-announces-more-attacks-against-hedge-funds-and-financial-firms/
+||aksia.co^$document
+||www.aksia.co


### PR DESCRIPTION
This pull request adds the domain name askia.co to the badware in response to BleepingComputer's article at https://www.bleepingcomputer.com/news/security/phisher-announces-more-attacks-against-hedge-funds-and-financial-firms/