### PR TITLE
Update WaPo anti-adblock

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -17672,7 +17672,8 @@ gamefront.com##+js(nano-stb, , 10000)
 ! washingtonpost.com##+js(acis, Promise.all, _0x)
 !#endif
 washingtonpost.com##^script:has-text(adblocker)
-@@||securepubads.g.doubleclick.net/gampad/adx$xhr,domain=washingtonpost.com
+washingtonpost.com##+js(nostif, 'overlay', 8000)
+washingtonpost.com##+js(nosiif, 'overlay', 200)
 washingtonpost.com##div:has-text(We noticed you’re blocking ads.)
 washingtonpost.com##.db-ns[style="height: 1250px;"]
 washingtonpost.com##html[style="overflow: hidden;"]:style(overflow: auto !important;)


### PR DESCRIPTION
If you're using PiHole/AdGuard Home/any other DNS-based adblocking solution, the exception fix doesn't work as `securepubads.g.doubleclick.net` doesn't resolve. I replaced it with two scriptlets that serve the same purpose.