### PR TITLE
Update https://github.com/NanoMeow/QuickReports/issues/4768 [NSFW]

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -4909,8 +4909,17 @@ indirlinks.xyz##+js(aopw, _pop)
 indirlinks.xyz##div[style^="margin:0px 0px 0px 0px"]
 
 ! https://github.com/NanoMeow/QuickReports/issues/4768
-*$script,3p,denyallow=disquscdn.com|disqus.com|fbcdn.net|facebook.net|fastly.net|fastlylb.net|jquery.com|hwcdn.net|hcaptcha.com|recaptcha.net|cloudflare.com|cloudflare.net|google.com|googleapis.com|gstatic.com,domain=loveheaven.net
+*$frame,script,3p,denyallow=cloudflare.com|cloudflare.net|discord.com|discordapp.com|disqus.com|disquscdn.com|facebook.com|facebook.net|fastly.net|fastlylb.net|fbcdn.net|google.com|googleapis.com|gstatic.com|hcaptcha.com|hwcdn.net|jquery.com|recaptcha.net,domain=loveheaven.net
+*$frame,script,3p,denyallow=cloudflare.net|disqus.com|disquscdn.com|facebook.com|facebook.net|fastlylb.net|fbcdn.net|hwcdn.net|loveheaven.net,domain=loveha.net
 ||jiltlargosirk.com^
+||upsieutoc.com^$domain=loveha.net
+loveha.net,loveheaven.net##.chapter-content > h3:has-text(ADVERTISEMENT)
+loveha.net,loveheaven.net##.float-ck
+loveha.net,loveheaven.net##.quang-cao
+loveha.net,loveheaven.net##center:has-text(ADVERTISEMENT)
+loveheaven.net###myCarousel:style(height:0 !important; margin-bottom:20px !important)
+loveheaven.net##.topday
+loveheaven.net##.col-lg-4 > .panel-body:has([id^=bidadx_])
 
 ! https://github.com/NanoAdblocker/NanoFilters/issues/568
 *$script,redirect-rule=noopjs,domain=linecad.com


### PR DESCRIPTION
`loveha.net` is subsection of loveheaven for adult contents, but I see image-only ads:

<details>

![loveha](https://user-images.githubusercontent.com/58900598/94792073-70e6dd80-0413-11eb-9a5a-b708ebb44788.png)

</details>

So tried `*$3p,denyallow=` but it turned out to be too risky, there are some legitimate images from minor domains from time to time. At least frame can safely be default-denied.

Test URL for cosmetic filters:
`https://loveha.net/read-keijo-chapter-177.html` or any contents pages
for
```
loveha.net,loveheaven.net##.chapter-content > h3:has-text(ADVERTISEMENT)
loveha.net,loveheaven.net##.float-ck
loveha.net,loveheaven.net##.quang-cao
loveha.net,loveheaven.net##center:has-text(ADVERTISEMENT)
```
`https://loveheaven.net/manga-runway-de-waratte-raw.html`
for
```
loveheaven.net##.col-lg-4 > .panel-body:has([id^=bidadx_])
loveheaven.net###myCarousel:style(height:0 !important; margin-bottom:20px !important)
```
but :has is to avoid FP at the top page `https://loveheaven.net` (Discord widget). `loveheaven.net##.topday` is for the top page.