### PR TITLE
Revert "address #7687"

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3876,7 +3876,3 @@ mirrorace.com#@#.uk-button-secondary
 
 ! https://github.com/NanoMeow/QuickReports/issues/2472
 @@||couponcabin.com/ga.*.js$1p
-
-! https://github.com/uBlockOrigin/uAssets/issues/7687
-||users.skynet.be^$badfilter
-||users.skynet.be/crisanar^$doc


### PR DESCRIPTION
This reverts commit d8cec239c9d893ac59cb4835446f16e4cf636976.

- Added to upstream's exclusion list
  * https://gitlab.com/curben/urlhaus-filter/-/commit/2ac6e89b77d196c64af7a55998ad4ad8664350e2
- Blocklist has been updated, it now blocks specific URL instead of the whole website of `users.skynet.be`.
  * https://gitlab.com/curben/urlhaus-filter/-/commit/31630147d5a9844ea1d7ad32aab97beea7d5c734
