### PR TITLE
Fix Anti-adblock redirect on standardmedia.co.ke

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -4769,7 +4769,7 @@ bitfly.io###overlay
 *$frame,script,3p,denyallow=google.com|gstatic.com|recaptcha.net,domain=bitfly.io
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7998
-standardmedia.co.ke##+js(set, canRunAds, true)
+standardmedia.co.ke##+js(aopr, canRunAds)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/65006
 *$script,redirect-rule=noopjs,domain=downloadrepack.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.standardmedia.co.ke/article/2001310291/how-kenyans-give-up-privacy-for-costly-mobile-loans` Redirects to adblock url

### Describe the issue

Visiting `https://www.standardmedia.co.ke/article/2001310291/how-kenyans-give-up-privacy-for-costly-mobile-loans` won't allow you to see the article.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.31.2

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

This seems to work better than the previous filter.
