### PR TITLE
Fix unviewable image on chan.sankakucomplex.com (Vivaldi specific) [NSFW]

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4034,3 +4034,6 @@ lebigdata.fr##.background-cover
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8158
 @@||tags.tiqcdn.com/utag/usbank/global-sync/prod/utag.sync.js$script,domain=usbank.com
+
+! Image unviewable on Vivaldi
+||otaserve.net^$frame,redirect-rule=noop.html,domain=chan.sankakucomplex.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://chan.sankakucomplex.com`
`https://chan.sankakucomplex.com/ja/post/show/22271391`

### Describe the issue

Images can't be viewed on Vivaldi (account required).

1. Use Vivaldi (not reproducible on Chrome)
2. Turn off built-in blocker via Option > Privacy
3. Create an account for sankakucomplex and login (mandatory, not reproducible without login)
4. Go to `https://chan.sankakucomplex.com` and click any of thumbnails.

### Screenshot(s)

<details>

![sankaku1](https://user-images.githubusercontent.com/58900598/98353284-7367d300-2062-11eb-93da-d08f9e59d3da.png)

</details>

### Versions

- Browser/version: Vivaldi 3.4.2066.94
- uBlock Origin version: 1.30.6

### Settings

- Default + AGJPN

### Notes

I also got a modal but can't reproduce now. 
```
chan.sankakucomplex.com###sank-prestitial
chan.sankakucomplex.com##body.no-scroll:style(overflow: visible !important;position: static !important)
```
fixed that and an equivalent rules are in AG Annoyances.