### PR TITLE
Fix Slack recipe and add other new recipes

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -27,7 +27,6 @@ Algolia as 1st-party
 Amazon no account
 	amazon.com *
 		_ 1st-party script
-		_ 1st-party xhr
 		! move between images on products
 		_ ssl-images-amazon.com *
 		_ ssl-images-amazon.com script
@@ -41,10 +40,8 @@ Apple Mapkit as 3rd-party
 Archive.org
 	archive.org *
 		_ 1st-party frame
-		_ 1st-party media
 		_ 1st-party other
 		_ 1st-party script
-		_ 1st-party xhr
 
 Ars Technica
 	arstechnica.com *
@@ -61,17 +58,14 @@ Ars Technica
 
 Autodesk 360
 	autodesk.com *
-		_ 1st-party media
 		_ 1st-party script
-		_ 1st-party xhr
 		_ autodesk.net *
 		_ autodesk.net frame
 		_ tiqcdn.com *
 		_ tiqcdn.com script
 	autodesk360.com *
 		_ 1st-party script
-		_ 1st-party xhr
-		_ autodesk.com
+		_ autodesk.com *
 		_ autodesk.com script
 		_ autodesk.com xhr
 		_ cloudflare.com *
@@ -80,15 +74,12 @@ Autodesk 360
 Bandcamp
 	bandcamp.com *
 		_ 1st-party script
-		_ 1st-party xhr
 		_ bcbits.com *
-		_ bcbits.com media
 		_ bcbits.com script
 
 Chief Delphi
 	chiefdelphi.com *
 		_ 1st-party script
-		_ 1st-party xhr
 		_ googlevideo.com *
 		_ googlevideo.com xhr
 		_ youtube.com *
@@ -112,7 +103,6 @@ Dailymotion
 Desmos
 	desmos.com *
 		1st-party script
-		1st-party xhr
 
 Discord
 	discordapp.com *
@@ -130,7 +120,6 @@ Disqus as 3rd-party
 Dropbox
 	dropbox.com *
 		_ 1st-party script
-		_ 1st-party xhr
 		_ dropboxstatic.com *
 		_ dropboxstatic.com script
 		_ dropboxstatic.com xhr
@@ -138,13 +127,10 @@ Dropbox
 DuckDuckGo
 	duckduckgo.com *
 		_ 1st-party script
-		! load images in search results
-		_ 1st-party xhr
 
 eBay
 	ebay.com *
 		_ 1st-party script
-		_ 1st-party xhr
 		_ ebaystatic.com *
 		_ ebaystatic.com script
 
@@ -165,7 +151,6 @@ Facebook no account
 Fandom (formerly Wikia)
 	fandom.com *
 		_ 1st-party script
-		_ 1st-party xhr
 		! media viewer does not work without this
 		_ nocookie.net *
 		_ nocookie.net script
@@ -188,7 +173,6 @@ Github
 Gitlab
 	gitlab.com *
 		_ 1st-party script
-		_ 1st-party xhr
 		_ gitlab-static.net *
 		_ gitlab-static.net script
 
@@ -213,15 +197,6 @@ Google Calendar
 		_ apis.google.com script
 		_ gstatic.com *
 		_ gstatic.com script
-
-Google Classroom
-	classroom.google.com *
-		_ google.com *
-		_ google.com frame
-		_ google.com script
-		_ google.com xhr
-		_ googleusercontent.com *
-		_ googleusercontent.com script
 
 Google Docs
 	docs.google.com *
@@ -336,7 +311,6 @@ JSFiddle
 Khan Academy
 	khanacademy.org *
 		_ 1st-party script
-		_ 1st-party xhr
 		_ kastatic.org *
 		_ kastatic.org script
 		_ kastatic.org xhr
@@ -354,7 +328,6 @@ Mediafire
 	mediafire.com *
 		_ 1st-party frame
 		_ 1st-party script
-		_ 1st-party xhr
 
 MEGA
 	mega.nz *
@@ -412,7 +385,6 @@ Slack
 	slack.com *
 		_ 1st-party frame
 		_ 1st-party script
-		_ 1st-party xhr
 		_ slack-edge.com *
 		_ slack-edge.com script
 		_ slack-msgs.com *
@@ -428,7 +400,6 @@ Startpage
 	startpage.com *
 		_ 1st-party frame
 		_ 1st-party script
-		_ 1st-party xhr
 
 Steam
 	steampowered.com *
@@ -453,7 +424,6 @@ Stripe as 3rd-party
 The Blue Alliance
 	thebluealliance.com *
 		_ 1st-party script
