### PR TITLE
Update badlists.txt

### DIFF
--- a/filters/badlists.txt
+++ b/filters/badlists.txt
@@ -24,3 +24,4 @@ https://easylist-downloads.adblockplus.org/antiadblockfilters.txt remove
 # https://github.com/gorhill/uBlock/commit/a13ac920892d25ba0bf431ea1410fd3c8612b2d6
 https://gitcdn.xyz/repo/NanoMeow/MDLMirror/master/hosts.txt remove
 https://mirror.cedia.org.ec/malwaredomains/justdomains remove
+https://easylist-downloads.adblockplus.org/malwaredomains_full.txt remove


### PR DESCRIPTION
Added alternative link (?) for Malwaredomains.

That it was not possible to install this filter from an alternative source.