### PR TITLE
Fix adblock detection on dictionary.com & thesaurus.com

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -24083,6 +24083,9 @@ sailuniverse.com##+js(set, $tieE3, true)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/50524
 sandiegouniontribune.com##+js(nostif, removeChild, 100)
 
+! thesaurus.com / dictionary.com Adblock detection
+dictionary.com,thesaurus.com##+js(aopr, adDetection)
+
 ! https://github.com/NanoMeow/QuickReports/issues/3149
 forum.outerspace.com.br##+js(acis, $, adBlock)
 

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -24083,9 +24083,6 @@ sailuniverse.com##+js(set, $tieE3, true)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/50524
 sandiegouniontribune.com##+js(nostif, removeChild, 100)
 
-! thesaurus.com / dictionary.com Adblock detection
-dictionary.com,thesaurus.com##+js(aopr, adDetection)
-
 ! https://github.com/NanoMeow/QuickReports/issues/3149
 forum.outerspace.com.br##+js(acis, $, adBlock)
 

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -183,3 +183,6 @@ sfr.fr##+js(aopr, _oEa)
 brillen.de##+js(acis, document.createElement, 'script')
 ||marketing.net.*^$1p
 ||sw88.espn.com^
+
+! thesaurus.com / dictionary.com Adblock detection
+dictionary.com,thesaurus.com##+js(aopr, adDetection)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

From `https://www.dictionary.com/` and `https://www.thesaurus.com/`

### Describe the issue

Blocking adDetection property from `https://www.dictionary.com/hp-assets/ads.js`

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.24.4
