### PR TITLE
Fix hibiki-radio.jp annoyances

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4643,3 +4643,7 @@ atlasobscura.com##body.modal-open:style(overflow:auto !important)
 
 ! https://github.com/NanoMeow/QuickReports/issues/4511
 webcamtaxi.com##+js(nostif, blocker)
+
+! ! https://hibiki-radio.jp/description/Afterglow/detail right click, text selection
+hibiki-radio.jp##+js(aeld, contextmenu)
+hibiki-radio.jp##body:style(-webkit-user-select:auto !important; -webkit-touch-callout: default !important;)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://hibiki-radio.jp/description/Afterglow/detail`

### Describe the issue

Annoyances: right-click and text selection disabled

### Versions

- Browser/version: Firefox 79.0
- uBlock Origin version: 1.29.0

### Settings

- Default + uBlock Annoyances + AGJPN

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
