### PR TITLE
Fix anti-adblock on https://elpais.com/

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -4043,6 +4043,9 @@ cut.my.id##+js(aopr, open)
 *$3p,script,frame,denyallow=google.com|gstatic.com|recaptcha.net|hcaptcha.com,domain=cut.my.id
 cut.my.id##.banner
 
+! googlefundingchoices elpais.com
+elpais.com##+js(nostif, f.parentNode.removeChild(f), 100)
+
 ! https://github.com/AdguardTeam/AdguardFilters/issues/62269
 adltc.cc##+js(nosiif, visibility, 1000)
 

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -14538,7 +14538,7 @@ gatevidyalay.com##.adsbygoogle
 ! https://github.com/uBlockOrigin/uAssets/issues/5288
 ! https://github.com/AdguardTeam/AdguardFilters/issues/49825
 @@||elpais.com^$ghide
-elpais.com##+js(aopr, googlefc)
+elpais.com##+js(nostif, f.parentNode.removeChild(f), 100)
 
 ! urlaubspartner.net anti-adb
 urlaubspartner.net##+js(set, adblock, false)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Prevent anti-adblock warning on elpais.com

### Describe the issue

Yellow anti-ablock bar shows.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.29.2

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
