### PR TITLE
Fix j-island.net right click and copy

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4640,3 +4640,8 @@ sagliktais.com##+js(aopw, ai_front)
 
 ! naisho .website warning anti adb
 naisho.website##+js(aopr, anOptions)
+
+! j-island.net right click, copy
+j-island.net##+js(acis, document.oncontextmenu)
+j-island.net##+js(ra, oncontextmenu|oncopy|ontouchstart, body)
+j-island.net##body:style(-webkit-touch-callout: default !important; -webkit-user-select: auto !important;)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://j-island.net/?lang=en`

### Describe the issue

Annoyances: right click and copy disabled

### Versions

- Browser/version: Firefox 79.0
- uBlock Origin version: 1.29.0

### Settings

- Default + uBlock Annoyances + AGJPN

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
