### PR TITLE
Block Google Docs logImpressions API

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -172,3 +172,6 @@ rediff.com##+js(remove-attr.js, onmousedown, [onmousedown^="return enc(this,'htt
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/bvlumg/oldredditcom_outbound_link_redirect/
 old.reddit.com##+js(remove-attr.js, data-outbound-url)
+
+! google docs tracking api
+||docs.google.com/*/logImpressions?$xmlhttprequest,domain=docs.google.com


### PR DESCRIPTION
This pull request blocks the logImpressions API, an API that is used for tracking by Google Docs.