### PR TITLE
Fix Anti-adblock on https://docker.events.cube365.net/docker/dockercon/content/Videos/icm6kmb3P3ZT8vwt5

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -1629,3 +1629,6 @@ supergoku.com##+js(ra, href, #clickfakeplayer)
 2conv.com,flvto.biz,flv2mp3.by##.horizontal-ads
 2conv.com,flvto.biz,flv2mp3.by##.push-offer
 2conv.com,flvto.biz,flv2mp3.by##.square-ads
+
+! docker.events.cube365.net
+cube365.net##+js(set, mixpanel.get_distinct_id, true)


### PR DESCRIPTION

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://docker.events.cube365.net/docker/dockercon/content/Videos/icm6kmb3P3ZT8vwt5`

### Describe the issue

Anti-adblock message

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.26

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Alternative filter added to [Brave](https://github.com/brave/adblock-lists/pull/390
). this was suggested by @llacb47  