### PR TITLE
Update #7233

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -164,8 +164,7 @@ brick-hill.trade##+js(acis, document.getElementById, Advert)
 helpnetsecurity.com##+js(aopr, hnsMagicBoxes)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7233
-t-mall.cmnw.jp##+js(set, adblock, false)
-t-mall.cmnw.jp##+js(set, sec, 0)
+cmnw.jp##+js(set, sec, 0)
 
 ! https://github.com/NanoMeow/QuickReports/issues/3574
 aldiblogger.com##+js(window.open-defuser)


### PR DESCRIPTION
https://github.com/uBlockOrigin/uAssets/issues/7233

Removed the anti-adblock rule as it will not be fired any more due to a change in EL (`/adframe.` -> `/adframe.$~script`). Generalized another rule as per https://github.com/AdguardTeam/AdguardFilters/issues/53900 but haven't added other domains since AG Japanese is default-enabled. 