### PR TITLE
Small fix for Facebook domains

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -1809,8 +1809,8 @@ bookbub.com##.post-section:style(filter: none !important; -webkit-filter: none !
 ndtv.com###___ndtvpushdiv
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5030
-facebook.com##._5hn6
-facebook.com##.generic_dialog_modal.pop_dialog
+facebook.com,facebookcorewwwi.onion##._5hn6
+facebook.com,facebookcorewwwi.onion##.generic_dialog_modal.pop_dialog
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5030
 quora.com##._DialogSignupForm

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -662,7 +662,7 @@ eurogamer.net##html:style(cursor: default !important;)
 facebook.com,facebookcorewwwi.onion###stream_pagelet div[id^="hyperfeed_story_id_"]:has(a.uiStreamSponsoredLink)
 ! "People You May Know": EasyList tries to block these, might as well block them fully
 facebook.com,facebookcorewwwi.onion###stream_pagelet div[id^="hyperfeed_story_id_"]:if(h6:has-text(People You May Know))
-m.facebook.com##article:has(footer > div > div > a[href^="/friends/center/?fb_ref="])
+m.facebook.com,m.beta.facebook.com,touch.facebook.com,touch.beta.facebook.com,m.facebookcorewwwi.onion##article:has(footer > div > div > a[href^="/friends/center/?fb_ref="])
 ! https://www.reddit.com/r/uBlockOrigin/comments/58o3k6/facebook_ads_solution/
 facebook.com,facebookcorewwwi.onion##.ego_section:has(a.adsCategoryTitleLink)
 ! https://github.com/uBlockOrigin/uAssets/issues/507
@@ -676,7 +676,7 @@ facebook.com,facebookcorewwwi.onion##.ego_section:if(a[href^="/ad_campaign"])
 facebook.com,facebookcorewwwi.onion##.userContentWrapper:has(a[href*="/ads/"]):not(:has(a[href*="/ads/preferences"]))
 ! https://github.com/uBlockOrigin/uAssets/issues/3367
 !facebook.com,facebookcorewwwi.onion##[id^="hyperfeed_story_id_"]:has(a[href*="client_token"])
-facebook.com#@#div[id^="hyperfeed_story_id_"]:has(a[href*="utm_campaign"])
+facebook.com,facebookcorewwwi.onion#@#div[id^="hyperfeed_story_id_"]:has(a[href*="utm_campaign"])
 facebook.com,facebookcorewwwi.onion##.userContentWrapper>div div>span>span:has-text(/^Suggested Post$/)
 facebook.com,facebookcorewwwi.onion##div[id^="hyperfeed_story_id_"]:has(div > span:has(abbr .timestampContent):matches-css(display: none))
 facebook.com,facebookcorewwwi.onion##.ego_section:has(a[href*="campaign_id"])


### PR DESCRIPTION
Facebook has been rolling out `touch.facebook.com`, as well as beta versions for its phone browser domains, so that's something that I felt should be covered.

I also added `facebookcorewwwi.onion` to three entries that had previously forgot to add them.