### PR TITLE
Speed up verystream download waiting time

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -21630,3 +21630,6 @@ humaribit.win##.adsbygoogle
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35676
 dictionnaire-medical.net##+js(setTimeout-defuser.js, nextFunction, 2000)
+
+! speed up Verystream waiting time
+verystream.com##+js(nano-setTimeout-booster.js)


### PR DESCRIPTION
Verystream usually requires you to wait five seconds until downloading the file is possible.  This uses `nano-setTimeout-booster.js` to speed that up.