### PR TITLE
Update filters.txt

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -13937,7 +13937,7 @@ gembelcit.net##+js(aopr, AaDetector)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5065
 *$xhr,redirect-rule=nooptext,domain=photopea.com
-photopea.com##+js(set, ppCanRunAds, true)
+photopea.com##+js(set, jsLoadedOK, true)
 
 ! https://github.com/NanoMeow/QuickReports/issues/755
 @@||hanimesubth.com/assets/js/ads.core.js$script,1p


### PR DESCRIPTION
The variable in `https://www.photopea.com/ads.js` changed, however this file isn't being blocked by default filterlists anymore. Should the filter be removed?