### PR TITLE
Fixes #7587

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -2372,3 +2372,6 @@ fabioambrosi.it##+js(nostif, ai_adb)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7585
 ||iseekgirls.com/wp-content/*$media,1p,redirect=noopmp3-0.1s
+
+! https://github.com/uBlockOrigin/uAssets/issues/7587
+cshort.org##+js(set, adblock, false)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://cshort.org/LPMNEEqK`

### Describe the issue

CShort detects uBlock Origin with Nano Defender.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/39853282/85382027-d7b84900-b53e-11ea-82c7-c262e768f53f.png)


### Versions

- Browser/version: Opera 68.0.3618.173
- uBlock Origin version: v1.27.10

### Settings

Default + Nano Defender

### Notes

Solution: `cshort.org##+js(set, adblock, false)`
