### PR TITLE
Add a recipe for Brightcove video streaming

### DIFF
--- a/recipes/recipes_en.txt
+++ b/recipes/recipes_en.txt
@@ -35,6 +35,20 @@ Ars Technica
 		_ d2c8v52ll5s99u.cloudfront.net script
 		_ dp8hsntg6do36.cloudfront.net *
 
+Brightcove Video Cloud
+	* brightcove.net
+		! https://support.brightcove.com/domains-and-ports-must-be-accessible-video-cloud
+		_ akafms.net *
+		_ akamaihd.net *
+		_ boltdns.net *
+		_ brightcove.com *
+		_ brightcove.net *
+		_ brightcovecdn.com *
+		_ llnw.net *
+		_ llnwd.net *
+		_ players.brightcove.net *
+		_ players.brightcove.net script
+
 Cloudflare Stream as 3rd-party
 	* cloudflarestream.com
 		_ embed.cloudflarestream.com script


### PR DESCRIPTION
### URL(s) where the issue occurs

- https://smh.com.au
- https://stuff.co.nz
- https://tvnz.co.nz
- https://xilinx.com
- https://wsvn.com

### Describe the issue

Adds the domains listed at https://support.brightcove.com/domains-and-ports-must-be-accessible-video-cloud as a recipe to support Brightcove video streaming on sites that use it, such as those listed above
