### PR TITLE
Update #7982

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -133,8 +133,6 @@ opisanie-kartin.com,painting-planet.com##+js(aopr, LieDetector)
 1plus1plus1equals1.net,cooksinfo.com,heatherdisarro.com,laurastewartblog.com,thesassyslowcooker.com##+js(aopr, Date.prototype.toUTCString)
 ||podfdch.com^$script
 
-! loveheaven .net popups, ads
-
 ! https://github.com/NanoMeow/QuickReports/issues/3558
 rikunime.com##+js(aeld, , _0x)
 ||robspabah.com^
@@ -4909,10 +4907,9 @@ indirlinks.xyz##div[style^="margin:0px 0px 0px 0px"]
 *$frame,script,3p,denyallow=cloudflare.com|cloudflare.net|discord.com|discordapp.com|disqus.com|disquscdn.com|facebook.com|facebook.net|fastly.net|fastlylb.net|fbcdn.net|google.com|googleapis.com|gstatic.com|hcaptcha.com|hwcdn.net|jquery.com|recaptcha.net,domain=loveheaven.net
 *$frame,script,3p,denyallow=cloudflare.net|disqus.com|disquscdn.com|facebook.com|facebook.net|fastlylb.net|fbcdn.net|hwcdn.net|loveheaven.net,domain=loveha.net
 ||upsieutoc.com^$domain=loveha.net
-loveha.net,loveheaven.net##.chapter-content > h3:has-text(ADVERTISEMENT)
 loveha.net,loveheaven.net##.float-ck
 loveha.net,loveheaven.net##.quang-cao
-loveha.net,loveheaven.net##center:has-text(ADVERTISEMENT)
+loveha.net,loveheaven.net##center:has-text(/ADVERTISEMENT/i)
 loveheaven.net###myCarousel:style(height:0 !important; margin-bottom:20px !important)
 loveheaven.net##.topday
 loveheaven.net##.col-lg-4 > .panel-body:has([id^=bidadx_])


### PR DESCRIPTION
Now they use small letter too, and `loveha.net,loveheaven.net##.chapter-content > h3:has-text(ADVERTISEMENT)` seems to be obsolete.