### PR TITLE
freeopenvpn.org fix

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -4952,7 +4952,8 @@ ethereum.cpucap.com,oominer.com##+js(set, ADSController, true)
 
 ! https://github.com/jspenguin2017/uBlockProtector/issues/868
 ! https://github.com/uBlockOrigin/uAssets/issues/2695
-freeopenvpn.org##+js(aeld, load, advert)
+freeopenvpn.org###advert_top:style(height: 10px !important;)
+freeopenvpn.org###advert:style(height: 2px !important;)
 @@||freeopenvpn.org^$ghide
 @@||freeopenvpn.org/units/*$image,1p
 freeopenvpn.org##.adsbygoogle


### PR DESCRIPTION
It allows to load password by modifying style of advert_top & advert.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://www.freeopenvpn.org/en/logpass/usa.php

### Describe the issue

User can not see the password

### Screenshot(s)

![Screenshot](https://i.ibb.co/CH4sMYw/Capture2w.png)

[Image](https://ibb.co/KrBzLf5) will be autodeleted after 2 weeks

### Versions

- Browser/version: 80.0.3987.163
- uBlock Origin version: 1.24.4

### Notes

The old bypass - eventlistener defuser - ```freeopenvpn.org##+js(aeld, load, advert)``` is not working as they have updated the code.
```
var ins_top = document.getElementById('advert_top');
var ins = document.getElementById('advert');
if (ins_top.clientHeight <= 5 || ins.clientHeight != 2) {
...
}
```

Now in order bypass - rules are updated as following:

```
freeopenvpn.org###advert_top:style(height: 10px !important;)
freeopenvpn.org###advert:style(height: 2px !important;)
``` 