### PR TITLE
Fix suzylu.co.uk anti-adblocker filter

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -24739,7 +24739,7 @@ bigbtc.win##+js(nosiif, visibility, 1000)
 bigbtc.win##center
 
 ! https://github.com/NanoMeow/QuickReports/issues/3314
-suzylu.co.uk##+js(aeld, /ready|canplay/, /adblock|AdBreak/)
+suzylu.co.uk##+js(aeld, , Ad)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/51615
 @@||alfaloji.org^$ghide


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`suzylu.co.uk`

### Describe the issue

The anti-adblocker filter for suzylu.co.uk doesn't working anymore, because the regex that was used by this filter didn't include `AdBlock` (only the lowercase version of it)

### Versions

- Browser/version: Firefox 75.0
- uBlock Origin version: 1.26.0

### Settings

Default settings
