### PR TITLE
Fix wpb.shueisha.co.jp right click

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4114,3 +4114,6 @@ ggeguide.com##+js(aopr, disableSelection)
 tanya-tanya.com##+js(acis, document.oncontextmenu)
 tanya-tanya.com##+js(acis, disableSelection, reEnable)
 tanya-tanya.com##.unselectable:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
+
+! wpb.shueisha.co.jp right click
+wpb.shueisha.co.jp##+js(aeld, contextmenu, preventDefault)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://wpb.shueisha.co.jp/`

### Describe the issue

Right click disabled

### Versions

- Browser/version: Firefox 76.0.1
- uBlock Origin version: 1.26.2

### Settings

- Default + uBlock Annoyances

### Notes

