### PR TITLE
Add zhihu.com modal login popup

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -5002,3 +5002,6 @@ liveroger.com##body:style(-webkit-touch-callout:text !important;-webkit-user-sel
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/69076
 freebulksmsonline.com##+js(aopw, ai_front)
+
+! zhihu.com modal login popup
+||static.zhihu.com/heifetz/main.signflow.*.js$script,domain=www.zhihu.com


### PR DESCRIPTION
See discussion in https://www.v2ex.com/t/730727

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`[https://www.zhihu.com/question/408769119]`

### Describe the issue

Recently, zhihu.com adds a mandentory login popup for every page. So nobody can read any user-generated-content on that site anonymously.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/54175165/100999309-86cc6800-3554-11eb-929f-91a34ae617ad.png)

### Versions

- Browser/version: Firefox/83.0
- uBlock Origin version: 1.31.0
