### PR TITLE
Fix anti-adblock on aternos.org (Solution 2)

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -4599,6 +4599,7 @@ themeslide.com##+js(nano-setInterval-booster.js, countdown, 1500)
 @@||snigelweb-com.videoplayerhub.com/videoloader.js$script,domain=aternos.org
 @@||static.h-bid.com^$css,script,domain=aternos.org
 @@*$xhr,3p,domain=aternos.org
+@@||google-analytics.com/analytics.js$script,domain=aternos.org
 
 ! https://github.com/uBlockOrigin/uAssets/issues/1027
 @@||imasdk.googleapis.com/js/sdkloader/*$script,domain=video.gjirafa.com


### PR DESCRIPTION
This PR fixes anti-adblock on aternos.org by keeping the existing filters and whitelisting another script.

Alternate solution in https://github.com/uBlockOrigin/uAssets/pull/6696