### PR TITLE
Block bulbagarden custom ad server

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -6273,3 +6273,9 @@ bollyholic.pw##div[class][style="float: none; margin:10px 0 10px 0; text-align:c
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/68391
 tecnomusic-evolution.com##+js(nosiif, visibility, 1000)
+
+! bulbagarden.net ads
+||ahost.bulbagarden.net
+||bulba-ad-host-website.azurewebsites.net
+bulbapedia.bulbagarden.net###navbarc > div
+


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://bulbapedia.bulbagarden.net/wiki/Main_Page`

### Describe the issue

Bulbagarden created their own ad servers to insert ads that are not present while logged in. This pull request mitigates the issues. It also removes the top menu which also is not present while logged in.

### Screenshot(s)

Without filter
![image](https://user-images.githubusercontent.com/2660574/100162947-a55e9f00-2e82-11eb-939a-e649d7781d99.png)


With filter
![image](https://user-images.githubusercontent.com/2660574/100162730-4d279d00-2e82-11eb-94ca-7f324da95078.png)


### Versions

- Browser/version: Chrome 87
- uBlock Origin version: v1.30.6

### Notes

Without the cosmetic filter, the menu is displaced.