### PR TITLE
Fix Adguard issue #55614 ads

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -1425,3 +1425,7 @@ delta.theta.casa##+js(ra, href, [href*="afu.php"])
 ! https://forums.lanik.us/viewtopic.php?p=154738#p154738
 @@||comandotorrents20.com^$ghide
 comandotorrents20.com##+js(aopr, LieDetector)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/55614
+punisoku.blogo.jp##+js(acis, url, Math.random)
+


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/55614
Only an uBO syntax not added to AG Japanese; the rest shall be addressed by Japanese filters.