### PR TITLE
www.cnx-software.com ads block list

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -22107,3 +22107,7 @@ foxyork.com##+js(aopr, app_vars.force_disable_adblock)
 
 ! https://github.com/NanoMeow/QuickReports/issues/2265
 209.133.194.205##+js(acis, setTimeout, manageAntiBlock)
+
+! 25/10/2019 https://www.cnx-software.com
+www.cnx-software.com##*.gcacheb-single
+www.cnx-software.com##*.acacheb-single


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.cnx-software.com/`

### Describe the issue

Default ads blocking list don't block anything on this page.

### Screenshot(s)

https://ibb.co/PcB6RWJ

### Versions

- Browser/version: [Chromium 78.0.3904.87]
- uBlock Origin version: [1.23.0]

### Settings

- enabled all uBlock builtin filters
    - enabled ROU (romanian) list

### Notes

The ads a served from a reverse proxy-like cdn from the same domain cnx-software.com 
