### PR TITLE
Fix bejav.net popup

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -4014,3 +4014,6 @@ moviesjoy.net##+js(aeld, , _0x)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/ietqo4/how_to_block_an_element_using_inspect_element/
 mp4.sh##+js(acis, Math, XMLHttpRequest)
+
+! bejav.net popup on playing video
+ffem.club##+js(aopr, open)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://bejav.net/rctd-202/`

### Describe the issue

Popup on playing any video.

### Screenshot(s)

![bejav](https://user-images.githubusercontent.com/58900598/91029587-ed7ae500-e639-11ea-8333-05cb2b24fba7.png)


### Versions

- Browser/version: Firefox 79.0
- uBlock Origin version: 1.29.2

### Settings

- Default + AGJPN + EL China + CJX

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
