### PR TITLE
Fixes https://github.com/brave/brave-browser/issues/12309

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3971,3 +3971,6 @@ hentaiplay.net###video_overlays
 
 ! https://www.fox.com/watch/bdb5db80949b2226d9caa10c08dc1032/ broken video
 @@||link.theplatform.com/*/media/*?affiliate=$xhr,domain=fox.com
+
+! https://github.com/brave/brave-browser/issues/12309
+@@||tags.tiqcdn.com/utag/*/utag.js$script,domain=myq.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Fixes links on `https://www.myq.com/`


### Describe the issue

Links are broken due to `tags.tiqcdn.com` block in Peter Lowes list.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave 
- uBlock Origin version: 1.30.6

