### PR TITLE
Fix CPU usage on ebay.com caused by portscanning

### DIFF
--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -267,3 +267,6 @@ shortbitsfree.net##+js(aopr, WebAssembly)
 ! https://github.com/uBlockOrigin/uAssets/issues/7449
 ||csgo.xyz^$doc
 ||mailboxdelivery.com^$doc
+
+! Prevent portscan from starting on ebay (CPU abuse)
+ebay.com##+js(acis, tmx_post_session_params_fixed)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.ebay.com`

### Describe the issue

Site is initiating a port scan, causing increased cpu usage.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave 
- uBlock Origin version: 1.29.2


### Notes

Easyprivacy blocks the ||127.0.0.1 requests from ebay (for privacy reasons), but this can cause issues regarding cpu usage. Preventing the script from loading in the first place will help

https://github.com/easylist/easylist/commit/b9995f09658872483e6eebde0a348e6bcdf56946

Was a quick network block workaround, but we can also use a snippet to get around this.
