### PR TITLE
Fix Verizon chat broken on https://www.verizon.com/support/contact-us/

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -3991,9 +3991,6 @@ techworlds24.com##+js(nostif, nextFunction, 2000)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/62098
 trentotoday.it##+js(nostif, bADBlock)
 
-! Verizon chat broken (https://www.verizon.com/support/contact-us/)
-@@||tags.tiqcdn.com/utag/vzw/main/$script,domain=verizon.com
-
 ! https://github.com/AdguardTeam/AdguardFilters/issues/62100
 sociadrive.com##+js(nosiif, visibility, 1000)
 

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3701,6 +3701,8 @@ mirrorace.com#@#.uk-button-secondary
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7706
 verizon.com##+js(set, newPageViewSpeedtest, noopFunc)
+! Verizon chat broken (https://www.verizon.com/support/contact-us/)
+@@||tags.tiqcdn.com/utag/vzw/main/$script,domain=verizon.com
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/i02d2c/
 @@||tags.tiqcdn.com/utag/godaddy/$script,domain=godaddy.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Clicking on `Chat now` on https://www.verizon.com/support/contact-us/ doesn't launch Chat window

### Describe the issue

[Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder.]

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.29.2

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Caused by Peter Lowes list, blocking `||tags.tiqcdn.com^`
