### PR TITLE
update wapo anti-adb filters

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -17696,6 +17696,7 @@ gamefront.com##+js(nano-stb, , 10000)
 ! https://github.com/NanoMeow/QuickReports/issues/1499
 !#if env_chromium
 washingtonpost.com##+js(acis, Promise, 'overlay')
+washingtonpost.com##+js(acis, document.createElement, 'overlay')
 !#endif
 washingtonpost.com##^script:has-text(adblock)
 washingtonpost.com##div:has-text(We noticed you’re blocking ads.)


### PR DESCRIPTION
Washington post's anti-adblock script changes the formatting of the article minus the first two paragraphs (teaser) for some reason. I don't really know why, maybe to be annoying, but this filter prevents it.

Without this filter
![image](https://user-images.githubusercontent.com/16567977/85814428-ea47a380-b733-11ea-9ad5-2184cb769c2d.png)

With this filter

![image](https://user-images.githubusercontent.com/16567977/85814448-f92e5600-b733-11ea-9188-cfd487a87a1a.png)
