### PR TITLE
Also remove cookie for base domain when on 'www.' subdomain

### DIFF
--- a/filters/resources.txt
+++ b/filters/resources.txt
@@ -2245,6 +2245,8 @@ cookie-remover.js application/javascript
 			let part1 = cookieName + '=';
 			let part2a = '; domain=' + document.location.hostname;
 			let part2b = '; domain=.' + document.location.hostname;
+			let domain = document.domain;
+			let part2c = domain && domain !== document.location.hostname ? '; domain=.' + domain : undefined;
 			let part3 = '; path=/';
 			let part4 = '; Max-Age=-1000; expires=Thu, 01 Jan 1970 00:00:00 GMT';
 			document.cookie = part1 + part4;
@@ -2253,6 +2255,9 @@ cookie-remover.js application/javascript
 			document.cookie = part1 + part3 + part4;
 			document.cookie = part1 + part2a + part3 + part4;
 			document.cookie = part1 + part2b + part3 + part4;
+			if ( part2c !== undefined ) {
+				document.cookie = part1 + part2c + part3 + part4;
+			}
 		});
 	};
 	removeCookie();


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### Describe the issue

We started having a problem with [removing cookies](https://github.com/tomasko126/easylistczechandslovak/blob/d7ae01/filters_ublock.txt#L13) used for showing ads on sites serving their content under `www.` subdomain. Problem was that they were setting cookie domain without `www.` part (just `.example.com`) and `cookie-remover.js` was not deleting those cookies.

### Versions

- Browser/version: Firefox 66/Chrome 74
- uBlock Origin version: 1.18.16
