### PR TITLE
Stop Anti-adblock checks on various 9to5

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -1611,6 +1611,7 @@ monova.*#@#script + [class] > [class]:first-child
 ! https://www.reddit.com/r/uBlockOrigin/comments/6w2o8c/i_keep_seeing_ads_on_9to5mac/
 ! https://www.wilderssecurity.com/threads/ublock-a-lean-and-fast-blocker.365273/page-166#post-2878614
 9to5google.com,9to5mac.com,9to5toys.com,dronedj.com,electrek.co,marketrealist.com##^script:has-text(_0x)
+9to5google.com,9to5mac.com,9to5toys.com,dronedj.com,electrek.co##+js(aopr, canRunAds)
 ||wp.com/*/adsbygoogle.js$script,important,domain=9to5mac.com
 !#if env_chromium
 9to5google.com,9to5mac.com,9to5toys.com,dronedj.com,electrek.co,marketrealist.com##+js(set, String.prototype.charCodeAt, trueFunc)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://9to5google.com/`

### Describe the issue

Anti-adblock checks on various 9to5 sites.

### Screenshot(s)

`https://9to5google.com/wp-content/themes/9to5-2015/assets/js/adsbygoogle.js`
`https://9to5toys.com/wp-content/themes/9to5-2015/assets/js/adsbygoogle.js`
`https://electrek.co/wp-content/themes/9to5-2015/assets/js/adsbygoogle.js`

`var canRunAds = true;`

