### PR TITLE
Added various look-alike domains for popular open source tools

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -92,31 +92,86 @@ upload4earn.org##+js(remove-attr.js, checked)
 ! https://github.com/uBlockOrigin/uAssets/issues/3060
 ! https://www.bleepingcomputer.com/news/security/fake-websites-for-keepass-7zip-audacity-others-found-pushing-adware/
 ! https://www.virustotal.com/#/file/a5616985e92ca7c1df3b132d2da2ef33c64f38ba2dca40445017037473d7d014/detection
+! https://twitter.com/certbund/status/1127864403276091393
+||7zip.es^$document
 ||7zip.fr^$document
+||7zip.it^$document
+||adblock.fr^$document
 ||appdownloads.co^$document
+||aresgalaxy.es^$document
+||audacity.es^$document
+||audacity.fr^$document
+||audacity.it^$document
+||audacity.pl^$document
 ||azureus.es^$document
+||bittorrent.es^$document
+||bleachbit.com^$document
+||blender3d.es^$document
+||blender3d.fr^$document
 ||bluestacksdownloads.com^$document
+||calibre.it^$document
 ||celestia.es^$document
 ||celestia.fr^$document
 ||clonezilla.es^$document
 ||clonezilla.fr^$document
+||clonezilla.it^$document
+||cyberduck.de^$document
+||cyberduck.es^$document
+||cyberduck.fr^$document
+||cyberduck.it^$document
+||filezilla.es^$document
+||filezilla.fr^$document
+||filezilla.it^$document
+||filezilla.net^$document
+||filezilla.pl^$document
+||filezilla.pt^$document
+||freefilesync.com^$document
+||freerapid.fr^$document
 ||garagebandforpc.org^$document
 ||gimp.es^$document
 ||gparted.fr^$document
+||gparted.it^$document
 ||greenshot.fr^$document
+||greenshot.org^$document
 ||handbrake.es^$document
+||handbrake.it^$document
 ||inkscape.es^$document
 ||inkscape.fr^$document
+||inkscape.it^$document
+||izarc.fr^$document
+||jdownloader.fr^$document
 ||keepass.com^$document
+||keepass.es^$document
 ||keepass.fr^$document
+||keepass.it^$document
 ||notepad2.com^$document
+||open-office.fr^$document
 ||paintnet.es^$document
 ||paintnet.fr^$document
+||paintnet.it^$document
+||pdfcreator.pt^$document
+||pdfsam.com^$document
+||peazip.com^$document
+||qbittorrent.com^$document
 ||scribus.fr^$document
+||scribus.it^$document
+||senuti.org^$document
+||sharex.es^$document
+||smplayer.org^$document
+||songbird.es^$document
+||stellarium.es^$document
 ||stellarium.fr^$document
+||telecharger-openoffice.fr^$document
 ||thunderbird.es^$document
+||truecrypt.es^$document
+||truecrypt.fr^$document
+||truecrypt.it^$document
+||truecrypt.pl^$document
 ||unetbootin.net^$document
 ||unetbootin.org^$document
+||utorrent.it^$document
+||virtualbox.es^$document
+||virtualbox.pl^$document
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3730
 ! https://blog.sucuri.net/2018/10/malicious-redirects-from-newsharecounts-com-tweet-counter.html


### PR DESCRIPTION
I observed that the past list for look-alike domains of popular tools like keepass, 7zip is missing some of the domains pointing to the same IP address i.e 185.46.229.39

### URL(s) where the issue occurs

https://greenshot.org/
https://open-office.fr/
https://songbird.es/
(skipping all the domains here)

### Notes

I have consciously updated the existing list instead of appending at bottom as it is the part of the same set of malicious domains. Please let me know if this shall be amended. The domains are obtained from passive DNS data which was also shared with [BSI-CERT](https://www.bsi.bund.de/DE/Themen/Cyber-Sicherheit/Aktivitaeten/CERT-Bund/certbund_node.html) [earlier](https://twitter.com/certbund/status/1127864403276091393).

Please review.