### PR TITLE
intego.com overlay filter

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -25058,3 +25058,6 @@ galvinconanstuart.blogspot.com##+js(aopr, absda)
 ! https://forums.lanik.us/viewtopic.php?p=153698#p153698
 freep.com##+js(set, adsEnabled, true)
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=freep.com
+
+! https://github.com/uBlockOrigin/uAssets/issues/7126
+www.intego.com##.roadblock


### PR DESCRIPTION
Fix for overlay on `https://www.intego.com/mac-security-blog` for issue #7126 

Reported: https://github.com/uBlockOrigin/uAssets/issues/7126