### PR TITLE
Avoid whitelisting all foxnews scripts, made more specific

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -2830,7 +2830,7 @@ webtor.io#@#.adsbox
 
 ! https://github.com/NanoMeow/QuickReports/issues/2240
 foxnews.com##:xpath(//*[contains(text(),"blocking software")]/../../..)
-/google-funding-choices.js$script,domain=foxnews.com,important
+/google-funding-choices.js$script,domain=foxnews.com
 
 ! smartpeople .id right click, select
 smartpeople.id##+js(ra, onkeydown|oncontextmenu|onselectstart|ondragstart)

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -36,7 +36,7 @@
 ||2mdn.net/instream/video/client.js$script,redirect=noopjs,domain=video.foxnews.com
 ||cdn.krxd.net^$script,redirect=noopjs,domain=video.foxnews.com
 @@||akamaihd.net/player/*/akamai/amp/prebid/*$script,domain=static.foxnews.com
-@@||global.fncstatic.com/$script,domain=video.foxnews.com
+@@||global.fncstatic.com^*/ads.js$script,domain=foxnews.com
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=insider.foxnews.com
 @@||amazon-adsystem.com/aax2/apstag.js$script,domain=foxnews.com
 


### PR DESCRIPTION
When just using unbreak, we found this whitelist is whitelisting too much on the site. Should be more specific. I adjusted to cover the "/ads.js" javascript.

This will allow Brave to block `https://global.fncstatic.com/static/isa/app/lib/google-funding-choices.js` while still using unbreak.txt