### PR TITLE
Fix annoyances of four sites

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4529,3 +4529,15 @@ cracksone.com##*:style(-webkit-touch-callout: default !important; -webkit-user-s
 
 ! indiatimes .com selection invisible
 indiatimes.com##*::selection:style(background-color:#338FFF!important)
+
+! railf.jp and https://spectank.jp/sl0060045.html right click
+railf.jp,spectank.jp##+js(ra, oncontextmenu, body)
+
+! cookie consent with scroll locked
+analog.com###cookie-consent-container
+analog.com##.modal-backdrop
+analog.com##body.modal-open:style(overflow:auto !important)
+
+! cookie consent with scroll locked
+germany.travel##.consent
+germany.travel##body.consent-overlay:style(overflow:auto !important)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

1. `https://railf.jp/`

2. `https://spectank.jp/sl0060045.html`
(not all pages of the domain)

3. `https://www.analog.com/jp/index.html`

4. `https://www.germany.travel/en/index.html`

### Describe the issue

1 & 2: right-click disabled

3 & 4: cookie-consent with scroll locked

### Screenshot(s)

3: with Fanboy Annoyances - overlay with impossible scrolling

![analog1](https://user-images.githubusercontent.com/58900598/88523003-325b2e00-d032-11ea-9730-1ee0f562fe93.png)

3: without Fanboy Annoyances

![analog2](https://user-images.githubusercontent.com/58900598/88523071-4bfc7580-d032-11ea-8b20-af710e19beac.png)

4: 

![germany](https://user-images.githubusercontent.com/58900598/88523087-51f25680-d032-11ea-9f82-d47ae80dbf22.png)


### Versions

- Browser/version: Brave 1.11.101
- uBlock Origin version: 1.27.10

### Settings

- Default + uBlock Annoyances + AGJPN (+ Fanboy Annoyances)

### Notes

