### PR TITLE
[Badware] 1hos.cf

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -273,7 +273,7 @@ majorgeeks.com##b:has(a[target^="reimage"])
 ||securemecca.com^$document
 ||hufilter.hu^$document
 ||fredfiber.no^$document
-! https://github.com/uBlockOrigin/uAssets/pull/[placeholder]
+! https://github.com/uBlockOrigin/uAssets/pull/6757
 ||1hos.cf^$document
 ||1hosts.cf^$document
 
@@ -446,5 +446,5 @@ howtoremove.guide###gray_de
 ! https://github.com/NanoMeow/QuickReports/issues/2522
 ||browser-update.*.top^
 
-! https://github.com/uBlockOrigin/uAssets/pull/[placeholder]
+! https://github.com/uBlockOrigin/uAssets/pull/6757
 ||katie.tncrun.net^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -266,13 +266,16 @@ majorgeeks.com##b:has(a[target^="reimage"])
 ! https://github.com/uBlockOrigin/uAssets/issues/5187
 ||check-prizes-now2.life^$document
 
-! Lapsed domain that once hosted adblock lists, several of whom are now used for bad purposes
+! Lapsed domains that once hosted adblock lists, several of whom are now used for bad purposes
 ! https://github.com/uBlockOrigin/uAssets/issues/5307
 ||adblock.gjtech.net^$document
 ||spam404bl.com^$document
 ||securemecca.com^$document
 ||hufilter.hu^$document
 ||fredfiber.no^$document
+! https://github.com/uBlockOrigin/uAssets/pull/[placeholder]
+||1hos.cf^$document
+||1hosts.cf^$document
 
 ! Badware
 ||kuhoot.it^$document
@@ -442,3 +445,6 @@ howtoremove.guide###gray_de
 
 ! https://github.com/NanoMeow/QuickReports/issues/2522
 ||browser-update.*.top^
+
+! https://github.com/uBlockOrigin/uAssets/pull/[placeholder]
+||katie.tncrun.net^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Mostly `1hos.cf`.

### Describe the issue

Okay, so the situation is that *badmojr*, who is the lone maintainer of *1hosts*, which was slowly becoming a reasonably respected compilation list with more than 120 source lists and its own XDA forum thread, appears to have just randomly vanished off the face of the earth, allowing his then-current domain (`1hos.cf`) to lapse (leaving only a meager little GitHub mirror behind), which has now been snapped up by a domain parking seller thingie that I don't think have the best of intentions.

In about 90% of cases, clicking on any previously-legit link to that domain, e.g. `https://1hos.cf/complete/adblock.txt`, leads me to some fishy (though not outright malicious per se) parking place that looks like the below screenshot (when used with a Norwegian locale) when loading insecure sources is turned on.

In about 10% of cases, and which I have no idea how to specifically trigger, it insta-redirected me to `katie.tncrun.net`, and from there to the usual malware sites and such things.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/22780683/71550132-749f8c80-29c9-11ea-9bd0-9d3196c7959d.png)

### Versions

- Browser/version: Chrome 79.0.3945.88 64-bit for Windows
- uBlock Origin version: Nano Adblocker 1.0.0.130 + Nano Defender 15.0.0.170

### Settings

I admit to be *very* unsure as to how to best list every single extension change of any kind, so I'll just post a screenshot of my used lists as per usual: 
![image](https://user-images.githubusercontent.com/22780683/71550154-05766800-29ca-11ea-9b44-5f6948adb5eb.png)

### Notes

The new *Windows Sandbox* tool seems to be pretty convenient to test out sites and links like these, as it makes me considerably less likely to insta-panic and close the browser before I've done enough research on such sites.

`1hosts.cf` seems to have been the first domain that the maintainer used. It too has lapsed, although it's not currently known to have been snapped up by anyone else.

I was unsure whether to use `||katie.tncrun.net^$all` or `||katie.tncrun.net^$document`. I'd go with the one that best prevents further redirections from happening, for which I've in previous cases had much luck with `$document`, but this time I got unsure if it'd block a super-obvious maldirection domain strongly enough.