### PR TITLE
Fix affiliate.fc2.com: anti-adblock message

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -3955,3 +3955,7 @@ suzylu.co.uk##+js(aeld, contextmenu)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/54745
 ggwptech.com##+js(aopr, anOptions)
+
+! https://affiliate.fc2.com/ anti-adblock
+affiliate.fc2.com##+js(nostif, checkFeed, 1000)
+


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://affiliate.fc2.com/`

### Describe the issue

Unobtrusive anti-adblock

### Screenshot(s)

![fc2](https://user-images.githubusercontent.com/58900598/80865098-faa64980-8cc1-11ea-9c38-a719a82eaba0.png)

### Versions

- Browser/version: Brave 1.8.86
- uBlock Origin version: 1.26.0

### Settings

- Default + Fanboy's Annoyances + uBlock Annoyances

### Notes

