### PR TITLE
Fix webcreator-journal.com anti adb

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -1028,3 +1028,6 @@ eoreuni.com##a[href^="https://iherb.co/"]
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/55132
 softfl.ru##+js(nostif, ai_adb)
+
+! webcreator-journal.com anti adb
+webcreator-journal.com##+js(acis, document.addEventListener, /google_ad_client/)

--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -1030,4 +1030,4 @@ eoreuni.com##a[href^="https://iherb.co/"]
 softfl.ru##+js(nostif, ai_adb)
 
 ! webcreator-journal.com anti adb
-webcreator-journal.com##+js(acis, document.addEventListener, /google_ad_client/)
+webcreator-journal.com##+js(acis, document.addEventListener, google_ad_client)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`http://webcreator-journal.com/`

### Describe the issue

Anti adb

### Screenshot(s)

![webcreator-journal](https://user-images.githubusercontent.com/58900598/81454001-0617da00-91c6-11ea-967e-ef089ac12c2f.png)

### Versions

- Browser/version: Brave 1.8.90
- uBlock Origin version: 1.26.0

### Settings

- Default

### Notes

