### PR TITLE
Remove outdated bombuj.eu rules (updated rules in EasyList CZ&SK)

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -15426,16 +15426,6 @@ gostreams.net##+js(abort-on-property-write.js, Fingerprint2)
 ! https://github.com/uBlockOrigin/uAssets/issues/4460
 movie4kto.org##+js(abort-on-property-read.js, decodeURIComponent)
 
-! https://github.com/NanoMeow/QuickReports/issues/509
-@@||bombuj.eu^$generichide
-@@||bombuj.eu/prehravace/overeniecaptcha3final.php
-@@||bombuj.eu/prehravace/openload.io.php
-@@||bombuj.eu/prehravace/verystream.com.php
-||bombuj.eu/*.php$subdocument
-bombuj.eu##[id*="rekl"]
-bombuj.eu###ad_banner
-bombuj.eu##+js(abort-on-property-read.js, AaDetector)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4464
 ! https://github.com/uBlockOrigin/uAssets/issues/4465
 ! https://github.com/uBlockOrigin/uAssets/issues/4468


### PR DESCRIPTION
These old filters now break site functionality and since its only for czech and slovak users I moved some of these filters and added new ones here https://github.com/tomasko126/easylistczechandslovak/commit/4dc67b484a8843710b98906742b567bb63b1a816.