### PR TITLE
Improved Facebook/Pornhub entry domain coverage even more

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -1770,7 +1770,7 @@ ndtv.com###___ndtvpushdiv
 facebook.com,facebookcorewwwi.onion##._5hn6
 facebook.com,facebookcorewwwi.onion##.generic_dialog_modal.pop_dialog
 ! https://github.com/uBlockOrigin/uAssets/issues/5136
-m.beta.facebook.com,m.facebook.com,m.facebookcorewwwi.onion,touch.facebook.com,touch.beta.facebook.com##div[style^="background: none;"]:has(#mobile_login_bar)
+touch.facebook.com,mtouch.facebook.com,x.facebook.com,iphone.facebook.com,m.beta.facebook.com,touch.beta.facebook.com,mtouch.beta.facebook.com,x.beta.facebook.com,iphone.beta.facebook.com,touch.facebookcorewwwi.onion,mtouch.facebookcorewwwi.onion,x.facebookcorewwwi.onion,iphone.facebookcorewwwi.onion,touch.beta.facebookcorewwwi.onion,m.facebook.com,m.facebookcorewwwi.onion,b-m.facebook.com,b-m.facebookcorewwwi.onion,mobile.facebook.com,mobile.facebookcorewwwi.onion##div[style^="background: none;"]:has(#mobile_login_bar)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5030
 quora.com##.new_signup_dialog.modal_bg

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -319,11 +319,9 @@ g9g.eu##+js(aopr, adBlockDetected)
 allmusic.com##.advertising
 
 ! Spotted on routine testing of opensubtitles.org
-||104.198.198.188^
-||104.198.198.188^$popup
+||104.198.198.188^$all
 ! https://forums.lanik.us/viewtopic.php?f=62&t=32144
-||104.197.199.227^
-||104.197.199.227^$popup
+||104.197.199.227^$all
 ! https://github.com/uBlockOrigin/uAssets/issues/699
 opensubtitles.org##+js(acis, atob)
 opensubtitles.org###loginBoxSubs
@@ -493,7 +491,7 @@ ndtv.com###ins_videodetail:style(display: block !important;)
 facebook.com,facebookcorewwwi.onion###stream_pagelet div[id^="hyperfeed_story_id_"]:has(a.uiStreamSponsoredLink)
 ! "People You May Know": EasyList tries to block these, might as well block them fully
 facebook.com,facebookcorewwwi.onion###stream_pagelet div[id^="hyperfeed_story_id_"]:if(h6:has-text(People You May Know))
-m.facebook.com,m.beta.facebook.com,touch.facebook.com,touch.beta.facebook.com,m.facebookcorewwwi.onion##article:has(footer > div > div > a[href^="/friends/center/?fb_ref="])
+touch.facebook.com,mtouch.facebook.com,x.facebook.com,iphone.facebook.com,m.beta.facebook.com,touch.beta.facebook.com,mtouch.beta.facebook.com,x.beta.facebook.com,iphone.beta.facebook.com,touch.facebookcorewwwi.onion,mtouch.facebookcorewwwi.onion,x.facebookcorewwwi.onion,iphone.facebookcorewwwi.onion,touch.beta.facebookcorewwwi.onion,m.facebook.com,m.facebookcorewwwi.onion,b-m.facebook.com,b-m.facebookcorewwwi.onion,mobile.facebook.com,mobile.facebookcorewwwi.onion##article:has(footer > div > div > a[href^="/friends/center/?fb_ref="])
 ! https://www.reddit.com/r/uBlockOrigin/comments/58o3k6/facebook_ads_solution/
 facebook.com,facebookcorewwwi.onion##.ego_section:has(a.adsCategoryTitleLink)
 ! https://github.com/uBlockOrigin/uAssets/issues/507

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -321,7 +321,7 @@ kinopoisk.ru###image:style(opacity: 1 !important;)
 ! Unduly broad EasyPrivacy filter ending up having the opposite effect of
 ! enhancing privacy as users are forced to turn off their blocker to unbreak
 ! sites. Need ability to blacklist filters ASAP.