-		_ 1st-party xhr
 		_ ajax.googleapis.com *
 		_ ajax.googleapis.com script
 		_ cloudflare.com *
@@ -471,9 +441,7 @@ The Blue Alliance
 
 Thingiverse
 	thingiverse.com *
-		_ 1st-party media
 		_ 1st-party script
-		_ 1st-party xhr
 		_ thingiverse-production-new.s3.amazonaws.com *
 		_ thingiverse-production-new.s3.amazonaws.com xhr
 
@@ -505,7 +473,6 @@ Twitch as 3rd-party
 Twitter no account
 	twitter.com *
 		_ 1st-party script
-		_ 1st-party xhr
 		_ twimg.com *
 		_ twimg.com media
 		_ twimg.com script
@@ -541,7 +508,6 @@ Wikia
 Wikipedia
 	wikipedia.org *
 		_ 1st-party script
-		_ 1st-party xhr
 		_ wikimedia.org *
 		_ wikimedia.org media
 
@@ -563,7 +529,6 @@ Yahoo Mail
 Youtube no account
 	youtube.com *
 		_ 1st-party script
-		_ 1st-party xhr
 		_ googlevideo.com *
 		_ googlevideo.com xhr
 		_ ytimg.com *

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -192,11 +192,94 @@ Gitlab
 		_ gitlab-static.net *
 		_ gitlab-static.net script
 
-Google account sign in
+Google Account
 	accounts.google.com *
 		_ 1st-party script
 		_ gstatic.com *
 		_ gstatic.com script
+
+Google Admin
+	admin.google.com *
+		_ admin.google.com script
+		_ admin.google.com xhr
+		_ gstatic.com *
+		_ gstatic.com script
+
+Google Calendar
+	calendar.google.com *
+		_ calendar.google.com script
+		_ calendar.google.com xhr
+		_ apis.google.com *
+		_ apis.google.com script
+		_ gstatic.com *
+		_ gstatic.com script
+
+Google Classroom
+	classroom.google.com *
+		_ google.com *
+		_ google.com frame
+		_ google.com script
+		_ google.com xhr
+		_ googleusercontent.com *
+		_ googleusercontent.com script
+
+Google Docs
+	docs.google.com *
+		_ docs.google.com frame
+		_ docs.google.com other
+		_ docs.google.com script
+		_ docs.google.com xhr
+		_ apis.google.com *
+		_ apis.google.com script
+		_ clients6.google.com *
+		_ clients6.google.com xhr
+		_ gstatic.com *
+		_ gstatic.com script
+		_ gstatic.com xhr
+
+Google Drive
+	drive.google.com *
+		_ drive.google.com frame
+		_ drive.google.com script
+		_ drive.google.com xhr
+		_ content.googleapis.com *
+		_ content.googleapis.com frame
+		_ content.googleapis.com script
+		_ content.googleapis.com xhr
+		_ docs.google.com *
+		_ docs.google.com frame
+		_ docs.google.com script
+		_ docs.google.com xhr
+		_ youtube.googleapis.com *
+		_ youtube.googleapis.com frame
+		_ youtube.googleapis.com script
+		_ ytimg.com *
+		_ ytimg.com script
+		! controls account switcher
+		_ gstatic.com *
+		_ gstatic.com script
+		_ gstatic.com xhr
+		! controls navigation
+		_ clients6.google.com *
+		_ clients6.google.com xhr
+		! controls thumbnails
+		_ lh3.google.com *
+		_ lh3.google.com image
+
+Google Groups
+	groups.google.com *
+		_ groups.google.com script
+		_ groups.google.com xhr
+
+Google Mail
+	mail.google.com *
+		_ mail.google.com script
+		_ mail.google.com xhr
+		_ mail.google.com frame
+		_ apis.google.com *
+		_ apis.google.com script
+		_ drive.google.com *
+		_ drive.google.com xhr
 
 Google Maps
 	google.* *
@@ -216,6 +299,14 @@ Google reCaptcha
 		_ www.google.com frame
 		_ www.gstatic.com *
 		_ www.gstatic.com script
+
+Google Translate
+	translate.google.com *
+		_ translate.google.com script
+		_ translate.google.com xhr
+		_ inputtools.google.com xhr
+		_ gstatic.com *
+		_ gstatic.com script
 
 IMDb
 	imdb.com *

--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -16,11 +16,35 @@
 		_ 4cdn.org *
 		_ 4cdn.org script
 
