### PR TITLE
Minor change

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -2265,4 +2265,4 @@ mega1link.com##+js(ra, href, #clickfakeplayer)
 softwaresde.com##+js(acis, $, advert)
 
 ! Amazon Music ads
-||cloudfront.net^*.mp3$media,redirect=noopmp3-0.1s,domain=music.amazon.com|music.amazon.ca|music.amazon.co.uk|music.amazon.fr|music.amazon.de|music.amazon.it|music.amazon.es|music.amazon.co.jp|music.amazon.com.au|music.amazon.com.mx
+||cloudfront.net^*.mp3|$media,redirect=noopmp3-0.1s,domain=music.amazon.com|music.amazon.ca|music.amazon.co.uk|music.amazon.fr|music.amazon.de|music.amazon.it|music.amazon.es|music.amazon.co.jp|music.amazon.com.au|music.amazon.com.mx


### PR DESCRIPTION
Update #7570 

We want to block the url format listed in https://github.com/uBlockOrigin/uAssets/pull/7570#issuecomment-645723061

not this type of url: `https://d4s1nbwjhj7ub.cloudfront.net/e38b6d48-a31d-4bb0-84a9-34560349a1bb?response-content-disposition=filename%3D%2212%20-%20Mysterious%20Intro%20Soundscapes.mp3%22&coid=f4d9e5f5-8758-4770-8ee5-26672bc3e981&Expires=1592446500&Signature=CWWwnf2fYxTGDMRqhyp0QxBivFcRhEg4b75I3i2VzTCyLGOWjFadbYDjfsGM1pNNEqL5N1BsRI~7Xmc3hcDmvfHOusKV6OZwxtqxjTTfy9tXINlvEDcEFMYEOJJoZje7l-ExvanCotwx1ahPD87XVWSejXf62CcVwi-xPKzK0PM_&Key-Pair-Id=APKAJVZTZLZ7I5XDXGUQ`