### PR TITLE
Update #8041 (fixes https://old.reddit.com/r/uBlockOrigin/comments/jg…

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -15716,7 +15716,7 @@ pixiv.net##iframe[name="dashboard_home"]:upward(div[span="1"])
 pixiv.net##iframe[name="infeed"]:upward(1)
 pixiv.net##iframe[width="300"][height="250"]:upward(2)
 pixiv.net##iframe[width="468"][height="60"]:upward(1)
-pixiv.net##iframe[width="500"][height="520"]:upward(1)
+pixiv.net##iframe[name][width="500"][height="520"]:upward(1)
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=43033
 ||nextclick.pl^$3p


### PR DESCRIPTION
…hjku/)

Reproduced and this should fix `https://old.reddit.com/r/uBlockOrigin/comments/jghjku/referrer_page_on_pixivnet_does_not_show_link_to/`.

![pixiv](https://user-images.githubusercontent.com/58900598/96984360-670c5200-155b-11eb-839e-8149b6fcac88.png)
