### PR TITLE
Fixes broken links on tvinfo.de

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -128,7 +128,7 @@ youtube.com##+js(json-prune, adPlacements)
 ! AdDefend
 !#if env_chromium
 haus-garten-test.de,sozialversicherung-kompetent.de##+js(set, Object.keys, trueFunc)
-bafoeg-aktuell.de,bikerszene.de,deine-tierwelt.de,dhd24.com,donnerwetter.de,e-hausaufgaben.de,fremdwort.de,gartendialog.de,gartenlexikon.de,gewinnspiele.tv,gut-erklaert.de,haus-garten-test.de,iban-rechner.de,kindergeld.org,ksta.de,messen.de,moviejones.de,mz-web.de,naumburger-tageblatt.de,newsbreak24.de,nickles.de,oeffentlicher-dienst.info,rheinische-anzeigenblaetter.de,rundschau-online.de,spielfilm.de,torgranate.de,truckscout24.*,tvinfo.de,unsere-helden.com,webfail.com,weser-kurier.de,wieistmeineip.*##+js(set, String.prototype.slice, noopFunc)
+bafoeg-aktuell.de,bikerszene.de,deine-tierwelt.de,dhd24.com,donnerwetter.de,e-hausaufgaben.de,fremdwort.de,gartendialog.de,gartenlexikon.de,gewinnspiele.tv,gut-erklaert.de,haus-garten-test.de,iban-rechner.de,kindergeld.org,ksta.de,messen.de,moviejones.de,mz-web.de,naumburger-tageblatt.de,newsbreak24.de,nickles.de,oeffentlicher-dienst.info,rheinische-anzeigenblaetter.de,rundschau-online.de,spielfilm.de,torgranate.de,truckscout24.*,unsere-helden.com,webfail.com,weser-kurier.de,wieistmeineip.*##+js(set, String.prototype.slice, noopFunc)
 computerbild.de##+js(aopr, Date.prototype.toUTCString)
 computerbild.de##+js(nostif, ())return)
 lablue.*##+js(nostif, push, 500)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Links on `https://www.tvinfo.de/` are being blocked due to `##+js(set, String.prototype.slice, noopFunc)` 

### Describe the issue

Links aren't clickable under the **"TV-Programm jetzt"**

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave <3
- uBlock Origin version: 3.8.4

### Settings

Enable uBlock fitlers.txt

### Notes

[User reported issue](https://github.com/brave/brave-browser/issues/9897) with this, haven't investigating if its affecting other .de sites. 