-@@.php?ref=$domain=facebook.com|materiel.net
+@@.php?ref=$domain=facebook.com|facebookcorewwwi.onion|materiel.net
 
 ! This unbreaks video playback on sfgate.com and other sites
 ! To counter `ensighten.com` in EasyPrivacy
@@ -538,7 +538,7 @@ orange.fr###o_carrepub:style(height: 1px; margin: 0; min-height: auto; visibilit
 @@||eccmp.com/*/conversen-SDK.js$script,domain=citi.com
 
 ! https://github.com/gorhill/uBlock/issues/3138
-@@||fbcdn.net/safe_image.php?$image,domain=facebook.com
+@@||fbcdn.net/safe_image.php?$image,domain=facebook.com|facebookcorewwwi.onion
 
 ! https://twitter.com/HartleyPrime/status/920858055453167617
 @@||cravetv.ca/js/$script,1p

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -461,7 +461,7 @@ pythonjobshq.com##+js(abort-on-property-read.js, Keen)
 ! https://github.com/uBlockOrigin/uAssets/issues/642
 ! https://forums.lanik.us/viewtopic.php?p=137800#p137800
 ! https://github.com/uBlockOrigin/uAssets/issues/3253
-@@||phncdn.com/www-static/js/amateur/amateur-signup.js$script,domain=www.pornhub.com
+@@||phncdn.com/www-static/js/amateur/amateur-signup.js$script,domain=www.pornhub.com|www.pornhub.org|www.pornhub.net
 
 ! https://github.com/gorhill/uBlock/issues/2893
 @@||assets.adobedtm.com^$script,domain=linkinghub.elsevier.com
@@ -1326,10 +1326,10 @@ warszawawpigulce.pl##.eklama
 |https://$script,domain=yts.am,badfilter
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/9hh9kb/pornhub_videos_only_works_after_i_disable_ublock/
-|https://$3p,script,domain=~feedback.pornhub.com|pornhub.com|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
-|https://$image,badfilter,domain=pornhub.com|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
-|https://$3p,image,badfilter,domain=~feedback.pornhub.com|pornhub.com|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
-|https://$3p,media,badfilter,domain=~feedback.pornhub.com|pornhub.com|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
+|https://$3p,script,domain=~feedback.pornhub.com|~feedback.pornhub.org|~feedback.pornhub.net|pornhub.com|pornhub.org|pornhub.net|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
+|https://$image,badfilter,domain=pornhub.com|pornhub.org|pornhub.net|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
+|https://$3p,image,badfilter,domain=~feedback.pornhub.com|~feedback.pornhub.org|~feedback.pornhub.net|pornhub.com|pornhub.org|pornhub.net|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
+|https://$3p,media,badfilter,domain=~feedback.pornhub.com|~feedback.pornhub.org|~feedback.pornhub.net|pornhub.com|pornhub.org|pornhub.net|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3532
 @@||ftse.com/Products/*/scripts/analytics_$script,1p
@@ -1969,8 +1969,8 @@ readmng.com#@#div > iframe:first-child
 @@||qualtrics.com^$1p
 
 ! https://github.com/NanoMeow/QuickReports/issues/9#issuecomment-473751320
