### PR TITLE
Block Criteo tracking on tagesspiegel.de

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -186,3 +186,7 @@ brillen.de##+js(acis, document.createElement, 'script')
 
 ! thesaurus.com / dictionary.com Adblock detection
 dictionary.com,thesaurus.com##+js(aopr, adDetection)
+
+! tagesspiegel.de Criteo tracking
+tagesspiegel.de##+js(acis, Criteo)
+


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
**Visiting:** `https://www.tagesspiegel.de/gesellschaft/panorama/coronavirus-weltweit-so-unterschiedlich-gehen-die-laender-mit-dem-virus-um/25595076.html`

### Describe the issue

We're blocking the following:

`<script type="text/javascript">`
`var Criteo = Criteo \|\| {};`
`Criteo.events = Criteo.events \|\| [];`
`Criteo.events.push(function() {`
`Criteo.DisplayAcceptableAdIfAdblocked({`
`"zoneid": 640113,`
`"width": 160,`
`"height": 600,`
`"containerid": "crt-sky-right",`
`"callbacksuccess": function() { adslotFilledByCriteo('sky-right', true); }`
`});`
`});`
`</script>`

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.24.4

