### PR TITLE
Fix anti-adblock on https://globalnews.ca/

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -1853,8 +1853,7 @@ cinemahd.eu##+js(aopw, document.onkeydown)
 cinemahd.eu##+js(ra, oncontextmenu)
 
 ! https://github.com/NanoMeow/QuickReports/issues/1324
-@@||globalnews.ca^$ghide
-globalnews.ca##.ad-container
+globalnews.ca##.c-newsletterSignup
 globalnews.ca###headerAd
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5321

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -8786,7 +8786,9 @@ scrapywar.com##.stream-item-widget
 
 ! Videos disabled by anti-blocker:
 ! https://globalnews.ca/news/4332734/quebec-farmers-hoping-for-rain-after-drought-heat-wave-threaten-crops/
+@@||globalnews.ca^$ghide
 globalnews.ca##+js(set, GNCA_Ad_Support, true)
+globalnews.ca##.l-headerAd__container
 globalnews.ca##.c-ad__unit
 globalnews.ca##.c-ad__label
 globalnews.ca##.c-ad


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Fixes anti-adblock on `https://globalnews.ca/` on video content

### Describe the issue

Opening videos will display anti-adblock message `https://globalnews.ca/news/7595483/spartan-coronavirus-rapid-test-approved/`

### Screenshot(s)

![globalnews](https://user-images.githubusercontent.com/1659004/105617030-85c30300-5e40-11eb-9fde-a5731d784e3f.png)

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.32.4

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Moving $ghide from annoyances, into filters will do enough to fix the message.
