### PR TITLE
Update #2652 filecrypt.cc popup

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -7481,8 +7481,8 @@ uploadbank.com##+js(nostif, appendChild)
 ! https://github.com/uBlockOrigin/uAssets/issues/2652
 ! https://github.com/uBlockOrigin/uAssets/issues/2742
 ! https://github.com/NanoMeow/QuickReports/issues/1520
-filecrypt.*##+js(acis, parseInt, UltraPop)
-filecrypt.*##+js(aopr, __pop_debug)
+filecrypt.*##+js(acis, parseInt, open)
+filecrypt.*##+js(aopr, __pop_debugX)
 filecrypt.*##+js(set, isAdblock, false)
 filecrypt.*##+js(popads-dummy.js)
 ||filecrypt.*^$popunder


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://filecrypt.cc/Container/BB4FA6D9AD.html`

### Describe the issue

Popup on clicking anywhere on the page

### Versions

- Browser/version: Firefox 79.0
- uBlock Origin version: 1.29.0

### Settings

- Default + AGJPN

### Notes

Apparently the two rules need to be updated, please check on your end too.
