### PR TITLE
block medium.com "pardon the interruption" modal

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -2537,3 +2537,6 @@ starblast.io##+js(ra, oncontextmenu)
 
 ! https://github.com/NanoMeow/QuickReports/issues/1692
 @@||thesaurus.com/assets/ads.js$xhr,1p
+
+! block medium.com "pardon the interruption" modal that prompts you to sign-up/log-in.
+medium.com##:xpath(//div[.//div[contains(@tabindex,"-1") and contains(@aria-modal,"true")]])


### PR DESCRIPTION
### Describe the issue

Medium.com displays an annoying modal prompting you to signup after you've read a few articles.

### URL(s) where the issue occurs

The modal appears after you open a few articles (3, I think)

`https://medium.com/swlh/state-of-the-digital-nation-2020-venture-road-22de4377836`

### Screenshot(s)

![pardon](https://user-images.githubusercontent.com/554078/63460481-e897ba00-c456-11e9-9975-cdeae4050b65.png)

### Notes

The filter is aggressive, but this was the only way to target the correct div. The class on the div is randomized in an effort combat adblocking. An alternative approach would be to target a particular string, but that is also prone to stop working the moment the copy inside the modal changes.
