### PR TITLE
Address modal on mobile for getnzlr.newzenler.com

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -3855,3 +3855,9 @@ selfstudyhistory.com##+js(aopw, document.onselectstart)
 selfstudyhistory.com##+js(acis, event, event.keyCode)
 selfstudyhistory.com##+js(acis, jQuery, contextmenu)
 selfstudyhistory.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
+
+! https://getnzlr.newzenler.com/ modal
+!#if env_mobile
+getnzlr.newzenler.com###zenPopupModal, .modal-backdrop
+getnzlr.newzenler.com##.modal-open:style(overflow: auto !important)
+!#endif


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://getnzlr.newzenler.com/`

### Describe the issue

Modal with scroll locked, only reproduced on real Android Firefox

### Screenshot(s)

![newzenler](https://user-images.githubusercontent.com/58900598/79985115-19982500-84e5-11ea-814c-2852e6b53cec.png)

### Versions

- Browser/version: Firefox Android 68.7.0
- uBlock Origin version: 1.26.0

### Settings

- Default + AG Base + AG Social + uBlock Annoyances + several custom filter lists + My filters; & medium mode

### Notes

Not reproduced on responsive mode or Mobile View Switcher 