### PR TITLE
Include youtube-nocookie.com in json-prune snippet

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -114,7 +114,7 @@ youtube.com##.ytd-carousel-ad-renderer
 ! https://github.com/easylist/easylist/issues/5112
 ! @@||youtube.com/get_video_info?*timedtext_editor$xhr,1p
 ! https://redd.it/ggcmkp https://redd.it/gx03e0
-youtube.com##+js(json-prune, [].playerResponse.adPlacements [].playerResponse.playerAds playerResponse.adPlacements playerResponse.playerAds adPlacements playerAds)
+youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.adPlacements [].playerResponse.playerAds playerResponse.adPlacements playerResponse.playerAds adPlacements playerAds)
 @@||youtube.com/get_video_info
 ||youtube.com/get_video_info?*=adunit&$important
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.racingcircuits.info/europe/norway/arctic-circle-raceway.html#.XzMw2CiA4uX`

### Describe the issue

Just include the domain `youtube-nocookie.com` in the json-prune snippet.

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.28.4

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Just to cover an additional domain in the current youtube snippet.
