### PR TITLE
fix freevocabulary.com anti adblock

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -22325,3 +22325,6 @@ ladepeche.fr##+js(aopr, localStorage)
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=43872
 projectfreetv.*##+js(aopw, _pop)
+
+! freevocabulary.com anti adb
+@@||freevocabulary.com^$generichide


### PR DESCRIPTION
See any page, for example `https://www.freevocabulary.com/`