### PR TITLE
Fix adservers on ovagames.com

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -14327,6 +14327,7 @@ books4arab.com##+js(acis, parseInt, decodeURIComponent)
 ! https://github.com/NanoAdblocker/NanoFilters/issues/453
 ovagames.com##+js(aopr, AaDetector)
 ovagames.com##+js(aopw, _pop)
+ovagames.com##+js(acis, Object.defineProperty, XMLHttpRequest)
 ovagames.com###adter:nth-ancestor(3)
 @@||ovagames.com^$ghide
 ||gadsecz.com^$3p


### PR DESCRIPTION
Recently added some adservers; from this site `ovagames.com`

From this https://github.com/easylist/easylist/commit/6e893726d6bed9eb868818ae91236727bb0d6f70

This should limit these ad servers:
`||341073be6e9db7d2.com^`
`||e2706c6e2b426f74.com^`
..