-|https://$xhr,domain=pornhub.com|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
-|https://$3p,xhr,domain=destructoid.com|diffen.com|divxatope1.com|dreamfilm.se|dumpaday.com|dwatchseries.to|episodetube.com|episodetube.net|fastpic.ru|fileone.tv|filme-streamz.com|filmlinks4u.is|firstforwomen.com|firstrowau.eu|firstrowus1.eu|flash-x.tv|flashsx.tv|flashx.co|flashx.me|flashx.run|flashx.tv|flashx1.tv|flashxx.tv|fmovies.to|fmovies.world|free-torrent.org|free-torrent.pw|free-torrents.org|free-torrents.pw|freewarefiles.com|gamenguide.com|genfb.com|gofirstrow.eu|gomovies.sc|gorillavid.in|gsmarena.com|hdvid.life|hdvid.tv|hdvid.xyz|health-weekly.net|homerun.re|i4u.com|ifirstrow.eu|ifirstrowit.eu|imagefap.com|instanonymous.com|investopedia.com|itechpost.com|izismile.com|jewsnews.co.il|keepvid.com|kino-streamz.com|kiplinger.com|kshowonline.com|lifehacklane.com|livecricketz.org|livescience.com|lolcounter.com|megaup.net|mobilenapps.com|mobipicker.com|movies123.xyz|movies4stream.com|movpod.in|myfeed4u.me|myfeed4u.net|mylivecricket.org|natureworldnews.com|navbug.com|ncscooper.com|newpct.com|newsarama.com|newseveryday.com|newtvworld.com|nowfeed2all.eu|okceleb.com|oloadcdn.net|olympicstreams.me|omgwhut.com|onvid.club|onvid.fun|onvid.online|onvid.pw|onvid.xyz|onwatchseries.to|openload.co|openload.pw|opensubtitles.org|otakustream.tv|parentherald.com|pcgames-download.net|playbill.com|pocketnow.com|pornhub.com|postimg.org|powvideo.net|pwinsider.com|qaafa.com|rapidvideo.com|reservedoffers.club|rinf.com|roadracerunner.com|salefiles.com|scienceworldreport.com|sgvideos.net|shorte.st|skidrowcrack.com|snoopfeed.com|stream-tv-series.net|stream-tv2.to|stream2watch.cc|streamazone.com|streamgaroo.com|strikeout.co|strikeout.me|strikeout.mobi|teamliquid.net|technobuffalo.com|the123movies.org|the4thofficial.net|thefreethoughtproject.com|thevideo.me|thinkinghumanity.com|todayshealth.buzz|tomsguide.com|tomshardware.co.uk|tomshardware.com|tomsitpro.com|toptenz.net|torrentz2.eu|tribune.com.pk|trifind.com|tune.pk|tv-series.me|uberhavoc.com|universityherald.com|usherald.com|vcpost.com|vidhd.club|vidhd.icu|vidhd.pw|vidmax.com|vidoza.net|vidtodo.com|vidzi.online|vidzi.si|vidzi.tv|viewmixed.com|viid.me|vipbox.bz|vipbox.is|vipbox.sx|vipbox.tv|vipboxeu.co|vipboxoc.co|vipboxtv.me|vipleague.ch|vipleague.co|vipleague.is|vipleague.me|vipleague.mobi|vipleague.se|vipleague.sx|vipleague.tv|vipleague.ws|vipstand.is|viralands.com|vrheads.com|watchepisodes-tv.com|watchseries.li|webfirstrow.eu|wholecloud.net|whydontyoutrythis.com|wrestlinginc.com|wrestlingnews.co|xda-developers.com|xilfy.com|yourtailorednews.com|yourtango.com,badfilter
+|https://$xhr,domain=pornhub.com|pornhub.org|pornhub.net|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
+|https://$3p,xhr,domain=destructoid.com|diffen.com|divxatope1.com|dreamfilm.se|dumpaday.com|dwatchseries.to|episodetube.com|episodetube.net|fastpic.ru|fileone.tv|filme-streamz.com|filmlinks4u.is|firstforwomen.com|firstrowau.eu|firstrowus1.eu|flash-x.tv|flashsx.tv|flashx.co|flashx.me|flashx.run|flashx.tv|flashx1.tv|flashxx.tv|fmovies.to|fmovies.world|free-torrent.org|free-torrent.pw|free-torrents.org|free-torrents.pw|freewarefiles.com|gamenguide.com|genfb.com|gofirstrow.eu|gomovies.sc|gorillavid.in|gsmarena.com|hdvid.life|hdvid.tv|hdvid.xyz|health-weekly.net|homerun.re|i4u.com|ifirstrow.eu|ifirstrowit.eu|imagefap.com|instanonymous.com|investopedia.com|itechpost.com|izismile.com|jewsnews.co.il|keepvid.com|kino-streamz.com|kiplinger.com|kshowonline.com|lifehacklane.com|livecricketz.org|livescience.com|lolcounter.com|megaup.net|mobilenapps.com|mobipicker.com|movies123.xyz|movies4stream.com|movpod.in|myfeed4u.me|myfeed4u.net|mylivecricket.org|natureworldnews.com|navbug.com|ncscooper.com|newpct.com|newsarama.com|newseveryday.com|newtvworld.com|nowfeed2all.eu|okceleb.com|oloadcdn.net|olympicstreams.me|omgwhut.com|onvid.club|onvid.fun|onvid.online|onvid.pw|onvid.xyz|onwatchseries.to|openload.co|openload.pw|opensubtitles.org|otakustream.tv|parentherald.com|pcgames-download.net|playbill.com|pocketnow.com|pornhub.com|pornhub.org|pornhub.net|postimg.org|powvideo.net|pwinsider.com|qaafa.com|rapidvideo.com|reservedoffers.club|rinf.com|roadracerunner.com|salefiles.com|scienceworldreport.com|sgvideos.net|shorte.st|skidrowcrack.com|snoopfeed.com|stream-tv-series.net|stream-tv2.to|stream2watch.cc|streamazone.com|streamgaroo.com|strikeout.co|strikeout.me|strikeout.mobi|teamliquid.net|technobuffalo.com|the123movies.org|the4thofficial.net|thefreethoughtproject.com|thevideo.me|thinkinghumanity.com|todayshealth.buzz|tomsguide.com|tomshardware.co.uk|tomshardware.com|tomsitpro.com|toptenz.net|torrentz2.eu|tribune.com.pk|trifind.com|tune.pk|tv-series.me|uberhavoc.com|universityherald.com|usherald.com|vcpost.com|vidhd.club|vidhd.icu|vidhd.pw|vidmax.com|vidoza.net|vidtodo.com|vidzi.online|vidzi.si|vidzi.tv|viewmixed.com|viid.me|vipbox.bz|vipbox.is|vipbox.sx|vipbox.tv|vipboxeu.co|vipboxoc.co|vipboxtv.me|vipleague.ch|vipleague.co|vipleague.is|vipleague.me|vipleague.mobi|vipleague.se|vipleague.sx|vipleague.tv|vipleague.ws|vipstand.is|viralands.com|vrheads.com|watchepisodes-tv.com|watchseries.li|webfirstrow.eu|wholecloud.net|whydontyoutrythis.com|wrestlinginc.com|wrestlingnews.co|xda-developers.com|xilfy.com|yourtailorednews.com|yourtango.com,badfilter
 
 ! https://adblockplus.org/forum/viewtopic.php?f=10&t=64912&p=186950#p186950
 @@||guyhollaway.co.uk^$generichide
