### PR TITLE
Block agar.io's full page transaction "ads"

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -2319,3 +2319,7 @@ foreignpolicy.com##.fb_lightbox-overlay-fixed.fb_lightbox-overlay
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5767
 firmwarefiledownload.xyz##.js-reveal-modal, .reveal-modal-bg
+
+! agar.io full page notice prompting to purchase microtransactions
+agar.io##div#openfl-overlay
+agar.io##div#openfl-content


### PR DESCRIPTION
This filter change removes the agar.io microtransaction "ads" (after a game, a message covers the whole page prompting a purchase of microtransactions).  Not a third party ad, just annoying.
