### PR TITLE
Fix breakage on aternos.org

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -4549,7 +4549,7 @@ themeslide.com##+js(nano-stb)
 @@||amazon-adsystem.com/aax2/apstag.js$script,domain=aternos.org
 ||cmp.tech426.com/sngvl.json$xhr,redirect=noop.txt,domain=aternos.org
 aternos.org##aside.sidebar:style(position: absolute !important; padding: calc(100vw - 100vw) !important)
-aternos.org##.ad.responsive-leaderboard:style(position: absolute !important)
+aternos.org##.ad.responsive-leaderboard:style(position: absolute !important; z-index: -2147483647 !important)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/1027
 @@||imasdk.googleapis.com/js/sdkloader/*$script,domain=video.gjirafa.com


### PR DESCRIPTION
On certain pages, for example `https://aternos.org/software/v/snapshot/latest`, the ad placeholder covers buttons and impedes site functionality.