### PR TITLE
Update unbreak.txt

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3008,7 +3008,7 @@ zone-anime.net##.code-block
 @@||analytics.edgekey.net/ma_library/html5/html5_malibrary.js$script,domain=mxplayer.in
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6609
-@@|blob:$popup,domain=box.com
+@@|blob:$popup,domain=patient.labcorp.com
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6615
 @@||epicgames.com/id/api/analytics/tracking$xhr,1p


### PR DESCRIPTION
Removed `box.com` as [fixed in EasyPrivacy](https://github.com/easylist/easylist/commit/574c3cc53ce6c2d8294ec4663c29b6ee6edfa2db#diff-2284536fd5efa67124975b0ee2e94f26), added new one that hasn't been fixed yet.
#6609