### PR TITLE
Remove two obsolete rules

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -1469,7 +1469,6 @@ fux.com##+js(aeld, , /exopop|adb/)
 streamplay.*##+js(aopr, miner)
 streamplay.*##+js(aopw, Fingerprint2)
 steamplay.*##+js(aopr, btoa)
-@@||streamplay.to/js/pop$script,1p
 steamplay.*,streamp1ay.*##+js(aopw, Fingerprint2)
 streamp1ay.*##+js(aopw, Fingerprent2)
 steamplay.*,streamp1ay.*##+js(aopr, console.clear)
@@ -19807,7 +19806,6 @@ vup.to##+js(aopr, AaDetector)
 vup.to##+js(nowebrtc)
 vup.to##+js(aopw, _pop)
 vup.to##+js(nowoif)
-@@||vup.to^$script,1p
 ||badslads.com^
 ||cadsipz.com^
 ||dadsecz.com^

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -19806,6 +19806,7 @@ vup.to##+js(aopr, AaDetector)
 vup.to##+js(nowebrtc)
 vup.to##+js(aopw, _pop)
 vup.to##+js(nowoif)
+@@||vup.to^$script,1p
 ||badslads.com^
 ||cadsipz.com^
 ||dadsecz.com^


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://vup.to/v/3k25asr2f395`
`https://streamp1ay.cc/2cjrsfxbyqww`

### Describe the issue

`@@||vup.to^$script,1p`
was probably for EasyList rule `/pop.js` which was removed so I guess it's no need any more.
`@@||streamplay.to/js/pop$script,1p`
also seems to be obsolete.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Firefox 79.0
- uBlock Origin version: 1.29.2

### Settings

- Default

### Notes
