### PR TITLE
Fix anti-adblock on aternos.org

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -4530,7 +4530,6 @@ themeslide.com##+js(nano-stb)
 ||tech426.com^$3p
 ||ultra-rv.com^$3p
 ||atom-ds.com^$3p
-aternos.org##+js(set, pRxKtsfeNaSRHGiFYgtNRWrTntdJFgkArcyysNzSxrgViIW, false)
 aternos.org##+js(set, __uspapi, noopFunc)
 aternos.org##+js(aeld, /error|load/, /^(.*_url)((?!-= 1).)*$/)
 aternos.org##+js(nostif, /[a-z]{0}/, 200)
@@ -4544,6 +4543,13 @@ aternos.org##.header,.body:style(display: flex !important)
 aternos.org##aside.sidebar:style(position: absolute !important; padding: calc(100vw - 100vw) !important)
 aternos.org##.ad.responsive-leaderboard:style(position: absolute !important; width: 0em !important; min-height: calc(100vw - 99.999vw + 0.01px) !important)
 aternos.org##.server-status-ad-container
+!#if env_chromium
+aternos.org##+js(nano-sib, btn-working, 1000, 0.02)
+aternos.org##.ad
+!#endif
+!#if env_firefox
+aternos.org##^script:has-text(\x20)
+!#endif
 
 ! https://github.com/uBlockOrigin/uAssets/issues/1027
 @@||imasdk.googleapis.com/js/sdkloader/*$script,domain=video.gjirafa.com


### PR DESCRIPTION
Well, only really a fix in Firefox. In chrome, you must click the button. I don't think there is any way to fix this in Chrome with uBO's current scriptlets.

The `pRxKtsfeNaSRHGiFYgtNRWrTntdJFgkArcyysNzSxrgViIW` is random for each user account, and the overlay cannot be hidden because the main content uses `!important` with inline styles. 

Last PR: https://github.com/uBlockOrigin/uAssets/pull/7208