### PR TITLE
fix(7062): Unbreak viki player

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -3248,7 +3248,7 @@ kitguru.net##+js(aopr, anOptions)
 pornktube.*##+js(aeld, load, exoJsPop)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7062
-viki.com##+js(set, VikiPlayer.prototype.pingAbFactor, function () { return true; })
+viki.com##+js(set, VikiPlayer.prototype.pingAbFactor, noopFunc)
 ! @@||pubads.g.doubleclick.net/gampad/ads*viki.com$xhr,domain=imasdk.googleapis.com
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xhr,redirect=noopjs,domain=viki.com
 *expire=$media,redirect=noopmp3-0.1s,domain=viki.com

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -3248,7 +3248,7 @@ kitguru.net##+js(aopr, anOptions)
 pornktube.*##+js(aeld, load, exoJsPop)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7062
-viki.com##+js(set, VikiPlayer.prototype.pingAbFactor, null)
+viki.com##+js(set, VikiPlayer.prototype.pingAbFactor, function () { return true; })
 ! @@||pubads.g.doubleclick.net/gampad/ads*viki.com$xhr,domain=imasdk.googleapis.com
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xhr,redirect=noopjs,domain=viki.com
 *expire=$media,redirect=noopmp3-0.1s,domain=viki.com


### PR DESCRIPTION
### URL(s) where the issue occurs

https://www.viki.com/videos/1145603v (logged in)

### Describe the issue

Exception: pingAbFactor() is not a function

In JavaScript null is not a function, aside from that, whatever we
return must be truthy. So let's just return a function that returns
true.

Because of the thrown exception, the player plays about 1 second of
content in a continious loop, even if one has a paid account that
disabled ads.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Firefox 76.0.1 64 bit, MacOS
- uBlock Origin version: 1.27.4

### Settings

- Changed how the player interacts with adblock detector

### Notes

