### PR TITLE
remove hyperurl.co "sponsorship" ad/annoyance

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -2337,3 +2337,6 @@ msn.com##p:style(-moz-user-select: text !important; -moz-user-drag: text !import
 
 ! glamourmagazine.co.uk anti adb annoyance
 glamourmagazine.co.uk##+js(set-constant.js, ads_not_blocked, true)
+
+! hyperurl.co iTunes sponsorship (e.g. http://hyperurl.co/d1zest)
+hyperurl.co##div#offer


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

http://hyperurl.co/d1zest

### Describe the issue

[Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder.]

### Screenshot(s)

Without filter:
![image](https://user-images.githubusercontent.com/11603778/59809227-9d81ef00-92cd-11e9-88ad-ce69023e46b4.png)
With filter:
![image](https://user-images.githubusercontent.com/11603778/59809239-a70b5700-92cd-11e9-91fe-fe6f05c924f4.png)

### Notes

Arguably an ad, but seems more relevant to annoyances.