+Algolia as 1st-party
+	algolia.com *
+		_ 1st-party script
+		_ algolianet.com *
+		_ algolianet.com xhr
+		_ d3nb9u6x572n0.cloudfront.net *
+		_ d3nb9u6x572n0.cloudfront.net script
+
+Amazon no account
+	amazon.com *
+		_ 1st-party script
+		_ 1st-party xhr
+		! move between images on products
+		_ ssl-images-amazon.com *
+		_ ssl-images-amazon.com script
+
 Apple Mapkit as 3rd-party
 	* apple-mapkit.com
 		_ apple-mapkit.com *
 		_ apple-mapkit.com script
 		no-workers: _ false
+
+Archive.org
+	archive.org *
+		_ 1st-party frame
+		_ 1st-party media
+		_ 1st-party other
+		_ 1st-party script
+		_ 1st-party xhr
 
 Ars Technica
 	arstechnica.com *
@@ -35,6 +59,43 @@ Ars Technica
 		_ d2c8v52ll5s99u.cloudfront.net script
 		_ dp8hsntg6do36.cloudfront.net *
 
+Autodesk 360
+	autodesk.com *
+		_ 1st-party media
+		_ 1st-party script
+		_ 1st-party xhr
+		_ autodesk.net *
+		_ autodesk.net frame
+		_ tiqcdn.com *
+		_ tiqcdn.com script
+	autodesk360.com *
+		_ 1st-party script
+		_ 1st-party xhr
+		_ autodesk.com
+		_ autodesk.com script
+		_ autodesk.com xhr
+		_ cloudflare.com *
+		_ cloudflare.com script
+
+Bandcamp
+	bandcamp.com *
+		_ 1st-party script
+		_ 1st-party xhr
+		_ bcbits.com *
+		_ bcbits.com media
+		_ bcbits.com script
+
+Chief Delphi
+	chiefdelphi.com *
+		_ 1st-party script
+		_ 1st-party xhr
+		_ googlevideo.com *
+		_ googlevideo.com xhr
+		_ youtube.com *
+		_ youtube.com frame
+		_ youtube.com script
+		_ youtube.com xhr
+
 Cloudflare Stream as 3rd-party
 	* cloudflarestream.com
 		_ embed.cloudflarestream.com script
@@ -48,6 +109,11 @@ Dailymotion
 		_ ajax.googleapis.com script
 		no-workers: dailymotion.com false
 
+Desmos
+	desmos.com *
+		1st-party script
+		1st-party xhr
+
 Discord
 	discordapp.com *
 		_ 1st-party script
@@ -60,7 +126,28 @@ Disqus as 3rd-party
 		_ disqus.com *
 		_ disqus.com frame
 		_ disquscdn.com *
-		
+
+Dropbox
+	dropbox.com *
+		_ 1st-party script
+		_ 1st-party xhr
+		_ dropboxstatic.com *
+		_ dropboxstatic.com script
+		_ dropboxstatic.com xhr
+
+DuckDuckGo
+	duckduckgo.com *
+		_ 1st-party script
+		! load images in search results
+		_ 1st-party xhr
+
+eBay
+	ebay.com *
+		_ 1st-party script
+		_ 1st-party xhr
+		_ ebaystatic.com *
+		_ ebaystatic.com script
+
 Embedly as 3rd-party
 	* embedly.com
 		_ api-cdn.embed.ly xhr
@@ -74,6 +161,14 @@ Facebook no account
 		_ fbcdn.net script
 		! Spoofing referrer breaks video playback
 		referrer-spoof: _ false
+
+Fandom (formerly Wikia)
+	fandom.com *
+		_ 1st-party script
+		_ 1st-party xhr
+		! media viewer does not work without this
+		_ nocookie.net *
+		_ nocookie.net script
 
 Github
 	github.com *
@@ -93,6 +188,7 @@ Github
 Gitlab
 	gitlab.com *
 		_ 1st-party script
+		_ 1st-party xhr
 		_ gitlab-static.net *
 		_ gitlab-static.net script
 
@@ -133,13 +229,27 @@ IMDb
 		_ 1st-party frame
 		_ amazonaws.com script
 
+Instagram
+	instagram.com *
+		_ 1st-party script
+		_ instagram.com *
+		_ instagram.com xhr
+
 JSFiddle
 	jsfiddle.net *
 		_ 1st-party script
 		_ jshell.net *
 		_ jshell.net script
 		_ jshell.net frame
-		
+
+Khan Academy
+	khanacademy.org *
+		_ 1st-party script
+		_ 1st-party xhr
+		_ kastatic.org *
+		_ kastatic.org script
+		_ kastatic.org xhr
+
 Mapbox as 3rd-party
 	* mapbox.com
 		_ api.mapbox.com *
@@ -148,6 +258,12 @@ Mapbox as 3rd-party
 		_ tiles.mapbox.com script
 		! mapbox gl needs workers
 		no-workers: _ false
