### PR TITLE
Fix Anti-adblock warnings on keybr.com

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -5276,6 +5276,9 @@ infodifesa.it##*:style(-webkit-touch-callout: default !important; -webkit-user-s
 ! irisbuddies. ml anti select
 irisbuddies.*##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
+! Anti-adb keybr.com
+keybr.com##.Placeholder
+
 ! kijyomatome-ch.com anti right-click, select
 kijyomatome-ch.com##+js(ra, oncontextmenu|onselectstart, body)
 kijyomatome-ch.com##body:style(user-select:auto !important;-webkit-user-select:auto !important;-ms-user-select:auto !important;-moz-user-select:auto !important;-webkit-user-drag:auto !important)

--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -540,5 +540,8 @@ cdnx.stream###banner
 jav720.net##.video-player-area > center
 ||i.pinimg.com/564x/$domain=3xphim.net|cdnx.stream|damvc.pro|jav720.net|phimsexkhongche.net|z900.net
 
+! Anti-adb keybr.com
+keybr.com##.Placeholder
+
 ! https://github.com/AdguardTeam/AdguardFilters/issues/72310
 @@||xxxdao.com^$ghide

--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -540,8 +540,5 @@ cdnx.stream###banner
 jav720.net##.video-player-area > center
 ||i.pinimg.com/564x/$domain=3xphim.net|cdnx.stream|damvc.pro|jav720.net|phimsexkhongche.net|z900.net
 
-! Anti-adb keybr.com
-keybr.com##.Placeholder
-
 ! https://github.com/AdguardTeam/AdguardFilters/issues/72310
 @@||xxxdao.com^$ghide


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Visit `https://keybr.com` with text warnings on top and left.

### Describe the issue

Placeholders for adblock warnings

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.32.4


