### PR TITLE
Fix mhwg.org anti right click/text selection

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4612,3 +4612,6 @@ freep.com##+js(acis, document.createElement, admiral)
 ! digital.lasegunda.com anti-contextmenu/anti-selection
 digital.lasegunda.com##+js(aeld, contextmenu)
 digital.lasegunda.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
+
+! mhwg.org anti right click, anti select
+mhwg.org##+js(ra, onContextmenu|onSelectStart|style, #body_game)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`http://mhwg.org/data/4316.html`

### Describe the issue

Annoyances: right-click & text selection disabled

### Versions

- Browser/version: Firefox 79.0
- uBlock Origin version: 1.28.4

### Settings

- Default + uBlock Annoyances

### Notes

