### PR TITLE
Update 9hentai [NSFW]

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -21172,8 +21172,9 @@ livenewsnow.com##+js(aopr, adblockDetector)
 ! https://github.com/NanoMeow/QuickReports/issues/2698
 dobrapogoda24.pl##+js(nostif, , 1)
 
-! 9hentai.com onclick popup/under
-9hentai.com##+js(set, _9HentaiPopJs, null)
+! 9hentai onclick popup/under
+9hentai.*##+js(set, _9HentaiPopJs, null)
+9hentai.*###ads
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6807
 @@||chuppito.fr^$ghide


### PR DESCRIPTION
TLD changed to ru and I got popunder. This also made an EL rule `9hentai.com###ads` obsolete.

<details>

![9hentai](https://user-images.githubusercontent.com/58900598/97158717-2dd31c80-17bd-11eb-9b93-2095570f4aa3.png)

</details>