### PR TITLE
Fix ads on gfycat.com

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -11929,6 +11929,7 @@ namemc.com##+js(abort-current-inline-script.js, setTimeout, runInIframe)
 namemc.com##+js(abort-on-property-write.js, deployads)
 pockettactics.com##+js(abort-current-inline-script.js, Math.floor, iframeTestTimeMS)
 tribunnews.com##+js(abort-current-inline-script.js, Math, ='\x)
+gfycat.com##+js(abort-current-inline-script.js, Math, ='\x)
 
 ! https://github.com/NanoMeow/QuickReports/issues/108
 descarga-animex.*##+js(abort-on-property-write.js, adBlockDetected)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://gfycat.com/jauntykeenbluejay-dramatic-kids`

### Describe the issue

Ads showing up from ga.gfycar.com

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave (Version 0.67.107 Chromium: 75.0.3770.100 (Official Build) (64-bit)
- uBlock Origin version: uBlock Origin 1.20.0

### Settings

- Easylist/Easyprivacy + Ublock filters.

### Notes

Was reported here; https://community.brave.com/t/pages-loads-3rd-party-ads-after-page-loads/71472/11