### PR TITLE
Fix 141tube.com popup [NSFW]

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -3388,3 +3388,6 @@ t-rocforum.de##+js(acis, $, prompt)
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=44972
 @@||starvid.xyz^$ghide
+
+! 141tube.com popup
+141tube.com##+js(acis, document.querySelectorAll, popMagic)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://141tube.com/video/21560/s0001`

### Describe the issue

Popup on playing the video

### Screenshot(s)

![141tube](https://user-images.githubusercontent.com/58900598/88655596-eed3f300-d109-11ea-848f-f31193b678a8.png)


### Versions

- Browser/version: Brave 1.11.101
- uBlock Origin version: 1.27.10

### Settings

- Default + EasyList China + CJX

### Notes

