### PR TITLE
Remove unused loadout.tf filter

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -7125,7 +7125,6 @@ zilinak.sk##+js(nostif, offsetHeight)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8413
 @@||loadout.tf^$ghide
-loadout.tf#@#.loadout-application-top > custom-panel:last-child
 loadout.tf##.adsbygoogle:upward(2):style(left-3000px !important;position:absolute !important)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/71225


### PR DESCRIPTION
`loadout.tf#@#.loadout-application-top > custom-panel:last-child` was being used to prevent the EasyList's filter on loadout.tf.
Since it [has been removed](https://easylist.to/easylist/easylist.txt), there is no need to keep it in the uBlock's filters list.

For reference: https://github.com/uBlockOrigin/uAssets/commit/241a197989150ffe9493d04c9647589bf7a040f4#commitcomment-45547568