### PR TITLE
Update #5059 [NSFW]

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -13577,13 +13577,10 @@ cambro.tv##[href^="https://t.grtya.com/"]
 *&offer_id=$frame
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5059
-jav789.com,javbuz.com,javhihi.com,letfap.com##+js(aopr, Date.prototype.toUTCString)
+jav789.com,javbuz.com,letfap.com##+js(aopr, Date.prototype.toUTCString)
+jav789.com,javbuz.com,letfap.com##+js(aeld, getexoloader)
 javkiki.com##+js(aopr, exoNoExternalUI38djdkjDDJsio96)
 jav789.com,javbuz.com,javkiki.com,letfap.com##div.container > .box:has(#ad-top-main)
-@@||letfap.com^$ghide
-@@||jav789.com^$ghide
-@@||javhihi.com^$ghide
-@@||javbuz.com^$ghide
 anime789.com##+js(nowoif)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5060


### PR DESCRIPTION
javhihi dead (redirects to javkiki), ghide no more needed. I suspect anime789 (lead by Download button on these porn sites) may also be dead, all Download returned 404 but not sure.