### PR TITLE
Fix www.sony.jp can't switch tabs

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3886,3 +3886,6 @@ hentaiplay.net###video_overlays
 !#if env_firefox
 @@||privacy-mgmt.com^$script,domain=handelsblatt.com
 !#endif
+
+! www.sony.jp can't switch tabs
+@@||tags.tiqcdn.com/utag/sony-marketing/main/prod/utag.sync.$script,domain=www.sony.jp


### PR DESCRIPTION
The same issue as https://github.com/easylist/easylist/pull/6062 so please forgive me for skipping the required steps. Due to `tags.tiqcdn.com` blocked by Peter Lowe's another fix is needed on uBO.