### PR TITLE
update #729

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -38,7 +38,7 @@
 ! https://github.com/NanoMeow/QuickReports/issues/1636
 ||2mdn.net/instream/video/client.js$script,redirect=noopjs,domain=video.foxnews.com
 ||cdn.krxd.net^$script,redirect=noopjs,domain=video.foxnews.com
-@@||akamaihd.net/player/*/akamai/amp/prebid/libs/prebid.js$script,domain=static.foxnews.com
+@@||akamaihd.net/player/*/akamai/amp/prebid/*$script,domain=static.foxnews.com
 @@||global.fncstatic.com/$script,domain=video.foxnews.com
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=insider.foxnews.com
 


### PR DESCRIPTION
Needs to be like this because the rule `/prebid/*` will then block
`https://foxnewsplayer-a.akamaihd.net/player/7.109.10/akamai/amp/prebid/Prebid.js` which also breaks the video.
#729