### PR TITLE
Block adscripts on https://www.theregister.co.uk/

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -24129,7 +24129,7 @@ tubexxxone.com##+js(aopr, Aloader.serve)
 
 ! theregister.co.uk
 theregister.co.uk##+js(aopr, RegAdBlocking)
-theregister.co.uk##+js(aopr, a.adm)
+theregister.co.uk##+js(acis, document.createElement, a.adm)
 
 ! https://github.com/NanoMeow/QuickReports/issues/3159
 foxplay.com.tr##+js(set, adblockerStatus, false)

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -24127,6 +24127,10 @@ perfectmomsporn.com##+js(noeval)
 tubexxxone.com##+js(noeval)
 tubexxxone.com##+js(aopr, Aloader.serve)
 
+! theregister.co.uk
+theregister.co.uk##+js(aopr, RegAdBlocking)
+theregister.co.uk##+js(aopr, a.adm)
+
 ! https://github.com/NanoMeow/QuickReports/issues/3159
 foxplay.com.tr##+js(set, adblockerStatus, false)
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.theregister.co.uk/`


### Describe the issue

Blocking 2 scripts from loading `RegAdBlocking` and `a.adm`


### Versions

- Browser/version: Brave
- uBlock Origin version:1.24.4

