### PR TITLE
Add keepassxc.com to badware list

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -243,3 +243,6 @@ majorgeeks.com##b:has(a[target^="reimage"])
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/bmnjfg/found_a_pretty_nasty_malware_site_had_to_kill/
 ||internet-security-73bd67kl.tk^$document
+
+! Look-alike domain for keepassxc.org, redirects to spam/malware domains
+keepassxc.com


### PR DESCRIPTION
### URL(s) where the issue occurs

keepassxc.com

### Describe the issue

Look-alike of keepassxc.org redirects to spam/malware domains.

### Screenshot(s)

N/A

### Versions

N/A

### Settings

N/A

### Notes

KeePassXC's twitter account disavowed the domain https://twitter.com/KeePassXC/status/1126845706000568320
