### PR TITLE
Fix AdguardFilters #66815 jav380.com plus ffjav.com popunder [NSFW]

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -5744,3 +5744,6 @@ pg-wuming.com##+js(acis, $, .test)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8152
 modapkfile.com##+js(acis, String.fromCharCode, btoa)
+
+! github.com/AdguardTeam/AdguardFilters/issues/66815 and ffjav.com popunder
+ffjav.com,jav380.com##+js(acis, document.querySelectorAll, popMagic)


### PR DESCRIPTION
Since fixed in Base than Japanese, I wanna add it to uBlock filters too.

<details> 
<summary>Screenshot of ffjav popunder</summary>

![ffjav](https://user-images.githubusercontent.com/58900598/98223793-f4a56400-1f95-11eb-8184-80974dcc548f.png)

</details>