### PR TITLE
Fix sekai-kabuka.com right click

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4083,3 +4083,6 @@ theguardian.com##.site-message--banner
 ! https://www.reddit.com/r/uBlockOrigin/comments/gig2vt/
 livemint.com##.subscription .paywall:style(height: unset !important; overflow: unset !important;)
 livemint.com##.subscription .paywall .subscriptionBox
+
+! https://sekai-kabuka.com/ right click
+sekai-kabuka.com##+js(ra, onContextmenu)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://sekai-kabuka.com/`

### Describe the issue

Annoyance: right-click disabled

### Versions

- Browser/version: Brave 1.8.95
- uBlock Origin version: 1.26.0

### Settings

- Default + uBlock Annoyances

### Notes

There's a left-over of an ad which requires style syntax (e.g. `sekai-kabuka.com###况くく0o杤lﾞ:style(height: 0 !important)`) too as simple cosmetic rule breaks the site layout, but didn't add as it may be a job for AG Japanese filter.

![sekai-kabuka](https://user-images.githubusercontent.com/58900598/81815383-dfaac380-9564-11ea-81fe-032d39c38e9e.png)
