### PR TITLE
Allow block on aproxy on all platforms, and cover dronedj.com

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -1640,11 +1640,11 @@ monova.*#@#script + [class] > [class]:first-child
 ! https://github.com/uBlockOrigin/uAssets/issues/598
 ! https://www.reddit.com/r/uBlockOrigin/comments/6w2o8c/i_keep_seeing_ads_on_9to5mac/
 ! https://www.wilderssecurity.com/threads/ublock-a-lean-and-fast-blocker.365273/page-166#post-2878614
-9to5google.com,9to5mac.com,9to5toys.com,electrek.co##^script:has-text(_0x)
-9to5google.com,9to5mac.com,9to5toys.com,electrek.co##+js(set, canRunAds, true)
+9to5google.com,9to5mac.com,9to5toys.com,electrek.co,dronedj.com##^script:has-text(_0x)
+9to5google.com,9to5mac.com,9to5toys.com,electrek.co,dronedj.com##+js(set, canRunAds, true)
+9to5google.com,9to5mac.com,9to5toys.com,electrek.co,dronedj.com##+js(aopr, $aproxy)
 !#if env_chromium
 9to5google.com,9to5mac.com,9to5toys.com,electrek.co##+js(aopr, localStorage)
-9to5mac.com##+js(aopr, $aproxy)
 !#endif
 ||wp.com/*/adsbygoogle.js$script,important,domain=9to5mac.com
 


### PR DESCRIPTION
Applicable to all the related 9to5 sites, including `dronedj.com` and should also cover other platforms.

Similar commits here; `https://github.com/abp-filters/abp-filters-anti-cv/commit/9f16210`