### PR TITLE
Update bing ads filter

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -17638,7 +17638,7 @@ bing.com###b_results > li[style]:not([class])
 bing.com##.b_algo:has(p:matches-css-before(content: "Ad"))
 bing.com##+js(set, Blob, noopFunc)
 bing.com##+js(set, AdBlockerTracking.AdBlockMonitor, noopFunc)
-bing.com##+js(aopr, AdMon)
+bing.com##+js(set, AdBTrack.AdbMon.isBlocked, noopFunc)
 bing.com##.productAd
 bing.com##.b_ad:style(position: absolute !important; left: -3000px !important;)
 bing.com#@#.b_ad


### PR DESCRIPTION
The current `AdMon` filter (which I added in #7345) breaks some bing search widgets.

`https://www.bing.com/search?q=cheap+flights+from+new+york+to+miami&go=Search&qs=ds&form=QBRE`
![image](https://user-images.githubusercontent.com/16567977/84184877-21436700-aa5c-11ea-9e3b-88d15c81d5bd.png)
The date picker doesn't work and nothing happens when you click on a flight option.

`https://www.bing.com/search?q=hotels+near+disney+world&go=Search&qs=ds&form=QBRE`
![image](https://user-images.githubusercontent.com/16567977/84185094-7bdcc300-aa5c-11ea-9328-e3c30c8ebce6.png)
The date picker and price slider don't work, and images don't load.


