### PR TITLE
Fix ads on https://mycima.me/

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -2162,6 +2162,9 @@ grhls.stream##+js(nostif, check, 100)
 ! https://github.com/NanoMeow/QuickReports/issues/4117
 @@||shinsori.com^$ghide
 
+! mycima.me
+mycima.me##+js(acis, Math, zfgloaded)
+
 ! https://github.com/NanoMeow/QuickReports/issues/4118
 @@||skaties.lv^$ghide
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://mycima.me/`

### Describe the issue

Adscripts shown on `https://mycima.me/series/%d9%85%d8%b3%d9%84%d8%b3%d9%84-%d8%ad%d8%af%d9%88%d8%aa%d9%87-%d9%85%d8%b1%d8%a9/` 
### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.27.10

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Adserver added, https://github.com/easylist/easylist/commit/226f5e4c05d522dcae57c101c1f777abddbf0841

Just a cleanup of the rest.
