### PR TITLE
fix EasyList #6078

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -2571,6 +2571,16 @@ tube8.*##.gridBanner
 tube8.*##.js-remove-ads-premium-link
 tube8.*##.ryghtc0lb4nn3r
 tube8.*##.rightColBanner
+tube8.*###announcement_ticker
+tube8.*###footer-text
+tube8.*###result_container > div
+tube8.*###result_container_fake
+tube8.*##.hot-porn-videos-wrapper > .gridList > div:first-child
+tube8.*##a[href^="https://sexsimulator.game/"]
+tube8.*##div[data-esp-node="catfish"]
+tube8.*##div[data-esp-node="footer_ads_banner"]
+tube8.*##div[data-esp-node="under_player_ad"]
+tube8.*##main.row > aside.col-4 > div[class]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/921
 @@||corporacionwarez.com^$ghide


### PR DESCRIPTION
github.com/easylist/easylist/issues/6078

Probably some old cosmetic filters are obsolete.
I see only these hit:
```
tube8.*##.adsbytrafficjunky
tube8.*##.js-remove-ads-premium-link
```
Please check if the rest of cosmetic filters are still needed.