### PR TITLE
Fixes adblock detect on thelayoff.com

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -25063,7 +25063,8 @@ dramacute.org##+js(aopr, glxopen)
 ||playerseo.club^$3p
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/52225
-thelayoff.com##+js(nostif, alert)
+! https://old.reddit.com/r/uBlockOrigin/comments/g3s525/thelayoffcom_detects_ublock/
+thelayoff.com##+js(acis, adblock)
 thelayoff.com##.epp-bf
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7155


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://old.reddit.com/r/uBlockOrigin/comments/g3s525/thelayoffcom_detects_ublock/`

### Describe the issue

Fixes anti-adblock overlay and message on `https://www.thelayoff.com/`
