### PR TITLE
Prevent cbs.com anti-adblock/easylist checks

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -5995,5 +5995,8 @@ pureshort.com##+js(aopr, app_vars.force_disable_adblock)
 pureshort.com##+js(aopr, open)
 ||speedynews.xyz^$3p
 
+! Anti-adblock on cbs-allaccess
+@@||cbs.com^$ghide
+
 ! https://github.com/AdguardTeam/AdguardFilters/issues/67651
 venge.io##+js(nofab)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Warning from cbs allaccess (ad supported) on `https://www.cbs.com/movies/console-wars/4ECA1036-8A7D-FF9C-7922-82AAC4352BB6`

### Describe the issue

I haven't tested this on a ad-free plan, seem pretty safe to add

### Screenshot(s)

![image (5)](https://user-images.githubusercontent.com/1659004/99180100-4913c500-2788-11eb-9712-0ff35617b20f.png)

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.30.6

### Notes

From: `https://www.cbs.com/assets/build/js/show/videoBottom-1181013bf61b2a5a4235.min.js`

```
var r = (n(0).get("detection:artifact:get_easylist_classnames"),
        ["ad-space", "placeholder-ad", "placeholderAd", "plainAd", "play-page-ads", "playAds1", "playAds2", "player-ads", "player-leaderboard-ad-wrapper", "player-under-ad", "playerAd", "player_ad", "player_ad2", "player_ad_box", "player_hover_ad", "player_page_ad_box"])
          , i = Math.floor(Math.random() * r.length) }
```
