### PR TITLE
Fix radichubu.jp right click

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4455,3 +4455,6 @@ leevz.io###leevz-io_300x250
 
 ! citas .in handling copy
 citas.in##+js(aeld, copy)
+
+! radichubu.jp right click
+radichubu.jp##+js(ra, onContextMenu, body)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://radichubu.jp/`

### Describe the issue

Annoyance: right-click disabled

### Versions

- Browser/version: Firefox 78.0.2
- uBlock Origin version: 1.28.2

### Settings

- Default + uBlock Annoyances

### Notes

