### PR TITLE
Update anti-adblock for cb01/wstream

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -19289,12 +19289,14 @@ wstream.*##+js(aopr, AaDetector)
 wstream.*##+js(nostif, eval)
 wstream.*##+js(nowoif, /^/, 1)
 wstream.*##+js(ra, onclick)
+wstream.*##+js(set, efrefr, true)
+wstream.*##+js(set, e4e4e4, true)
 @@||wstream.*^$ghide
 @@||wstream.*^$script,1p
 ||advinci.uno^$3p
 nowagoal.stream##+js(nowebrtc)
 @@*$image,domain=wstream.video
-@@||4snip.pw/popads.js$script,domain=wstream.video
+@@||4snip.pw/ads.js$script,domain=wstream.video
 @@||akvideo.stream/popunder.js$script,domain=wstream.video
 @@||vstera.tech^$script,domain=wstream.video
 *$script,redirect-rule=noopjs,domain=wstream.video


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://cb01.trade/disturbing-the-peace-sotto-asseadio-hd-2020/`

### Describe the issue

[Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder.]

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: `Brave / Version 1.10.97 Chromium: 83.0.4103.116 (Official Build) (64-bit)`
- uBlock Origin version: `1.27.10`

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Just update exisiting filters 