### PR TITLE
Unbreak Sentry while keeping grofers.com exception

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -222,7 +222,7 @@ frogogo.ru##+js(aopw, ADMITAD)
 ||artfut.com/static/tagtag.$script,3p,redirect=noop.js
 
 ! grofers.com sentry data-collection/fingerprinting
-||sentry.io^$3p
+||sentry.io^$3p,domain=grofers.com
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/62696
 ||freegames.io/log^


### PR DESCRIPTION
### URL(s) where the issue occurs

We use Sentry.io in web application that is not closed to public and so cannot provide an URL.
It's API endpoint URL is requested usually only in case of unexpected events so only way to demonstrate problem would be via controlled error,

### Describe the issue

Sentry.io is an error tracking utility, one of it's platform allows to be used in web browsers.

In commit https://github.com/uBlockOrigin/uAssets/commit/6489ab5eaf2a838bcdf2ae74ec8542ebb897d16d sentry.io was added to the privacy list, apparently because the `grofers.com` site is misusing it to report user fingerprints (more information is in mentioned commit comments).

Unfortunately this breaks all web apps that use [@sentry/browser](https://www.npmjs.com/package/@sentry/browser) package as these are not able to send error events anymore.

This Pull requests changes filter restricts filter to be applied only in case of `grofers.com` site:

```diff
-||sentry.io^$3p
+||sentry.io^$3p,domain=grofers.com
```

### Screenshot(s)

Log from Chrome DevTools console
```
https://xxx.ingest.sentry.io/api/xxx/store/?sentry_key=xxx&sentry_version=7
net::ERR_BLOCKED_BY_CLIENT
```

### Versions

- Browser/version: Chrome/ Version 85.0.4183.102 (Official Build) (64-bit)
- uBlock Origin version: 1.29.2

### Settings

- no changes to default settings

### Notes

none