### PR TITLE
Fix CNAME on https://darknetdiaries.com/episode/78/

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3783,5 +3783,8 @@ researchgate.net##.research-resources-summary__inner.is-sticky:style(top: 0 !imp
 ! alotporn.com cname
 @@||cdn13.com^$script,domain=alotporn.com
 
+! darknetdiaries..com cname
+@@||adserver.va3.megaphone.cloud^$media,domain=podigee.com
+
 ! https://www.reddit.com/r/uBlockOrigin/comments/kpl5ty/
 ||data.over-blog-kiwi.com^$badfilter


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

CNAME issues causing broken playback `https://darknetdiaries.com/episode/78/`

### Describe the issue

Unable to playback  https://darknetdiaries.com/episode/78/


### Versions

- Browser/version: Brave & Firefox
- uBlock Origin version: 1.31.2

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

`traffic.megaphone.fm. 60 IN CNAME adserver.va3.megaphone.cloud.`