### PR TITLE
Fixes GDPR warning on https://www.politico.eu/

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -5313,5 +5313,8 @@ loveplay123.com##*:style(-webkit-touch-callout: default !important; -webkit-user
 ! minecraftquiz .com anti select
 minecraftquiz.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
+! sp-prod.net gdpr warnings 
+||gdpr-tcfv2.sp-prod.net^
+
 ! magelang1337 .com anti select
 magelang1337.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Fixes gdpr warning on `https://www.politico.eu/`

### Describe the issue

Due to reasons, `sp-prod.net` is exempt from various sites 


### Versions

- Browser/version: Brave
- uBlock Origin version: 1.32.4


