### PR TITLE
bulbagarden.net procedural cosmetic filters

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -6273,3 +6273,9 @@ bollyholic.pw##div[class][style="float: none; margin:10px 0 10px 0; text-align:c
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/68391
 tecnomusic-evolution.com##+js(nosiif, visibility, 1000)
+
+! bulbagarden.net ads
+||ahost.bulbagarden.net
+||bulba-ad-host-website.azurewebsites.net
+bulbapedia.bulbagarden.net###navbarc > div
+

--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -6277,5 +6277,5 @@ tecnomusic-evolution.com##+js(nosiif, visibility, 1000)
 ! bulbagarden.net ads
 ||ahost.bulbagarden.net
 ||bulba-ad-host-website.azurewebsites.net
-bulbapedia.bulbagarden.net###navbarc > div
-
+bulbagarden.net###navbarc > div
+bulbagarden.net###globalWrapper:style(position: initial !important)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
```

https://bulbapedia.bulbagarden.net/wiki/Main_Page
https://bulbanews.bulbagarden.net/wiki/Main_Page
```

### Describe the issue

Bulbagarden created their own ad servers to insert ads that are not present while logged in. This pull request mitigates the issues. It also removes the top menu which also is not present while logged in.

Furthermore, without the procedural cosmetic filter added, the sidebar menu breaks and is unclickable.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/2660574/100249573-b4892f80-2f0a-11eb-8abb-1d2bd524d7f1.png)
![image](https://user-images.githubusercontent.com/2660574/100249544-aa673100-2f0a-11eb-8299-6dc56332ddaa.png)

### Versions

- Browser/version: Chrome 87
- uBlock Origin version: 1.30.6

### Notes

Without the procedural cosmetic filter added, the menu breaks and is unclickable.