### PR TITLE
Moved 1 entry from the Privacy list to the main list

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -3260,3 +3260,12 @@ vidtobo.com##+js(aopw, _pop)
 vidtobo.com##+js(aopr, LieDetector)
 ||supperopeningturnstile.com^
 ||gcxjczooe.com^
+
+! Examples of what is fixed by even an unfilled dummy API:
+! https://twitter.com/kenn_butler/status/709163241021317120
+! https://adblockplus.org/forum/viewtopic.php?f=10&t=48183
+! https://forums.lanik.us/viewtopic.php?f=64&t=32161
+! https://forums.lanik.us/viewtopic.php?f=64&t=30670
+! Also prevents many sites from trying to connect to "fundingchoicesmessages.google.com", thus preventing anti-adblock banners from appearing.
+! https://github.com/uBlockOrigin/uAssets/issues/7691
+||googletagmanager.com/gtm.js$script,redirect=googletagmanager.com/gtm.js

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -94,13 +94,6 @@ free18.net,gadgetlove.com,nrc.gov,onbeing.org,rapgenius.com,schonmagazine.com,te
 ! Foil blocker-sniffer code on Condé Nast sites.
 architecturaldigest.com,arstechnica.com,bonappetit.com,brides.com,cntraveler.com,details.com,epicurious.com,gq.com,golfdigest.com,newyorker.com,pitchfork.com,self.com,teenvogue.com,thescene.com,vanityfair.com,vogue.com,wmagazine.com##+js(fuckadblock.js-3.2.0)
 
-! Examples of what is fixed by even an unfilled dummy API:
-! https://twitter.com/kenn_butler/status/709163241021317120
-! https://adblockplus.org/forum/viewtopic.php?f=10&t=48183
-! https://forums.lanik.us/viewtopic.php?f=64&t=32161
-! https://forums.lanik.us/viewtopic.php?f=64&t=30670
-||googletagmanager.com/gtm.js$script,redirect=googletagmanager.com/gtm.js
-
 ! https://github.com/gorhill/uBlock/issues/1082
 ! https://github.com/gorhill/uBlock/issues/1250#issuecomment-173533894
 ! https://github.com/gorhill/uBlock/issues/2155


### PR DESCRIPTION
This is directly based on https://github.com/uBlockOrigin/uAssets/issues/7691, thus why I'm skipping the report template for this PR.

Although the uAssets team successfully argued for how I should've tested with a default uBO setup, I see no problems with moving the entry from one default list to another default list, since the entry turned out to be a lot more versatile than what was believed when it was first added 4 years ago.

I've turned on the "Allow edits by maintainers" button, if you guys want to modify this PR in any way without needing to ask me to do any such modifications.