### PR TITLE
uMatrix: Ruleset recipe: Add `Dailymotion as 3rd-party` ruleset

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -48,6 +48,15 @@ Dailymotion
 		_ ajax.googleapis.com script
 		no-workers: dailymotion.com false
 
+Dailymotion as 3rd-party
+	* dailymotion.com
+		_ api.dmcdn.net script
+		_ dailymotion.com xhr
+		_ dmxleo.dailymotion.com script
+		_ static1.dmcdn.net script
+		_ www.dailymotion.com *
+		_ ajax.googleapis.com script
+
 Discord
 	discordapp.com *
 		_ 1st-party script


### PR DESCRIPTION
(Per #3485, the correct procedure for adding to [recipes/recipes_en.txt](https://github.com/uBlockOrigin/uAssets/blob/master/recipes/recipes_en.txt) is to submit a pull request here and ping @gorhill.)

@gorhil, I'm not certain if I got the syntax right, but assuming I did, I think this ruleset recipe should work for showing embedded Dailymotion videos. Please take a look! The page I originally tested this on was [this one](https://nesn.com/2019/08/patriots-brandon-king-carted-off-field-after-left-leg-injury-vs-panthers/), but it would probably be wise to try others before accepting this PR.
