### PR TITLE
Fix lookmovie icon breakage

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -13998,7 +13998,7 @@ lookmovie.ag##+js(aopr, AaDetector)
 @@||lookmovie.ag^$ghide
 lookmovie.ag##.view-top-ab
 lookmovie.ag##.notifyjs-corner
-*$3p,denyallow=google.com|googleapis.com|gstatic.com|lookmovie.io|hcaptcha.com,domain=lookmovie.ag
+*$3p,denyallow=google.com|googleapis.com|gstatic.com|lookmovie.io|hcaptcha.com|nflxext.com,domain=lookmovie.ag
 ||mopnixhem.com^$3p
 ||opsoomet.net^$3p
 


### PR DESCRIPTION
`lookmovie.ag` is using play buttons from `nflxext.com` (netflix cdn)  (...?)

Example page: `https://lookmovie.ag/movies/view/8503618-hamilton-2020`

Reported by `https://old.reddit.com/iggwi7/`