### PR TITLE
Targets anti-adblock-layer on t-online

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4362,3 +4362,5 @@ jwearn.com###cookie-pop
 relet365.com##+js(aopr, disable_copy)
 relet365.com##+js(aopw, document.ondragstart)
 relet365.com##.unselectable,html:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important; cursor: auto !important)
+
+t-online.de###TAdBlockOverlayWrapper


### PR DESCRIPTION

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.t-online.de/nachrichten/deutschland/id_88096234/corona-ausbruch-bei-toennies-mitarbeiter-wohl-vor-quarantaene-abgereist.html
`

### Describe the issue

The element with the id targets ad block users to disable their adblocker.

### Screenshot(s)

<img width="794" alt="Screenshot 2020-06-21 at 15 55 10" src="https://user-images.githubusercontent.com/3136416/85226430-b426be80-b3d7-11ea-93ed-e29811138eb5.png">

### Versions

- Browser/version: Chrome 83
- uBlock Origin version: 1.27.10

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
