### PR TITLE
Replace the Wikia recipe with a Fandom recipe

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -60,7 +60,7 @@ Disqus as 3rd-party
 		_ disqus.com *
 		_ disqus.com frame
 		_ disquscdn.com *
-		
+
 Embedly as 3rd-party
 	* embedly.com
 		_ api-cdn.embed.ly xhr
@@ -74,6 +74,14 @@ Facebook no account
 		_ fbcdn.net script
 		! Spoofing referrer breaks video playback
 		referrer-spoof: _ false
+
+Fandom
+	fandom.com *
+		_ 1st-party script
+		_ fandom.com *
+		_ fandom.com xhr
+		_ nocookie.net *
+		_ nocookie.net script
 
 Github
 	github.com *
@@ -139,7 +147,7 @@ JSFiddle
 		_ jshell.net *
 		_ jshell.net script
 		_ jshell.net frame
-		
+
 Mapbox as 3rd-party
 	* mapbox.com
 		_ api.mapbox.com *
@@ -221,7 +229,7 @@ Steam
 		_ steamstatic.com *
 		_ steamstatic.com media
 		_ steamstatic.com script
-		
+
 Stripe as 3rd-party
 	* stripe.com
 		_ stripe.com *
@@ -242,7 +250,7 @@ Twitch
 		_ ttvnw.net script
 		_ twitchcdn.net *
 		_ twitchcdn.net script
-		
+
 Twitch as 3rd-party
 	* twitch.tv
 		no-workers: _ false
@@ -266,19 +274,13 @@ Twitter with account
 		_ 1st-party script
 		_ twimg.com *
 		_ twimg.com script
-		
+
 Twitter as 3rd-party
 	* platform.twitter.com
 		_ platform.twitter.com *
 		_ platform.twitter.com script
 		_ platform.twitter.com frame
 		_ cdn.syndication.twimg.com script
-
-Wikia
-	wikia.com *
-		! wikis are displayed as text-only without this
-		_ wikia.nocookie.net *
-		_ wikia.nocookie.net script
 
 Vimeo as 3rd-party
 	* player.vimeo.com

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -290,6 +290,14 @@ Vimeo as 3rd-party
 		_ vimeocdn.com *
 		_ vimeocdn.com script
 
+Wikia.org
+	wikia.org *
+		_ 1st-party script
+		_ wikia.org *
+		_ wikia.org xhr
+		_ nocookie.net *
+		_ nocookie.net script
+
 XDA-Developers
 	xda-developers.com *
 		_ xda-cdn.com *


### PR DESCRIPTION
Every site that used to be hosted on wikia.com has been moved to fandom.com.\
This PR updates the recipe to fandom.com and modifies it to work properly.