### PR TITLE
Going ballistic on uBlock non-Origin

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -91,6 +91,7 @@ upload4earn.org##+js(remove-attr.js, checked)
 ||chrismatic.io/ublock^$document
 google.*##.g > div[data-hveid][data-ved]:has(cite:has-text(://www.ublock.org/))
 google.*##.g > div[data-hveid][data-ved]:has(cite:has-text(/ublock/epcnnfbjfcgphgdmggkamkmgojdagdn))
+google.*##.g > div[data-hveid][data-ved]:has(cite:has-text(/firefox/addon/ublock/))
 google.*##.g > div[data-hveid][data-ved]:has(cite:has-text(chrismatic.io/ublock/))
 google.*###rhs_block:has-text(uBlock):has-text(23):has-text(2014)
 

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -88,6 +88,11 @@ upload4earn.org##+js(remove-attr.js, checked)
 
 ! https://github.com/gorhill/uBlock/wiki/Badware-risks#ublockorg
 ||ublock.org^$document
+||chrismatic.io/ublock^$document
+google.*##.g > div[data-hveid][data-ved]:has(cite:has-text(://www.ublock.org/))
+google.*##.g > div[data-hveid][data-ved]:has(cite:has-text(/ublock/epcnnfbjfcgphgdmggkamkmgojdagdn))
+google.*##.g > div[data-hveid][data-ved]:has(cite:has-text(chrismatic.io/ublock/))
+google.*###rhs_block:has-text(uBlock):has-text(23):has-text(2014)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3060
 ! https://www.bleepingcomputer.com/news/security/fake-websites-for-keepass-7zip-audacity-others-found-pushing-adware/


### PR DESCRIPTION
Long story short, I came across https://www.reddit.com/r/assholedesign/comments/b2k7qj/ad_blocker_blocks_itself_ublock/, wherein the majority opinion was that uBO was a malware scam that tried to prevent people from downloading the """real""" uBlock.

That thread pissed me off so hard, that I'm feeling like really hammering the point into them and to similar kinds of oblivious internetizens that uBO is the real (i.e. the by far and beyond most maintained) one.

What the new entries do:

```
! Removes Google results to their official website
google.*##.g > div[data-hveid][data-ved]:has(cite:has-text(://www.ublock.org/))
! Removes Google results for uBlock's Chrome extension page
google.*##.g > div[data-hveid][data-ved]:has(cite:has-text(/ublock/epcnnfbjfcgphgdmggkamkmgojdagdn))
! Removes Google results for μBlock's Firefox extension page
google.*##.g > div[data-hveid][data-ved]:has(cite:has-text(/firefox/addon/ublock/))
! Removes Google results for Chrismatic's homepage's uBlock section
google.*##.g > div[data-hveid][data-ved]:has(cite:has-text(chrismatic.io/ublock/))
! Removes the uBlock info section to the right of the search results (Presumes that the release date of uBlock is shown as being on the 23rd in all timezones)
google.*###rhs_block:has-text(uBlock):has-text(23):has-text(2014)
! Attempts to block the uBlock section of Chrismatic's website
||chrismatic.io/ublock^$document
```