### PR TITLE
Fix anti-adblock on niusdiario(.)es

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -6373,7 +6373,7 @@ o2tvseries.website##+js(acis, String.fromCharCode, btoa)
 pinayviralsexx.com##+js(acis, document.querySelectorAll, popMagic)
 
 ! niusdiario.es anti-adblock
-niusdiario.es##[class^="adsInfo__container"]
+niusdiario.es##+js(aeld, load, Adblock)
 
 ! rapbhe.com popups
 rapbhe.com##+js(acis, String.fromCharCode, atob)

--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -6372,5 +6372,8 @@ o2tvseries.website##+js(acis, String.fromCharCode, btoa)
 ! pinayviralsexx.com popup
 pinayviralsexx.com##+js(acis, document.querySelectorAll, popMagic)
 
+! niusdiario.es anti-adblock
+niusdiario.es##[class^="adsInfo__container"]
+
 ! rapbhe.com popups
 rapbhe.com##+js(acis, String.fromCharCode, atob)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Fixed anti-adblock on `https://www.niusdiario.es/sociedad/sanidad/alfonso-valencia-creador-mapa-covid-vemos-zonas-estan-riesgo-peligrosas-navidad_18_3049995378.html`

### Describe the issue

[Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder.]

### Screenshot(s)
![warning-div-2](https://user-images.githubusercontent.com/1659004/100557737-e554d480-330f-11eb-8e07-777e3de7580c.png)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.30.6

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
