### PR TITLE
Update #1614 (popup)

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -4538,9 +4538,8 @@ imageweb.ws##+js(popads-dummy)
 imageweb.ws##a[href^="http://refer.ccbill.com/"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/1614
-stream2watch.*##+js(aopw, Fingerprint2)
-stream2watch.*##+js(set, ab, false)
 stream2watch.*##+js(acis, atob)
+stream2watch.*##+js(aopr, AdservingModule)
 stream2watch.*##p[style="color:white;"]
 stream2watch.*##.min-test
 |http*://$3p,frame,domain=stream2watch.ws,badfilter


### PR DESCRIPTION
Still got popup (fixed by this filter) and I don't see ab or Fingerprint2 even with uBO turned off.