### PR TITLE
Fix anti-Brave message on archive for uBO/Brave

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4034,3 +4034,7 @@ lebigdata.fr##.background-cover
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8158
 @@||tags.tiqcdn.com/utag/usbank/global-sync/prod/utag.sync.js$script,domain=usbank.com
+
+! Brave specific (using Brave/uBO)
+archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion##+js(acis, document.cookie, document.location.href)
+

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4035,6 +4035,6 @@ lebigdata.fr##.background-cover
 ! https://github.com/uBlockOrigin/uAssets/issues/8158
 @@||tags.tiqcdn.com/utag/usbank/global-sync/prod/utag.sync.js$script,domain=usbank.com
 
-! Brave specific (using Brave/uBO)
+! https://github.com/uBlockOrigin/uAssets/pull/8160 
 archive.is,btdig.com,archive.today,archive.vn,archive.fo,archive.md,archive.li,archive.ph,archiveiya74codqgiixo33q62qlrqtkgmcitqx5u2oeqnmn5bpcbiyd.onion##+js(acis, document.cookie, document.location.href)
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://archive.is/` is using an Anti-Brave check, this patch is for Brave/uBO (assuming the user is disable shields)

### Describe the issue

Site is using Anti-Brave checks, and user is unfairly targeting the browser. We worked around it in Brave with a similar fix, but for users of uBO and Brave, shouldn't be forgotten.

### Screenshot(s)
![579ef1665583fd91853dfb84757566138c6f40ed](https://user-images.githubusercontent.com/1659004/98296849-68885080-2018-11eb-897f-ffe8ecdcc098.png)

### Versions

- Browser/version: Brave Version 1.16.68 Chromium: 86.0.4240.111 (Official Build) (64-bit)
- uBlock Origin version: 1.30.6

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Breaking this check, targeting (US IP)

`try { if (Object.keys(Object.getPrototypeOf(navigator)).join(' ').match(/\bbrave\b/)) { document .cookie = 'us=1;path=/;max-age=86400'; document.location.href='/unsupported-browser'; } } catch(e) { document .cookie = 'us=1;path=/;max-age=86400'; document.location.href='/unsupported-browser'; }`
