### PR TITLE
Update Filters.txt to stop false positive blocking of Bugsnag JS

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -1745,7 +1745,6 @@ jav.guru##.alignnone
 ||9anime.*^$script,1p
 @@||9anime.*/assets/$script,1p
 @@||9anime.ru/cdn-cgi/scripts/hcaptcha$script
-||d2wy8f7a9ursnm.cloudfront.net^
 ||soujoobafoo.com^
 ! https://www.reddit.com/r/uBlockOrigin/comments/e5b4h6/popups_and_ads_from_certain_websites_dont_get/
 ||bqiovml.com^


### PR DESCRIPTION
Bugsnag, an error catching service, provides their javascript library over a CloudFront URL. 

`http://d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js` 

It seems the CloudFront domain name is being blocked on this list and is causing issues rendering pages where Bugsnag JS is being used.

### Versions

- Browser/version: Latest Chrome on macOS
- uBlock Origin version: 1.28.4
