### PR TITLE
Fix sh.st: anti-adblock message

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -3955,3 +3955,6 @@ suzylu.co.uk##+js(aeld, contextmenu)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/54745
 ggwptech.com##+js(aopr, anOptions)
+
+! http://sh.st/iA5JK
+sh.st##+js(set, isAdsBlockerDetected, false)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`http://sh.st/iA5JK`

### Describe the issue

Unobtrusive anti-adblock

### Screenshot(s)

![sh](https://user-images.githubusercontent.com/58900598/80865001-5cb27f00-8cc1-11ea-8952-00e7034b9924.png)

### Versions

- Browser/version: Brave 1.8.86
- uBlock Origin version: 1.26.0

### Settings

- Default + Fanboy's Annoyances + uBlock Annoyances

### Notes
