### PR TITLE
Verge filters no longer needed

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -175,10 +175,6 @@ old.reddit.com##+js(remove-attr.js, data-outbound-url)
 ! https://github.com/uBlockOrigin/uAssets/issues/5795#issuecomment-500244236
 ||browser-update.org^$3p
 
-! https://github.com/easylist/easylist/commit/541012705c64
-||google-analytics.com^$important,script,domain=theverge.com
-||googletagmanager.com^$important,script,domain=theverge.com
-
 ! https://github.com/uBlockOrigin/uAssets/issues/6538
 liberation.fr,officedepot.fr,oui.sncf##+js(acis, document.createElement, '.js')
 sfr.fr##+js(aopr, _oEa)


### PR DESCRIPTION
Have removed these filters here;

https://github.com/easylist/easylist/commit/9d4e52635e425decae34c533cb64b52e16bdb2de
https://github.com/easylist/easylist/commit/a2aec170f08d19e69c0b8fce94660537fde85621

