### PR TITLE
Update #2154 for CNAME

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -6166,7 +6166,7 @@ ad4msan.*##+js(noeval-if, fab)
 japscan.*##+js(aopw, Fingerprint2)
 japscan.*##+js(acis, Math, zfgloaded)
 japscan.*##^script:has-text(blur)
-*$3p,script,denyallow=cdnjs.cloudflare.com|code.jquery.com,domain=japscan.co
+*$3p,script,denyallow=cdnjs.cloudflare.com|code.jquery.com|hwcdn.net,domain=japscan.co
 
 ! https://github.com/uBlockOrigin/uAssets/issues/2163
 pes-patch.com##+js(nobab)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.japscan.co/`

### Describe the issue

The current denyallow rule lacks an entry for CNAME, as a result it's impossible to switch contents in ranking widget. Unfortunately it's so far reproduced only with ISP DNS; Cloudflare, Quad9, and CleanBrowsing all fine.

### Screenshot(s)

![japscan](https://user-images.githubusercontent.com/58900598/89711191-a814b180-d9c3-11ea-8ca1-323774bc596e.png)

![japscan2](https://user-images.githubusercontent.com/58900598/89711197-b1058300-d9c3-11ea-89f3-3486c4036f62.png)

### Versions

- Browser/version: Firefox 79.0
- uBlock Origin version: 1.28.4

### Settings

- Default + AGJPN

### Notes

https://github.com/uBlockOrigin/uAssets/issues/2154