### PR TITLE
Add colpirio .com tracker

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -166,3 +166,6 @@ rediff.com##+js(remove-attr.js, onmousedown, [onmousedown^="return enc(this,'htt
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/b9qsix/new_reddit_tracks_a_ton_more_data_someone_said/
 ||reddit.com/api/jail/$xhr,1p
+
+! https://github.com/uBlockOrigin/uAssets/pull/5578
+||colpirio.com^$3p


### PR DESCRIPTION
Started seeing this tracker more often now. Mostly on czech sites but if you look on their website (`https://www.colpirio.com/home/#anchor-contact`) they also have offices in poland so its not local only.

From what I have seen its only used for collecting user data. Last time seen on `youradio.cz` but as I said I have seen it before somewhere else too.