### PR TITLE
Fixes popups on https://video1tube.com/freshest/ (NSFW)

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -3782,6 +3782,10 @@ real-sky.com##+js(aopr, app_vars.force_disable_adblock)
 healthline.com##a[href*="/confirm_linkout_redirect.aspx?"]:upward(section)
 healthline.com##hl-adsense
 
+! https://community.brave.com/t/website-kept-asking-leave-site-if-i-click-cancel-it-opened-new-window-i-couldnt-even-close-brave-without-end-process/
+video1tube.com##+js(set, popit, false)
+video1tube.com##+js(acis, btoa)
+
 ! https://github.com/AdguardTeam/AdguardFilters/issues/61263
 @@||mercedesclub.cz^$ghide
 mercedesclub.cz##.adsbygoogle, [class^="side_ad_"]


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://video1tube.com/freshest/`  **(NSFW)**

### Describe the issue

Popup on exit and other popups.

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.28.4

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Was reported by a user. https://community.brave.com/t/website-kept-asking-leave-site-if-i-click-cancel-it-opened-new-window-i-couldnt-even-close-brave-without-end-process/

There could be a few ways to fix this, but here is my take.
