### PR TITLE
Fix Cookie message on gadgethacks.com

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4430,3 +4430,7 @@ legacy.com##+js(acis, document.getElementsByTagName, admiral)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/58292
 imgur.com##.Footer-whitelist
+
+! gadgethacks cookie
+gadgethacks.com##+js(set, WHT.ShowConsentForm, trueFunc)
+


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.gadgethacks.com/` displays unskippable cookie message

### Describe the issue

Visiting `gadgethacks.com` will show a cookie message from an EU IP


### Screenshot(s)

![gadget](https://user-images.githubusercontent.com/1659004/86179149-dbbb1b00-bb7d-11ea-84c5-a327a859a413.png)

### Versions

- Browser/version: Brave Version 1.10.97 Chromium: 83.0.4103.116 (Official Build) (64-bit)
- uBlock Origin version: 1.27.10

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes


