### PR TITLE
Remove obnoxious ad placeholders in vidlii.com

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -23838,6 +23838,7 @@ trendsderzukunft.de##+js(aopr, onload)
 @@||vidlii.com^$ghide
 vidlii.com##+js(nostif, cloudflare-app)
 vidlii.com##.adsbygoogle
+vidlii.com##.abb_parent
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/50316
 docer.pl##+js(set, ads_unblocked, true)

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -23837,8 +23837,8 @@ trendsderzukunft.de##+js(aopr, onload)
 ! https://github.com/NanoMeow/QuickReports/issues/3117
 @@||vidlii.com^$ghide
 vidlii.com##+js(nostif, cloudflare-app)
+vidlii.com##+js(aopw, ABB_config)
 vidlii.com##.adsbygoogle
-vidlii.com##.abb_parent
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/50316
 docer.pl##+js(set, ads_unblocked, true)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
`vidlii.com`

### Describe the issue

There are red ad placeholders in vidlii.com which are made using [InventivetalentDev/AdBlockBanner](https://github.com/InventivetalentDev/AdBlockBanner)

### Screenshot(s)

![sc](https://user-images.githubusercontent.com/59537482/79187127-627c1980-7e13-11ea-9465-daf494c7903d.png)
