### PR TITLE
Fix chatbot on https://brave.com/brave-ads/

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3810,5 +3810,8 @@ seazon.fr##+js(no-fetch-if, url:ipapi.co)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/72063
 @@||tags.tiqcdn.com/utag/politico/main/prod/utag.js$script,domain=politico.com
 
+! Fix chatbot on https://brave.com/brave-ads/ via Peter Lowes List
+||targeting.api.drift.com^$badfilter
+
 ! https://github.com/uBlockOrigin/uAssets/issues/8450
 @@/wp-content/plugins/woocommerce-google-adwords-conversion-tracking-tag/*/admin$1p


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Clicking on chatbot icon on bottom right on `https://brave.com/brave-ads/` won't open

### Describe the issue

badfilter Peter Lowes filter to allow a chatbot to work

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.32.4

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes


