### PR TITLE
NSFW fix erovideoseek.com and kyonyuquest.com right click

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4440,3 +4440,6 @@ analizy.pl##+js(acis, setTimeout, newsletterPopup)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/59499
 otakuwire.com##+js(aopr, anOptions)
+
+! erovideoseek.com & kyonyuquest.com right click
+erovideoseek.com,kyonyuquest.com##+js(ra, oncontextmenu, body)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

[NSFW]
`http://erovideoseek.com/`
`http://kyonyuquest.com/`

### Describe the issue

Annoyance: right-click disabled

### Versions

- Browser/version: Brave 1.10.97
- uBlock Origin version: 1.27.10

### Settings

- Default + uBlock Annoyances

### Notes