+
+Mediafire
+	mediafire.com *
+		_ 1st-party frame
+		_ 1st-party script
+		_ 1st-party xhr
 
 MEGA
 	mega.nz *
@@ -203,7 +319,9 @@ Reddit
 
 Slack
 	slack.com *
+		_ 1st-party frame
 		_ 1st-party script
+		_ 1st-party xhr
 		_ slack-edge.com *
 		_ slack-edge.com script
 		_ slack-msgs.com *
@@ -215,13 +333,19 @@ Soundcloud
 		_ sndcdn.com script
 		_ sndcdn.com xhr
 
+Startpage
+	startpage.com *
+		_ 1st-party frame
+		_ 1st-party script
+		_ 1st-party xhr
+
 Steam
 	steampowered.com *
 		_ 1st-party script
 		_ steamstatic.com *
 		_ steamstatic.com media
 		_ steamstatic.com script
-		
+
 Stripe as 3rd-party
 	* stripe.com
 		_ stripe.com *
@@ -235,6 +359,33 @@ Stripe as 3rd-party
 		_ m.stripe.network frame
 		_ m.stripe.network script
 
+The Blue Alliance
+	thebluealliance.com *
+		_ 1st-party script
+		_ 1st-party xhr
+		_ ajax.googleapis.com *
+		_ ajax.googleapis.com script
+		_ cloudflare.com *
+		_ cloudflare.com script
+		_ google.com *
+		_ google.com script
+		_ googlevideo.com *
+		_ googlevideo.com xhr
+		_ gstatic.com *
+		_ gstatic.com xhr
+		_ youtube.com *
+		_ youtube.com frame
+		_ youtube.com script
+		_ youtube.com xhr
+
+Thingiverse
+	thingiverse.com *
+		_ 1st-party media
+		_ 1st-party script
+		_ 1st-party xhr
+		_ thingiverse-production-new.s3.amazonaws.com *
+		_ thingiverse-production-new.s3.amazonaws.com xhr
+
 Twitch
 	twitch.tv *
 		no-workers: twitch.tv false
@@ -247,7 +398,7 @@ Twitch
 		_ ttvnw.net script
 		_ twitchcdn.net *
 		_ twitchcdn.net script
-		
+
 Twitch as 3rd-party
 	* twitch.tv
 		no-workers: _ false
@@ -263,27 +414,24 @@ Twitch as 3rd-party
 Twitter no account
 	twitter.com *
 		_ 1st-party script
+		_ 1st-party xhr
 		_ twimg.com *
+		_ twimg.com media
 		_ twimg.com script
+		_ twimg.com xhr
 
 Twitter with account
 	twitter.com *
 		_ 1st-party script
 		_ twimg.com *
 		_ twimg.com script
-		
+
 Twitter as 3rd-party
 	* platform.twitter.com
 		_ platform.twitter.com *
 		_ platform.twitter.com script
 		_ platform.twitter.com frame
 		_ cdn.syndication.twimg.com script
-
-Wikia
-	wikia.com *
-		! wikis are displayed as text-only without this
-		_ wikia.nocookie.net *
-		_ wikia.nocookie.net script
 
 Vimeo as 3rd-party
 	* player.vimeo.com
@@ -293,10 +441,26 @@ Vimeo as 3rd-party
 		_ vimeocdn.com *
 		_ vimeocdn.com script
 
+Wikia
+	wikia.com *
+		! wikis are displayed as text-only without this
+		_ wikia.nocookie.net *
+		_ wikia.nocookie.net script
+
+Wikipedia
+	wikipedia.org *
+		_ 1st-party script
+		_ 1st-party xhr
+		_ wikimedia.org *
+		_ wikimedia.org media
+
 XDA-Developers
 	xda-developers.com *
+		_ 1st-party script
 		_ xda-cdn.com *
 		_ xda-cdn.com script
+		_ cloudflare.com *
+		_ cloudflare.com script
 
 Yahoo Mail
 	mail.yahoo.com *
@@ -308,7 +472,9 @@ Yahoo Mail
 Youtube no account
 	youtube.com *
 		_ 1st-party script
+		_ 1st-party xhr
 		_ googlevideo.com *
+		_ googlevideo.com xhr
 		_ ytimg.com *
 		_ ytimg.com script
 


### PR DESCRIPTION
The Slack recipe has been broken since their browser redesign a few months ago. This should fix it.

I threw in some recipes for other websites (Amazon, Archive.org, Bandcamp, Chief Delphi, DuckDuckGo, eBay, Instagram, and Wikipedia). If needed, I can break each off into their own pull requests.