### PR TITLE
Update latimes.com filters

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -1241,7 +1241,7 @@ mind42.com###content.sidebar2:style(margin-right: 0 !important;)
 ||d1n7ypf85zfej7.cloudfront.net^
 
 ! https://github.com/uBlockOrigin/uAssets/pull/7963
-latimes.com##+js(nosiif, visibility, 1000)
+latimes.com##+js(nosiif)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6947
 xhamster.*,xhamster1.*##+js(aopr, wih-popunder)

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -991,6 +991,7 @@ pornhub.*,pornhubthbh7ap3u.onion##div video[id]:first-child > source[src^="data:
 pornhub.*,pornhubthbh7ap3u.onion##+js(aopw, isAdblockOn)
 
 ! https://news.ycombinator.com/item?id=13958134
+! https://github.com/uBlockOrigin/uAssets/pull/7963
 ||platform.californiatimes.com/meteringjs/latspot.js$script,domain=latimes.com
 
 ! https://github.com/uBlockOrigin/uAssets/issues/331
@@ -1239,7 +1240,7 @@ mind42.com###content.sidebar2:style(margin-right: 0 !important;)
 ! https://github.com/gorhill/uBlock/issues/2701
 ||d1n7ypf85zfej7.cloudfront.net^
 
-! https://github.com/uBlockOrigin/uAssets/issues/458
+! https://github.com/uBlockOrigin/uAssets/pull/7963
 latimes.com##+js(nosiif, visibility, 1000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6947

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -991,7 +991,7 @@ pornhub.*,pornhubthbh7ap3u.onion##div video[id]:first-child > source[src^="data:
 pornhub.*,pornhubthbh7ap3u.onion##+js(aopw, isAdblockOn)
 
 ! https://news.ycombinator.com/item?id=13958134
-||tribdss.com/meter$script,domain=latimes.com
+||platform.californiatimes.com/meteringjs/latspot.js$script,domain=latimes.com
 
 ! https://github.com/uBlockOrigin/uAssets/issues/331
 ! https://github.com/NanoMeow/QuickReports/issues/401
@@ -1240,11 +1240,7 @@ mind42.com###content.sidebar2:style(margin-right: 0 !important;)
 ||d1n7ypf85zfej7.cloudfront.net^
 
 ! https://github.com/uBlockOrigin/uAssets/issues/458
-||latimes.com^$ghide,important
-||googlesyndication.com^$script,important,domain=latimes.com
-||ntv.io^$script,important,domain=latimes.com
-||openx.net^$script,important,domain=latimes.com
-||rubiconproject.com^$script,important,domain=latimes.com
+latimes.com##+js(nosiif, visibility, 1000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6947
 xhamster.*,xhamster1.*##+js(aopr, wih-popunder)

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -990,10 +990,6 @@ fdesouche.com##+js(aopw, advanced_ads_check_adblocker)
 pornhub.*,pornhubthbh7ap3u.onion##div video[id]:first-child > source[src^="data:"]:xpath(../../..)
 pornhub.*,pornhubthbh7ap3u.onion##+js(aopw, isAdblockOn)
 
-! https://news.ycombinator.com/item?id=13958134
-! https://github.com/uBlockOrigin/uAssets/pull/7963
-||platform.californiatimes.com/meteringjs/latspot.js$script,domain=latimes.com
-
 ! https://github.com/uBlockOrigin/uAssets/issues/331
 ! https://github.com/NanoMeow/QuickReports/issues/401
 handelsblatt.com##+js(acis, hcf_userconfig, hcf_userconfig.cgi_adb_redirect_url)
@@ -1241,7 +1237,7 @@ mind42.com###content.sidebar2:style(margin-right: 0 !important;)
 ||d1n7ypf85zfej7.cloudfront.net^
 
 ! https://github.com/uBlockOrigin/uAssets/pull/7963
-latimes.com##+js(nosiif)
+latimes.com##+js(nostif, f.parentNode.removeChild(f), 100)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6947
 xhamster.*,xhamster1.*##+js(aopr, wih-popunder)


### PR DESCRIPTION
`https://www.latimes.com` google funding and metering fix.

### URL(s) where the issue occurs

Updates 2 issues with latimes, googlefunding warning and the metering script.

### Describe the issue

[Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder.]

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.29.2

### Notes

Can adjust the commit, just modifying existing placeholders.
