### PR TITLE
Fix https://www.cbssports.com/nfl/superbowl/live/

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3554,6 +3554,7 @@ lebigdata.fr##.background-cover
 ! https://www.reddit.com/r/uBlockOrigin/comments/jpy4b6/running_into_this_message_on_cbs_and_fox_sports/
 @@||imasdk.googleapis.com/js/sdkloader/ima3_dai.js^$script,domain=cbssports.com
 @@||tags.tiqcdn.com/utag/cbsi/videotracking-v3/prod/utag$script,domain=cbssports.com
+@@||tags.tiqcdn.com/utag/cbsi/cbssportssite/prod/utag.js$script,domain=cbssports.com
 @@||pubads.g.doubleclick.net/ssai/event/*/streams$xhr,domain=cbssports.com
 
 ! https://uktvplay.uktv.co.uk/shows/les-miserables/watch-online - broken player controls


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

` https://www.cbssports.com/nfl/superbowl/live/`

### Describe the issue

Site is blank, blocked by Peter lowes list

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.32


A bit late, but a fix for live sports on cbssports.
