### PR TITLE
Add exceptions for bombuj.eu

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -15398,6 +15398,9 @@ movie4kto.org##+js(abort-on-property-read.js, decodeURIComponent)
 
 ! https://github.com/NanoMeow/QuickReports/issues/509
 @@||bombuj.eu^$generichide
+@@||bombuj.eu/prehravace/overeniecaptcha3final.php
+@@||bombuj.eu/prehravace/openload.io.php
+@@||bombuj.eu/prehravace/verystream.com.php
 ||bombuj.eu/*.php$subdocument
 bombuj.eu##[id*="rekl"]
 bombuj.eu###ad_banner


### PR DESCRIPTION
This PR adds exceptions for bombuj.eu. The filter ` ||bombuj.eu/*.php$subdocument` blocks also URLs which are needed.
