### PR TITLE
I found another ReImagePlus link where such links shouldn't be

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -255,6 +255,8 @@ majorgeeks.com##b:has(a[target^="reimage"])
 2-spyware.com,novirus.uk,faravirus.ro,uirusu.jp,virusi.hr,wubingdu.cn,avirus.hu,ioys.gr,odstranitvirus.cz,tanpavirus.web.id,utanvirus.se,virukset.fi,losvirus.es,virusler.info.tr,semvirus.pt,lesvirus.fr,senzavirus.it,dieviren.de,viruset.no,usunwirusa.pl,zondervirus.nl,bedynet.ru,virusai.lt,virusi.bg,viirused.ee,udenvirus.dk##.nfc-bottom-right:has-text(Reimage)
 2-spyware.com,novirus.uk,faravirus.ro,uirusu.jp,virusi.hr,wubingdu.cn,avirus.hu,ioys.gr,odstranitvirus.cz,tanpavirus.web.id,utanvirus.se,virukset.fi,losvirus.es,virusler.info.tr,semvirus.pt,lesvirus.fr,senzavirus.it,dieviren.de,viruset.no,usunwirusa.pl,zondervirus.nl,bedynet.ru,virusai.lt,virusi.bg,viirused.ee,udenvirus.dk##a:has-text(Reimage)
 2-spyware.com,novirus.uk,faravirus.ro,uirusu.jp,virusi.hr,wubingdu.cn,avirus.hu,ioys.gr,odstranitvirus.cz,tanpavirus.web.id,utanvirus.se,virukset.fi,losvirus.es,virusler.info.tr,semvirus.pt,lesvirus.fr,senzavirus.it,dieviren.de,viruset.no,usunwirusa.pl,zondervirus.nl,bedynet.ru,virusai.lt,virusi.bg,viirused.ee,udenvirus.dk##.quick-download-button-text
+! https://windowsloop.com/network-adapters-shortcut/
+windowsloop.com##.wl-prakatana
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5187
 ||check-prizes-now2.life^$document

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -257,6 +257,7 @@ majorgeeks.com##b:has(a[target^="reimage"])
 2-spyware.com,novirus.uk,faravirus.ro,uirusu.jp,virusi.hr,wubingdu.cn,avirus.hu,ioys.gr,odstranitvirus.cz,tanpavirus.web.id,utanvirus.se,virukset.fi,losvirus.es,virusler.info.tr,semvirus.pt,lesvirus.fr,senzavirus.it,dieviren.de,viruset.no,usunwirusa.pl,zondervirus.nl,bedynet.ru,virusai.lt,virusi.bg,viirused.ee,udenvirus.dk##.quick-download-button-text
 ! https://windowsloop.com/network-adapters-shortcut/
 windowsloop.com##.wl-prakatana
+||reimageplus.com^$doc
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5187
 ||check-prizes-now2.life^$document


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://windowsloop.com/network-adapters-shortcut/`

### Describe the issue

The title is pretty self-descriptive in this case. Give me a heads-up if it isn't.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/22780683/74074297-bdf1eb80-4a0d-11ea-8885-78f19d01a30b.png)

### Versions

N/A

### Settings

N/A

### Notes

Strangely, all of the sites I've found so far that fronted `ReImagePlus` shill links (for lack of a less malignant-memetic term that'd fit this) have it as a native 1st-party page element, without any 3rd-party scripts involved that I can find. This could make it much harder to score a decisive victory against their scheme(s).

The "Allow edits from maintainers" button is of course turned on, as I always do for all PRs to all projects of all kinds.