### PR TITLE
fix seoul.cs.land.to drag

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4261,3 +4261,6 @@ malekal.com##+js(nostif, adb)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7506
 jfdb.jp##+js(aeld, contextmenu)
+
+! seoul.cs.land.to drag
+seoul.cs.land.to##+js(ra, onselectstart)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`http://seoul.cs.land.to/`

### Describe the issue

Annoyance: drag disabled

### Versions

- Browser/version: Brave 1.9.76
- uBlock Origin version: 1.27.10

### Settings

- Default + uBlock Annoyances

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
