### PR TITLE
Expanded PornHub entries to its new .onion address

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -330,15 +330,15 @@ redtube.com##.clearfix:has-text(Ads)
 redtube.com###browse_section > div:has(:scope > div > a.ad-link)
 redtube.net###pb_block
 ||fotzenparty.eu^$important
-||192.168.*/images/$important,domain=pornhub.com|xtube.com
-pornhub.com,xtube.com##+js(aopw, AdDelivery)
-pornhub.com##.sectionWrapper > div[class]:has(:scope > div > .ad-link)
+||192.168.*/images/$important,domain=pornhub.com|pornhubthbh7ap3u.onion|xtube.com
+pornhub.com,pornhubthbh7ap3u.onion,xtube.com##+js(aopw, AdDelivery)
+pornhub.com,pornhubthbh7ap3u.onion##.sectionWrapper > div[class]:has(:scope > div > .ad-link)
 ! https://github.com/uBlockOrigin/uAssets/issues/39#issuecomment-269403620
 /fp.eng?id=$popunder
-pornhub.com##+js(aopw, rAb)
+pornhub.com,pornhubthbh7ap3u.onion##+js(aopw, rAb)
 ! https://github.com/uBlockOrigin/uAssets/issues/2913
-pornhub.com##+js(aeld, DOMContentLoaded, [native code])
-pornhub.com##sads
+pornhub.com,pornhubthbh7ap3u.onion##+js(aeld, DOMContentLoaded, [native code])
+pornhub.com,pornhubthbh7ap3u.onion##sads
 ! https://github.com/uBlockOrigin/uAssets/issues/356
 ! https://forums.lanik.us/viewtopic.php?p=120148#p120148
 youjizz.com##+js(aopw, nb)
@@ -945,7 +945,7 @@ rarbg.unblockall.org,rarbgtor.org##+js(aopr, __htapop)
 proxyrarbg.*,rarbg.is,rarbg.to,rarbgget.org,rarbgenter.org,rarbgprx.org,rarbgp2p.org,rarbgto.org,rarbg2019.org,rarbg2020.org,rarbg.unblockall.org,rarbg.unblocked.kim,rarbgaccess.org,rarbgcore.org,rarbgdata.org,rarbggo.org,rarbgmirror.*,rarbgproxied.*,rarbgproxy.*,rarbgtor.org,rarbgunblock.*,rarbgweb.org,unblockedrarbg.org##+js(aopr, LieDetector)
 rarbgmirrored.org,rarbgproxy.org##+js(window.open-defuser)
 proxyrarbg.*,rarbg.is,rarbg.to,rarbgget.org,rarbgenter.org,rarbgprx.org,rarbgp2p.org,rarbgto.org,rarbgtor.org,rarbg2019.org,rarbg2020.org,rarbg.unblockall.org,rarbg.unblocked.kim,rarbgaccess.org,rarbgcore.org,rarbgdata.org,rarbggo.org,rarbgmirror.*,rarbgmirrored.org,rarbgproxied.*,rarbgproxy.*,rarbgunblock.*,rarbgweb.org,unblockedrarbg.org##.lista > tbody > tr:has-text(/v\s{0,}p\s{0,}n/i)
-fullmatchesandshows.com,mediafire.com,newser.com,pornhub.com,rlslog.net,scienceworldreport.com##+js(aopw, UAParser)
+fullmatchesandshows.com,mediafire.com,newser.com,pornhub.com,pornhubthbh7ap3u.onion,rlslog.net,scienceworldreport.com##+js(aopw, UAParser)
 ||ladsup.com^$all
 mediafire.com##.errorExtraContent
 
@@ -1020,8 +1020,8 @@ there.to##+js(aopr, AaDetector)
 fdesouche.com##+js(nobab)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/326
-pornhub.com##div video[id]:first-child > source[src^="data:"]:xpath(../../..)
-pornhub.com##+js(aopw, isAdblockOn)
+pornhub.com,pornhubthbh7ap3u.onion##div video[id]:first-child > source[src^="data:"]:xpath(../../..)
+pornhub.com,pornhubthbh7ap3u.onion##+js(aopw, isAdblockOn)
 
 ! https://news.ycombinator.com/item?id=13958134
 ||tribdss.com/meter$script,domain=latimes.com
@@ -17635,9 +17635,9 @@ dreamdth.com##+js(acis, $, show)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5272
 ! https://github.com/uBlockOrigin/uAssets/issues/5799
-pornhub.com##+js(acis, Math, createShadowRoot)
-pornhub.com##+js(aopr, smpop)
-pornhub.com##+js(set, atob, trueFunc)
+pornhub.com,pornhubthbh7ap3u.onion##+js(acis, Math, createShadowRoot)
+pornhub.com,pornhubthbh7ap3u.onion##+js(aopr, smpop)
+pornhub.com,pornhubthbh7ap3u.onion##+js(set, atob, trueFunc)
 ||smpop.icfcdn.com/smpop-stable.js$script
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5804


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`http://pornhubthbh7ap3u.onion/`

### Describe the issue

It appears that `PornHub` now has a Tor address. So, much like I previously did for `Facebook` and `New York Times`, I've now expanded you guys' existing entries to that new address.

### Screenshot(s)

N/A

### Versions

N/A

### Settings

N/A

### Notes

Tor service rollouts among major websites, is still going very, *very* slowly. So far in 2020, only `PornHub` and `Cliqz` seem to have received new such services.

I also presume that someone should've told EasyList and AdGuard to expand their lists' entries for `Facebook`, `New York Times` and `PornHub` as well, come to think of it.
