### PR TITLE
Fix foreignaffairs.com modal

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4189,3 +4189,8 @@ start.me##.widget-page__banner
 ! right click, select, copy https://github.com/NanoMeow/QuickReports/issues/3942
 lalawin.com##+js(acis, document.oncontextmenu)
 lalawin.com##+js(aopr, tjQuery)
+
+! foreignaffairs.com modal
+||foreignaffairs.com^*/newsletter-overlay$image
+foreignaffairs.com##.newsletter-backdrop
+foreignaffairs.com##body.no-scroll:style(overflow:auto !important)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.foreignaffairs.com/`

### Describe the issue

Modal with scroll locked

### Screenshot(s)

![foreignaffairs](https://user-images.githubusercontent.com/58900598/82878548-97cd6880-9f76-11ea-9c02-ed41b36105d2.png)


### Versions

- Browser/version: Brave 1.9.72
- uBlock Origin version: 1.26.0

### Settings

- Default + Fanboy Annoyances + uBlock Annoyances

### Notes

Blocked the image as it's fairly large and loaded twice if not blocked.
