### PR TITLE
Admiral anti-adblock on winhelponline.com

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -24092,3 +24092,6 @@ vidload.net##+js(aopr, AaDetector)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/50520
 sailuniverse.com##+js(set, $tieE3, true)
+
+! Admiral anti-adblock
+||absorbingcorn.com^$third-party


### PR DESCRIPTION
![kuva](https://user-images.githubusercontent.com/17256841/75354783-34b83100-58b6-11ea-8415-fa6962d7eee1.png)

Scroll down the page down a bit on winhelponline.com and you will see this nag.

` ||absorbingcorn.com^$third-party`