### PR TITLE
Block sponsored results on DDG Lite

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -692,3 +692,6 @@ shortlinkpay.com##+js(set, blurred, false)
 shortlinkpay.com##.banner
 shortlinkpay.com##.box-main > .blog-item
 *$script,3p,denyallow=google.com|gstatic.com|recaptcha.net,domain=shortlinkpay.com
+
+! DDG Lite ads
+lite.duckduckgo.com##.result-sponsored


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://lite.duckduckgo.com/lite/?q=test`

### Describe the issue

Some "sponsored results" are visible.

### Versions

- Browser/version: Firefox ~84
- uBlock Origin version: 1.32.4
