### PR TITLE
Remove *.bugsnag.com from privacy filters

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -214,9 +214,6 @@ dictionary.com,thesaurus.com##+js(aopr, adDetection)
 ! https://www.yst.am/movies/lady-driver-2020
 ||ga-analytics.com^
 
-! https://www.eventbrite.com
-||bugsnag.com^$3p
-
 ! https://github.com/uBlockOrigin/uAssets/issues/7833
 frogogo.ru##+js(aopw, ADMITAD)
 ||artfut.com/static/tagtag.$script,3p,redirect=noop.js


### PR DESCRIPTION
Hi 👋 full and early disclosure here – I'm the maintainer of Bugsnag's JS SDK.

We noticed that https://github.com/uBlockOrigin/uAssets/commit/9635e296aa91f3fd946ecfec5d1d97ab2a62e1a0 added .bugsnag.com to the list of privacy filters. Subsequently for any of our customers with users running uBlock, they will no longer be able to see if their web app is crashing.

### URL(s) where the issue occurs

The URLs affected are AJAX requests to `notify.bugsnag.com` and `sessions.bugsnag.com`
I can provide URLs of web pages where this happens upon request. But it is basically every website that uses Bugsnag.

### Describe the issue

I understand this is a grey area, but Bugsnag's product is not a tracking product. It's for monitoring application stability and reporting back to developers when their users experience errors or crashes. We do not harvest or sell user data – we detect what we need to provide a utility for engineering teams.

Blocking requests to Bugsnag's APIs limits the ability of application developers to know about bugs they have shipped.

The ideal scenario for us, obviously, is to have Bugsnag removed from this list, so that our users are able to get crash reports and stability info for all of their visitors (not just those without uBlock), but if this rule is to remain in place we would like to see it fairly applied. There are other companies operating similar products (for example Sentry, Crashlytics etc.) which are not in this list and also services is in the adjacent space of application performance monitoring (APM, for example, NewRelic, Elastic etc.).

### Screenshot(s)

![image](https://user-images.githubusercontent.com/609579/91432610-e3373180-e859-11ea-973b-d3cf433e492e.png)

### Versions

Affects any, but here are my versions anyway…

- Browser/version: Firefox 79.0 (mac)
- uBlock Origin version: v1.28.4

### Settings

Default settings.

### Notes

I couldn't find any explanation for the addition in 9635e296aa91f3fd946ecfec5d1d97ab2a62e1a0 but it did come with the comment of eventbrite – one of our customers. Could it have been that somebody just saw that while browsing eventbrite that it made an http request to a third party api and assumed it was tracking?
