### PR TITLE
fix de.steelseries.com

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3933,3 +3933,6 @@ digg.com##.single-story > header:style(margin-top: 40px !important)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/kahlmt/
 ||akamaized.net/sc/*.gif$domain=msn.com,redirect-rule=1x1.gif
+
+! CNAME broken site https://github.com/uBlockOrigin/uAssets/pull/8357
+@@||onelink-translations.com^$domain=de.steelseries.com


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://de.steelseries.com/`

### Describe the issue

```
de.steelseries.com is an alias for steelseries.onelink-translations.com.
steelseries.onelink-translations.com is an alias for nva-pcid-as-cluster01.pcilb.onelink-translations.com.
```

de.steelseries.com is served by onelink. I'm not too familiar with why this is blocked as it's just a CNAME but appearently that is relevant for the filters.

I've taken 224b73497392f7501e69c95843933db4096445d4 as example and tested that this change works.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/3694534/101895945-82cdc500-3ba8-11eb-9c45-97650078069d.png)

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/3694534/101896061-adb81900-3ba8-11eb-84bf-804e8bacd066.png">


### Versions

- Browser/version: Firefox 83.0
- uBlock Origin version: uBlock Origin v1.31.0

### Settings

--

### Notes

I checked for a few other countries (change `Shipping to` near the bottom of the site), those I tested didn't have any country subdomain and no translation service included.