### PR TITLE
Update 4chan denyallow filter

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -2416,4 +2416,4 @@ bondibeachau.com###custom_html-2
 ! further investigation, this fixes the issue.
 ||4chan.org^$csp=connect-src https: http:
 ! https://www.reddit.com/r/uBlockOrigin/comments/heiw4s/ublock_help/
-*$3p,script,domain=boards.4channel.org,denyallow=4cdn.org|4chan.org|google.com|gstatic.com
+*$3p,script,domain=boards.4channel.org,denyallow=4cdn.org|4chan.org|cdn.mathjax.org|cdnjs.cloudflare.com|google.com|gstatic.com|hcaptcha.com


### PR DESCRIPTION
Parity with CSP injected by `https://github.com/ccd0/4chan-x`

`cdn.mathjax.org` - used by /sci/ board
`cdnjs.cloudflare.com` - better safe then sorry, i didn't see any requests to it so you can remove if you want
`hcaptcha.com` - both sites use/used cloudflare ddos protection, again, you can remove until we get any breakage report if you want