### PR TITLE
Add upscore.com tracker

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -175,3 +175,6 @@ old.reddit.com##+js(remove-attr.js, data-outbound-url)
 
 ! google docs tracking api
 ||docs.google.com/*/logImpressions?$xmlhttprequest,domain=docs.google.com
+
+! https://github.com/uBlockOrigin/uAssets/pull/5793
+||upscore.com^$3p


### PR DESCRIPTION
Blocks tracking by `https://www.upscore.com/`. 
Its used on multiple sites across europe (`https://publicwww.com/websites/%22%2Fasync%2FupScore.js%22/`)