### PR TITLE
Fix anti-adblock at burbuja.info

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -585,3 +585,6 @@ anicchan.net##.pp, .footerparceiros
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/36335
 imagezilla.net##+js(window.open-defuser, pornoh.info, 0)
+
+! https://github.com/uBlockOrigin/uAssets/pull/7289
+burbuja.info##.samItem:style(height: 50px !important;)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.burbuja.info/inmobiliaria/threads/la-agonia-de-los-duenos-de-pisos-turisticos-jorge-deja-de-ingresar-7-000-euros-al-mes-por-dos-apartamentos.1340938/`

### Describe the issue

There is an anti-adblock script which checks the height of the elements with the `samUnit` class. If the size of any element is zero, it displays a notice while making the content grayer and harder to see.

### Screenshot(s)

https://imgur.com/a/lrov3s8

### Versions

- Browser/version: Firefox 75.0
- uBlock Origin version: 1.26.2

### Settings

- Standard installation with no custom rules
