### PR TITLE
Fix blank page on https://myaccount.chicagotribune.com/

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -5313,8 +5313,5 @@ loveplay123.com##*:style(-webkit-touch-callout: default !important; -webkit-user
 ! minecraftquiz .com anti select
 minecraftquiz.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! sp-prod.net gdpr warnings 
-||gdpr-tcfv2.sp-prod.net^
-
 ! magelang1337 .com anti select
 magelang1337.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)

--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -5313,5 +5313,8 @@ loveplay123.com##*:style(-webkit-touch-callout: default !important; -webkit-user
 ! minecraftquiz .com anti select
 minecraftquiz.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
+! sp-prod.net gdpr warnings 
+||gdpr-tcfv2.sp-prod.net^
+
 ! magelang1337 .com anti select
 magelang1337.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)

--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -2897,7 +2897,6 @@ tv-sport-hd.com###reklama1
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/hu1j47/block_website_from_locking_scrolling/
 chicagotribune.com##body,html:style(overflow:auto !important)
-chicagotribune.com###reg-overlay
 chicagotribune.com##+js(aeld, scroll)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/59669

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3817,5 +3817,8 @@ seazon.fr##+js(no-fetch-if, url:ipapi.co)
 ! https://www.reddit.com/r/uBlockOrigin/comments/kwnggu/legitimate_enterprise_website_being_blocked_by/
 @@||microcat-america.superservice.com/content/microcat-dist/js/$script,1p
 
+! https://myaccount.chicagotribune.com/300/home
+||myaccount.chicagotribune.com/assets/scripts/tag-manager/googleTag.js$script,redirect=googletagmanager.com/gtm.js,important
+
 ! https://github.com/uBlockOrigin/uAssets/issues/1632#issuecomment-761010732
 @@||google.com^*recaptcha/$csp


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Fixes blank page on https://myaccount.chicagotribune.com/300/home

### Describe the issue

Page is blank when loaded on default uBO filters

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave 
- uBlock Origin version: 1.32.4

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

