### PR TITLE
Block the-japan-news.com fingerprint2

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -208,3 +208,6 @@ dictionary.com,thesaurus.com##+js(aopr, adDetection)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/gc42jw/wstreamvideo_asking_me_to_disable_ubo/
 ||tracker.cdnbye.com^
+
+! https://github.com/uBlockOrigin/uAssets/pull/4961
+||the-japan-news.com/modules/js/lib/fgp/fingerprint2.js$script,redirect=fingerprint2.js,important


### PR DESCRIPTION
https://github.com/uBlockOrigin/uAssets/pull/4961#issuecomment-615288342

Since v 1.27 is now widely distributed it's time to block this staff, isn't it?