### PR TITLE
Fix anti-adblock on aternos.org

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -4542,9 +4542,9 @@ themeslide.com##+js(nano-stb)
 @@||tech426.com/prebid/latest/prebid.js$script,domain=aternos.org
 @@||tech426.com/snhb/snhbGlobalSettings.js$script,domain=aternos.org
 @@||amazon-adsystem.com/aax2/apstag.js$script,domain=aternos.org
+||cmp.tech426.com/sngvl.json$xhr,redirect=noop.txt,domain=aternos.org
 aternos.org##aside.sidebar:style(position: absolute !important; padding: calc(100vw - 100vw) !important)
 aternos.org##.ad.responsive-leaderboard:style(position: absolute !important)
-aternos.org##+js(aopr, pbjs.cmd.push)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/1027
 @@||imasdk.googleapis.com/js/sdkloader/*$script,domain=video.gjirafa.com


### PR DESCRIPTION
Last PR: https://github.com/uBlockOrigin/uAssets/pull/6996

Note: the site added code to detect scriptlet injection, which will probably make things more difficult in the future.