### PR TITLE
unbreak Google Docs (site breaks without tracking API)

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -173,8 +173,5 @@ rediff.com##+js(remove-attr.js, onmousedown, [onmousedown^="return enc(this,'htt
 ! https://www.reddit.com/r/uBlockOrigin/comments/bvlumg/oldredditcom_outbound_link_redirect/
 old.reddit.com##+js(remove-attr.js, data-outbound-url)
 
-! google docs tracking api
-||docs.google.com/*/logImpressions?$xmlhttprequest,domain=docs.google.com
-
 ! https://github.com/uBlockOrigin/uAssets/issues/5795#issuecomment-500244236
 ||browser-update.org^$3p


### PR DESCRIPTION
Unfortunately, Google Docs has changed their site backend to break if the logImpressions API fails.