### PR TITLE
Fixes #7170 paywall on foreignpolicy.com

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -2285,6 +2285,11 @@ buienradar.nl###adholderContainerHeader
 ||lightboxcdn.com^$domain=foreignpolicy.com
 foreignpolicy.com##.fb_lightbox-lock:style(overflow-x: hidden !important; overflow-y: scroll !important;)
 foreignpolicy.com##.fb_lightbox-overlay-fixed.fb_lightbox-overlay
+foreignpolicy.com##div.tp-modal
+foreignpolicy.com##div.tp-backdrop
+foreignpolicy.com##.tp-active.tp-backdrop
+foreignpolicy.com##html>body.tp-modal-open:style(overflow: auto !important; height: auto; -webkit-overflow-scrolling: auto;)
+
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5767
 firmwarefiledownload.xyz##.js-reveal-modal, .reveal-modal-bg


### PR DESCRIPTION
This removes the paywall on foreignpolicy.com

The two lines below may seem a bit redundant since this is the same element but the JavaScript on the page removes and adds this class back so this catches that, otherwise it flashes a dark modal background for a second.

foreignpolicy.com##div.tp-backdrop
foreignpolicy.com##.tp-active.tp-backdrop

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://foreignpolicy.com/2020/03/25/blame-china-and-xi-jinping-for-coronavirus-pandemic/`

### Describe the issue

Modal popup with a paywall

This fixes #7170 

### Versions

- Browser/version: 74.0-2
- uBlock Origin version: 1.25.2

### Settings

```
foreignpolicy.com##div.tp-modal
foreignpolicy.com##div.tp-backdrop
foreignpolicy.com##.tp-active.tp-backdrop
foreignpolicy.com##html>body.tp-modal-open:style(overflow: auto !important; height: auto; -webkit-overflow-scrolling: auto;)
```

### Notes

After hitting a paywall I created the following rules to start with:  
```
foreignpolicy.com##div.tp-modal
foreignpolicy.com##.tp-active.tp-backdrop
```

Then started with adding breakpoints to <body> since I noticed it is replacing classes for the paywall to appear. the class `tp-modal-open` on the <body> tag was blocking scrolling on the page so I created a filter which has more specific selector which overwrites those blocking values to `auto`.

`tp-modal-resizing` is a class that gets added to the <body> tag but it doesn't affect the page visual so I didn't create a rule for it.

At this point the paywall was removed but there was still a quick flash of black on the page when it popped up and before it was removed after a bit of investigating and adding breakpoints to the page to catch DOM attribute modifications I noticed `div.tp-backdrop.tp-active` was modifying it's class attribute and removing the `tp-active` class, this breaks the rules I added to block the paywall. It's a simple fix, create two rules, one with and one without the `tp-active` class.

