### PR TITLE
Fix Amazon Music ads

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -2263,3 +2263,6 @@ mega1link.com##+js(ra, href, #clickfakeplayer)
 
 ! https://github.com/NanoMeow/QuickReports/issues/4140
 softwaresde.com##+js(acis, $, advert)
+
+! Amazon Music ads
+||cloudfront.net^*.mp3$media,redirect=noopmp3-0.1s,domain=music.amazon.com|music.amazon.ca|music.amazon.co.uk|music.amazon.fr|music.amazon.de|music.amazon.it|music.amazon.es|music.amazon.co.jp|music.amazon.com.au|music.amazon.com.mx


### PR DESCRIPTION
List of domains from `https://music.amazon.com/help?nodeId=202204440` - countries offered `Amazon Music (free with ads)`

Requires account to test.