### PR TITLE
Block Discord's "give nitro" button in annoyances filter

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -2275,3 +2275,6 @@ targetstudy.com##+js(abort-on-property-write.js, stopSelect)
 ! https://github.com/uBlockOrigin/uAssets/issues/5622
 tinder.com###content > span > .App main div[class^="Pos"][class*="NetHeight"]:style(height: 100% !important;)
 tinder.com###content > span > .App > div[class^="Pos"][class*="Start"]:has-text(cookie)
+
+! discord's "give nitro" button
+discordapp.com##[class^="buttonWrapper"][tabindex="2"]


### PR DESCRIPTION
This is an often complained about "feature" on Discord that shows a button to "give Nitro" (Discord's premium subscription) in the chatbox at all times.  This is considered very annoying (and could be reasonably be considered an advertisement) so it should be blocked by the annoyances filter.