### PR TITLE
Google.com - Fix #7877

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -100,6 +100,10 @@ google.*##a[href*="/aclk?"][data-al]:upward(2)
 ! https://github.com/NanoMeow/QuickReports/issues/1375#issuecomment-503802350
 www.google.*##div.ellip > span:has-text(/^Ads?$/):upward(2)
 
+! https://github.com/uBlockOrigin/uAssets/issues/7877
+www.google.com###before-appbar+div
+www.google.com##html:style(overflow: auto !important;)
+
 ! http://www.wilderssecurity.com/threads/ublock-a-lean-and-fast-blocker.365273/page-25#post-2461804
 ! Specific cosmetic filters for Youtube home page
 youtube.com##.masthead-ad-control,.ad-div,.pyv-afc-ads-container


### PR DESCRIPTION
### URL(s) where the issue occurs
`https://www.google.com/search?client=firefox-b-d&q=test`

### Describe the issue
There is "Before you continue" Popup. #7877 

### Screenshot(s)

![Screenshot](https://i.ibb.co/gb13y9c/test.png)

[Image](https://ibb.co/twf4BK1) will be autodeleted after 2 weeks

### Versions

- Browser/version: Firefox/80.0.1
- uBlock Origin version: 1.29.2

### Settings

- Default

### Notes
After #before-appbar there is div which creates popup, moreover html is set to overflow: hidden.

To fix that I've removed that div with ```#before-appbar+div``` and also added ```overflow: auto !important``` to html.
