### PR TITLE
Add YouTube Premium filter

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -3923,3 +3923,7 @@ dafideff.com##+js(acis, addEventListener, google_ad_client)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/61779
 gurl.pw##+js(nosiif, visibility, 1000)
+
+! YouTube Premium
+||youtube.com/premium^$document
+


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`[https://youtube.com/premium]`

### Describe the issue

**Scam (paying for nothing)**. One can use uBlock Origin and some downloading software instead of paying for no ads and [defective by design](https://defectivebydesign.org) downloads (30 days offline limit).