### PR TITLE
fix shop.forster.at being unclickable and blurred

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3928,3 +3928,7 @@ hero-magazine.com###header:style(position: inherit !important;)
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=mewatch.sg
 @@||youborafds01.com/data?outputformat=json$xhr,domain=mewatch.sg
 @@||pubads.g.doubleclick.net/gampad/ads$xhr,domain=mewatch.sg
+
+! fix shop.forster.at is unclickable and blurred
+shop.forster.at##.lock
+shop.forster.at##.blur:style(filter: none !important)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

* https://shop.forster.at/Verkehrszeichen/Verkehrszeichen-und-Schilder/Hinweiszeichen/53-17a-Ortstafel.html

### Describe the issue

Site is unclickable and blurred

### Screenshot(s)

![20201206_03h16m18s_grim](https://user-images.githubusercontent.com/6215916/101269653-77763600-3771-11eb-9543-9170dd685b0f.jpeg)

### Versions

- Browser/version: firefox-83.0
- uBlock Origin version: 1.31.0
