### PR TITLE
Remove filter without domain scope

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -216,7 +216,6 @@ nude-teen-18.com##.cht6
 nude-teen-18.com##.rtrrtrlight-in-2
 pornteens.mobi##.fixx.chtrb
 *$script,domain=hoporno.net,3p,denyallow=googleapis.com
-##[id*="exo_"]
 cartoonvideos247.com##.adv
 cartoonvideos247.com##.sponsor
 cartoonvideos247.com##.topad


### PR DESCRIPTION
Was triggered on our Mattermost server which uses random IDs for messages such as `7re6ktgrfdfs54d5d6ew91ywexo_message`

### URL(s) where the issue occurs

Not applicable, but any document with an ID containing `exo_`

### Describe the issue

All elements with IDs containing `exo_` are hidden.

### Versions

- Browser/version: Firefox 84.0.2
- uBlock Origin version: 1.32.4

