### PR TITLE
Add fingerprinting honeypots to privacy list

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -221,7 +221,7 @@ frogogo.ru##+js(aopw, ADMITAD)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/64477
 ||videostats.kakao.com^
 
-! https://github.com/uBlockOrigin/uAssets/issues/8105
+! https://github.com/uBlockOrigin/uAssets/issues/8106
 ! block known tracking honeypots
 ||copyhomework.com^
 ||coursecopy.com^

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -220,3 +220,13 @@ frogogo.ru##+js(aopw, ADMITAD)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/64477
 ||videostats.kakao.com^
+
+! https://github.com/uBlockOrigin/uAssets/issues/8105
+! block known tracking honeypots
+||copyhomework.com^
+||coursecopy.com^
+||quiztoolbox.com^
+||quizlookup.com^
+||studyeffect.com^
+||testbooksolutions.com^
+


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
copyhomework.com
coursecopy.com
quiztoolbox.com
quizlookup.com
studyeffect.com
testbooksolutions.com

<!-- [At least one URL for a web page where the clearly described issue occurs is **mandatory**. The backticks surrounding the URLs is important, it prevents the URL from being clickable. Warn with "NSFW" where applicable.] -->
#### example URL
`https://studyeffect.com/qscjmrtzrt-2018-10-27-corpus-study-13-14-for-computer-engineering/`
### Describe the issue
No major visual issues. Sites track users with server-side code and Inspectlet, **without any visible disclaimer or privacy policy!** Since tracking is done server side, the best mitigation is to prevent the site from loading in the first place, hence the proposed list items.
Minor annoyances: Sites auto-play sounds on button press, depending on how the site was accessed (depends if accessed through Google Search or direct link)
<!-- [Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder.] --> 
These honeypot sites are run by Honorlock, and are implementations of patent US9881516B1. By statements from the company and the patent, the sites intent to collect as much client information as possible with the intention of **matching users to personally identifiable information.**
### Screenshot(s)

<!-- [Screenshot(s) for difficult to describe visual issues are **mandatory**. Post links instead of **Inline Images** for Screenshots containing **Adult material**.] -->
Imgur screenshot https://imgur.com/a/GPvc7jF
### Versions

- Browser/version: Firefox 81.0.2, Ubuntu 18.04
- uBlock Origin version:  1.30.6

### Settings

<!-- [List here all the changes you made to uBO's default settings] -->
- added above sites to user list

### Notes

<!-- [Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.] -->
