### PR TITLE
Block ad elements on Bing

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -18028,6 +18028,7 @@ bing.com###b_results > li[style]:not([class])
 bing.com###b_results:xpath(//span[(text()='d') or (text()='n')]):nth-ancestor(5)
 bing.com##.b_algo:has(p:matches-css-before(content: "Ad"))
 bing.com##+js(set, Blob, noopFunc)
+bing.com##^.b_ad
 
 ! https://github.com/NanoMeow/QuickReports/issues/1475
 ! https://github.com/NanoAdblocker/NanoFilters/issues/426


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.bing.com/search?q=consoles`
`https://www.bing.com/search?q=travel`

### Describe the issue

Ads blocked by current visual filters are made visible again by a script in the page.

### Versions

- Browser/version: 73.0.1
- uBlock Origin version: 1.25.0

### Settings

No changes.

### Notes

The script in question removes the ".b_ad" class and uses CSS "::before" to insert the "Ad" label rather than a HTML element. Therefore the ads after processing are indistinguishable from a legit result by just looking at the HTML, and thus unblockable by means of CSS filters (ie from EasyList).

By removing the elements straight from the HTML the script finds no ads, and thus no elements are made visible again.