@@ -3297,7 +3297,7 @@ dziennikbaltycki.pl,dzienniklodzki.pl,dziennikpolski24.pl,dziennikzachodni.pl,ec
 @@||sourcepoint.mgr.consensu.org/$xhr,domain=spiegel.de
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/f2n92g/pornhub_stuck_forever_loading_video_only_when/
-@@||gstatic.com^$script,domain=pornhub.com
+@@||gstatic.com^$script,domain=pornhub.com|pornhub.org|pornhub.net
 
 ! broken search filmesonlinegratis .com
 @@||soazooge.com/*.json$xhr,domain=filmesonlinegratis.com
@@ -3404,7 +3404,7 @@ amnews.com###div-gpt-ad-instory-bottom
 @@||adnxs.com^$xhr,domain=go.cnn.com
 
 ! https://forums.lanik.us/viewtopic.php?p=153236#p153236
-|https://$script,3p,domain=~feedback.pornhub.com|~feedback.pornhubthbh7ap3u.onion|pornhub.com|pornhubthbh7ap3u.onion|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
+|https://$script,3p,domain=~feedback.pornhub.com|~feedback.pornhub.org|~feedback.pornhub.net|~feedback.pornhubthbh7ap3u.onion|pornhub.com|pornhub.org|pornhub.net|pornhubthbh7ap3u.onion|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter
 
 ! https://github.com/NanoMeow/QuickReports/issues/3195
 youjizz.com#@#[src*="blob:"]


### PR DESCRIPTION
I decided to attempt to improve the entries for `Pornhub` and `Facebook` furthermore (At least those that needed it; some entries in filters.txt had already been fixed beforehand so that they covered `pornhub.org` and `pornhub.net`), in connection to how I [was doing the same for EasyList](https://github.com/easylist/easylist/pull/5072).

I also noticed four entries in filters.txt that could be distilled into two `$all` entries, which I did.