### PR TITLE
create filter to prevent blocker detection on kachelmannwetter

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -22346,3 +22346,5 @@ vidia.tv##+js(acis, $, undefined)
 ! https://github.com/uBlockOrigin/uAssets/issues/5435
 *$popunder,domain=multiup.eu|multiup.org,3p
 ||multinews.me^$all
+
+kachelmannwetter.*##+js(set-constant, isGoogle, trueFunc)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://kachelmannwetter.com/de`

### Describe the issue

The Website redirects the request if an adblocker is detected by an obfuscated script. This PR sets a variable, which causes the scripts output to be ignored.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/3575167/64169930-28936f80-ce4f-11e9-90f3-134bd7f178ef.png)

### Versions

- Browser/version: Google Chrome | 76.0.3809.132
- uBlock Origin version: v1.21.6

### Settings

- I am an experienced user

### Notes

Reverse engineered script which causes the redirection. An obfuscated snippet, which is likely a content-blocker-detector script calls an obfuscated function. However, the function checks for search-engine crawlers and, if it detects a crawler, ignores the output of the content-blocker-detector script.
