### PR TITLE
Fix cookie message overlay on obuvki.bg

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -5000,6 +5000,10 @@ techoreels.com##+js(ra, oncontextmenu, body)
 ! https://github.com/uBlockOrigin/uAssets/issues/8299
 promobit.com.br##+js(aeld, mouseout)
 
+! Cookie notice 
+obuvki.bg##body:style(overflow: auto !important;)
+obuvki.bg##.popup
+
 ! liveroger.com anti-select
 liveroger.com##body:style(-webkit-touch-callout:text !important;-webkit-user-select:text !important;-khtml-user-select:text !important;-moz-user-select:text !important;-ms-user-select:text !important;user-select:text !important)
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.obuvki.bg/goljam-damski-portfejl-guess-brightside-vy-slg-swvy75-80430-bla.html`

### Describe the issue

Fixes popup, and restores scroll.

### Screenshot(s)

![obuvk](https://user-images.githubusercontent.com/1659004/101160717-5db2f100-3694-11eb-9738-fe474af64367.png)


### Versions

- Browser/version: Brave
- uBlock Origin version: 1.31.2

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes


