### PR TITLE
Add Algolia DocSearch as 3rd-party

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -16,6 +16,11 @@
 		_ 4cdn.org *
 		_ 4cdn.org script
 
+Algolia DocSearch as 3rd-party
+	* algolia.net
+		_ algolia.net script
+		_ algolia.net xhr
+
 Apple Mapkit as 3rd-party
 	* apple-mapkit.com
 		_ apple-mapkit.com *


### PR DESCRIPTION
Algolia DocSearch is used to provide outsourced JS based search to websites.

Official website of the service:
https://www.algolia.com/

Used on
https://forum.xda-developers.com/?query=test
https://grafana.com/docs/grafana/latest/


--- 
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://forum.xda-developers.com/?query=test
https://grafana.com/docs/grafana/latest/

### Describe the issue

Search based on Algolia DocSearch does not work

### Screenshot(s)

None

### Versions

not applicable

### Settings

not applicable

### Notes

none
