### PR TITLE
Fix mbs.jp right click

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4473,3 +4473,6 @@ scriptinghelpers.org##.shvertise-banner
 omgkpop.top##+js(aopw, document.oncontextmenu)
 omgkpop.top##style:has-text(:not(textarea)):remove()
 omgkpop.top###ays_tooltip
+
+! mbs.jp right click
+mbs.jp##+js(aopw, document.oncontextmenu)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.mbs.jp/`

### Describe the issue

Annoyance: right-click disabled

### Versions

- Browser/version: Brave 1.11.97
- uBlock Origin version: 1.27.10

### Settings

- Default + uBlock Annoyances

### Notes
