### PR TITLE
Fix dropdown menu on https://www.healthgrades.com/

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -4790,7 +4790,7 @@ highporn.net##.fel-playclose
 ||sowhypepse.pro^
 ||graxarosi.pro^
 
-! https://github.com/uBlockOrigin/uAssets/pull/7931
+! https://github.com/uBlockOrigin/uAssets/pull/7948
 @@||tags.tiqcdn.com/utag/hg/main/prod/utag.js$script,domain=healthgrades.com
 
 ! https://github.com/NanoMeow/QuickReports/issues/4745

--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -4790,6 +4790,9 @@ highporn.net##.fel-playclose
 ||sowhypepse.pro^
 ||graxarosi.pro^
 
+! https://github.com/uBlockOrigin/uAssets/pull/7931
+@@||tags.tiqcdn.com/utag/hg/main/prod/utag.js$script,domain=healthgrades.com
+
 ! https://github.com/NanoMeow/QuickReports/issues/4745
 animeshouse.info##+js(acis, Object.defineProperty, XMLHttpRequest)
 @@||animeshouse.info^$ghide


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`Searching on https://www.healthgrades.com/ is broken`

### Describe the issue

If you search for `Family Medicine` on `https://www.healthgrades.com` It won't forward to a new page



### Versions

- Browser/version: Brave
- uBlock Origin version:  1.29.1

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Broken due to Peter Lowes filter `||tags.tiqcdn.com^`