### PR TITLE
Fix Anti-adblock on https://www.lapresse.ca/

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -21852,7 +21852,9 @@ arabseed.*##+js(acis, Math, zfgloaded)
 ||arabseed.*/sw.js$script,1p
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6640
-lapresse.ca##+js(aopr, _sp_._networkListenerData)
+! https://github.com/brave/brave-browser/issues/8453
+lapresse.ca##+js(set, noBlocker, true)
+lapresse.ca##+js(aopw, _sp_)
 
 ! https://github.com/NanoMeow/QuickReports/issues/2407
 ! https://github.com/NanoMeow/QuickReports/issues/2409


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Fixes 2 adblock checks, see:  https://github.com/brave/brave-browser/issues/8453

`lapresse.ca##+js(aopw, _sp_)`
`lapresse.ca##+js(set, noBlocker, true)`

Should help with prevent sourcepoint Anti-adblock check (improve existing filter). And anti-check script via `@@||static.lpcdn.ca/lpweb/common/scripts/advertisement.js`


### Versions

- Browser/version: `Brave Version 1.4.95 Chromium: 80.0.3987.122 (Official Build) (64-bit)`
- uBlock Origin version: 1.24.4


