### PR TITLE
Remove backend.dna-delivery.com from blacklist

### DIFF
--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -255,9 +255,6 @@ steamplay.*##+js(aopw, CoinNebula)
 ! https://github.com/uBlockOrigin/uAssets/issues/5612
 ||homeporno.pro^$csp=worker-src 'none';
 
-! https://github.com/uBlockOrigin/uAssets/issues/6433
-||backend.dna-delivery.com^$domain=france.tv|rt.com
-
 ! https://github.com/uBlockOrigin/uAssets/issues/6734
 ||cloud-miner.eu^
 


### PR DESCRIPTION
### URL(s) where the issue occurs
- `https://www.france.tv/france-2/direct.html` (All channels of France Televisions)
- `https://www.rt.com/on-air/`

### Describe the issue

Hello,
I got the [previous PR 8428](https://github.com/uBlockOrigin/uAssets/pull/8428) closed without any explanation, just a link to a previous comment on issue #6433 that does not apply to this specific case:

> Bandwidth abuse is abuse regardless of the device, the filter should apply everywhere.

Our solution is not abusing of bandwidth: as clearly stated in France Televisions and Russia Today T&C, a viewer agrees to high usage of bandwidth to be able to watch the videos free of charge.
A person that does not agree to these T&C must NOT use the service at all, therefore the fruition of the service without our solution active (due the uBlockOrigin rule) is an infringement of the aforementioned T&C.

For these reasons, I kindly ask again to remove the hostname "backend.dna-delivery.com" from the list of blocked domains.

I thank you in advance for your understanding and cooperation.

Best regards,
Giovanni Usai
name_dot_surname_at_lumen_dot_com

### Screenshot(s)

N/A

### Versions

- Browser/version: all
- uBlock Origin version: all

### Settings

N/A

### Notes

Previous [PR 8428](https://github.com/uBlockOrigin/uAssets/pull/8428) message:

Hello uBlockOrigin maintainers,

First and foremost, thanks for your active role in making the internet better.

I am the owner of [CDN Mesh Delivery product](https://streamroot.io/cdn-mesh-delivery/): we noticed a drop in our users for customers France Televisions and Russia Today, due to our service “backend.dna-delivery.com”, being blocked since uBlockOrigin issue #6433.

France Televisions specifies in its terms & conditions -for free watching of content- that high usage of bandwidth is expected: "2.2.1 L’accès à certains services sur et/ou depuis les Sites et Applications FRANCE TELEVISIONS peut être subordonné à l’acceptation de conditions spécifiques d’utilisation et/ou de vente auxquelles tout Utilisateur souhaitant accéder auxdits services doit adhérer. Les Applications sont gratuites hors coût d’abonnement Internet à l’opérateur et hors surcoût éventuel facturé par l’opérateur via les Applications, pour le chargement et l’envoi des données. L’utilisation des applications pouvant engendrer une consommation importante de données, particulièrement la consultation de vidéos, FRANCE TELEVISIONS recommande l’utilisation des Applications dans le cadre d’un forfait adapté, type « illimité » ou en mode Wifi." (https://www.francetelevisions.fr/cgu, section 2.2.1.)

Russia Today specifies in its terms & conditions that "[RT] do not warrant that: [...] iv. the results of using the services will meet your requirements. Your use of the services is solely at your own risk." (https://www.rt.com/terms-of-use/, section Limitation of Liability, paragraph 4.)

In addition to the T&C:
- Broadcasters can leverage [our activation/deactivation API](https://support.streamroot.io/hc/en-us/articles/360008861134) to let viewers opt-in / opt-out of peer-to-peer.
- We already have many mechanisms in place to protect users from overuse of resources (bandwidth, CPU, RAM), e.g. as per article "I’m concerned about overloading my viewers’ upload bandwidth" in [FAQ](https://streamroot.io/faq/).

For all the aforementioned reasons, would you please consider the removal of “backend.dna-delivery.com” from the list of blocked domains?

I would be happy to discuss it over a call whenever you would be available.

Thanks in advance and best regards,
Giovanni Usai
name_dot_surname_at_lumen_dot_com