### PR TITLE
Update bing filters

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -16669,9 +16669,11 @@ bing.com##.b_algo:has(p:matches-css-before(content: "Ad"))
 bing.com##+js(set, Blob, noopFunc)
 bing.com##+js(set, AdBlockerTracking.AdBlockMonitor, noopFunc)
 bing.com##+js(set, AdBTrack.AdbMon.isBlocked, noopFunc)
+bing.com##+js(set, SVGForeignObjectElement, undefined)
 bing.com##.productAd
 bing.com##.b_ad:remove()
 bing.com##.b_ad:style(position: absolute !important; left: -3000px !important;)
+bing.com##.b_algo:has(.b_textAdTitleLink)
 bing.com#@#.b_ad
 bing.com#@##b_results > li:not(.b_algo):not(.b_ans):not(.b_pag):not(.aca_algo):not(.aca_algo_count):not(.b_msg)
 bing.com#@#a[h$=",Ads"]


### PR DESCRIPTION
Yesterday bing updated their adblock circumvention.

Test here:

```
https://www.bing.com/search?q=book+me+a+flight
https://www.bing.com/search?q=lose+weight
https://www.bing.com/search?q=car+insurance
```

The filter ` bing.com##+js(set, SVGForeignObjectElement, undefined)` prevents bing from setting the cookie `ABDEF` on your machine (this cookie tracks your adblock status) and prevents circumvention from taking place.

In case the cookie is already set, the filter `bing.com##.b_algo:has(.b_textAdTitleLink)` hides the ads.

Here is the code: https://gist.github.com/llacb47/8f7dc92b687ecdacfa78c4242a5a26c9