### PR TITLE
Update rules for adshr.ink

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -19385,10 +19385,11 @@ upclips.*##[id*="ScriptRoot"]
 @@||unikampus.net^$ghide
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=43693
-adshr.ink##+js(aopr, app_vars.force_disable_adblock)
-adshr.ink##+js(aopr, absda)
-adshr.ink,thekingavatar.com##+js(acis, Math, zfgloaded)
-adshr.ink##+js(aeld, click, trigger)
+adsh.cc##+js(acis, Math, XMLHttpRequest)
+adsh.cc##+js(aopr, app_vars.force_disable_adblock)
+adsh.cc##+js(aopr, open)
+||nutscolouredrefrain.com^
+thekingavatar.com##+js(acis, Math, zfgloaded)
 @@||thekingavatar.com^$ghide
 ||foastail.net^
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://adsh.cc/obvL` (redirected from `https://adshr.ink/obvL`)

### Describe the issue

`adshr.ink` is now `adsh.cc`, addressed
1. Anti-adblock
2. pop-banner (`||nutscolouredrefrain.com^`)
3. Popup/redirect on click

### Screenshot(s)

![adsh](https://user-images.githubusercontent.com/58900598/91158369-7f99f080-e701-11ea-9cb2-99d8e0ff6e89.png)

### Versions

- Browser/version: Firefox 79.0
- uBlock Origin version: 1.29.2

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
