### PR TITLE
Add new google ads carousel match format.

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -24492,3 +24492,6 @@ techdracula.com##.adsbygoogle
 
 ! As of 2020-04-09 new domains for filters.txt will be added to filters-2020.txt sublist
 !#include filters-2020.txt
+
+! https://github.com/uBlockOrigin/uAssets/pull/8014
+google.*###atvcap > div:has(h3[role="heading"] > span:has-text(/^Ads/))


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.google.com/search?q=oven`

### Describe the issue

Fixes match for new google ads carousel layout.

### Versions

- Browser/version: Chrome 85.0.4183.121
- uBlock Origin version: 1.30.2

### Settings

- defaults