### PR TITLE
Fix anti-adblock on jnovels.com

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -20855,6 +20855,7 @@ globalscripts.xyz##+js(aopr, urlArray)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/e0uvbc/justlightnovelscom_stuck_on_browser_checking/
 @@||justlightnovels.com^$ghide
+jnovels.com##+js(aopw, KillAdBlock)
 
 ! https://github.com/NanoMeow/QuickReports/issues/2357
 cracking-dz.com##+js(aeld, load, 0x)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Fixes Anti-adblock on `https://jnovels.com/light-novels-epub/`  was reported here https://github.com/brave/adblock-lists/issues/436

### Describe the issue

Just a anti-adblock message on load


### Versions

- Browser/version: Brave
- uBlock Origin version: 1.28.4

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Just a fix of Anti-adblock, similar site too justlightnovels.com, can move to filters-2020 if needed.
