### PR TITLE
Fix popups on https://keepvid.works/

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -14057,7 +14057,7 @@ youtubemp4.biz##[href="/g-ban.php"]
 youtubemp4.biz##[href="/w.php"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5222
-keepvid.*##+js(acis, atob, decodeURIComponent)
+keepvid.*##+js(acis, find_links)
 
 ! https://github.com/NanoMeow/QuickReports/issues/880
 ||player.ooyala.com/static/*/ad-plugin/*$script,redirect=noopjs,domain=dragons.com.au


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Popup occur when uploading a youtube clip  on `https://keepvid.works/`



### Versions

- Browser/version: Brave 
- uBlock Origin version:1.30.6

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Fixes popup on site

```
function find_links() {
    window.open('//whimsoplynx.com/ip3PiZnBKBYdQ/26878');
}
```
