### PR TITLE
vlare.tv tracking

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -187,3 +187,9 @@ dictionary.com,thesaurus.com##+js(aopr, adDetection)
 ! https://usefathom.com/
 ||usefathom.com^$3p
 ||usesfathom.com^$3p
+
+! https://vlare.tv/ tracking
+vlare.tv##+js(set, player.on, noopFunc)
+vlare.tv##+js(aopr, v_id, !v0)
+||vlare.tv/a/scs.php
+||vlare.tv/a/v.php


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

<!-- `[At least one URL for a web page where the clearly described issue occurs is **mandatory**. The backticks surrounding the URLs is important, it prevents the URL from being clickable. Warn with "NSFW" where applicable.]` -->
`vlare.tv`

### Describe the issue

<!-- [Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder.] -->
Disables page-defined JWPlayer events, blocks `/a/scs.php` (sends screen resolution info), blocks `/a/v.php` (pushes video to watch history), etc.
### Versions

- Browser/version: Firefox Android 68.5.0
- uBlock Origin version: 1.24.4
