### PR TITLE
Removed superfluous $ghide entries

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -1185,8 +1185,6 @@ vev.io##+js(aeld, adb.updated)
 vev.io##+js(nowoif)
 vev.io##+js(set, console.clear, trueFunc)
 vev.io##+js(set, __INITIAL_STATE__.ads, undefined)
-@@||vev.io^$ghide
-*$frame,3p,domain=vev.io
 ||googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,domain=vev.io|vev.red
 
 ! https://github.com/uBlockOrigin/uAssets/issues/413
@@ -1463,7 +1461,6 @@ streamp1ay.*##+js(aopw, Fingerprent2)
 steamplay.*,streamp1ay.*##+js(aopr, console.clear)
 steamplay.*,streamp1ay.*,streamplay.*##+js(aopw, adcashMacros)
 steamplay.*##+js(nosiif, visibility, 1000)
-@@||streamp1ay.me^$ghide
 |about:$popup,domain=steamplay.me
 ||terdiparcalpe.info^
 ||*ontent.steamplay.*^$all
@@ -4577,9 +4574,6 @@ dirpy.com##a[href*="bit.ly"]
 dirpy.com##a[href*="out.dirpy.com"]
 dirpy.com###dirpy-news
 
-! https://github.com/uBlockOrigin/uAssets/pull/1625
-@@||player.r7.com^$ghide
-
 ! https://github.com/jspenguin2017/uBlockProtector/issues/865
 clix4btc.com##+js(set, adblock, false)
 
@@ -6359,9 +6353,6 @@ lnk.news,lnk.parts##.child-centered.display-300x250
 nzbstars.com##+js(aeld, DOMContentLoaded, ads)
 ||nzbstars.com/*.gif$image
 
-! https://github.com/uBlockOrigin/uAssets/issues/2336
-@@||geomedia.gala100.net^$ghide
-
 ! https://github.com/uBlockOrigin/uAssets/issues/2338
 @@||muhendisimaaslari.com^$ghide
 muhendisimaaslari.com##.adsbygoogle
@@ -7299,6 +7290,7 @@ kissjav.com##+js(popads-dummy)
 @@||kissjav.com^$ghide
 kissjav.com###player-advertising
 
+! https://github.com/uBlockOrigin/uAssets/issues/2336
 ! https://github.com/uBlockOrigin/uAssets/issues/2686
 @@||gala100.net^$ghide
 galaxy.gala100.net##.metaRedirectWrapperTopAds
@@ -8431,6 +8423,7 @@ flylink.io##+js(aopr, app_vars.force_disable_adblock)
 ! https://forums.lanik.us/viewtopic.php?f=62&t=40238
 gameofporn.net##.video-banner-close-play
 
+! https://github.com/uBlockOrigin/uAssets/pull/1625
 ! https://github.com/uBlockOrigin/uAssets/issues/3240
 @@||r7.com^$ghide
 r7.com###vertical-header-ads
@@ -12147,7 +12140,7 @@ naszraciborz.pl##+js(aopw, adBlockDetected)
 brainly.*,eodev.com,znanija.com##+js(aeld, message, data.slice)
 brainly.*,eodev.com,znanija.com##+js(nostif, trigger, 0)
 brainly.*,eodev.com,znanija.com##+js(aopr, localStorage)
-@@*$ghide,domain=brainly.com|brainly.com.br|brainly.co.id|brainly.in|brainly.in|brainly.lat|brainly.ph|brainly.pl|brainly.ro|eodev.com|znanija.com
+@@*$ghide,domain=brainly.com|brainly.com.br|brainly.co.id|brainly.in|brainly.lat|brainly.ph|brainly.pl|brainly.ro|eodev.com|znanija.com
 brainly.*,eodev.com,znanija.com##.js-scroll-to-unlock-section.brn-kodiak-answer-redesigned__unlock
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4647
@@ -12295,7 +12288,6 @@ acortar.xyz##+js(set, Ok, true)
 dclinks.info##+js(aeld, DOMContentLoaded, adlinkfly)
 ||acortar.xyz^$popunder
 ||lovquiz.com^$popunder
-@@||acortar.xyz^$ghide
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4718
 dutchycorp.*##+js(aopr, app_vars.force_disable_adblock)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt`

### Describe the issue

I noticed this afternoon that there were some superfluent `$ghide` entries in uAssets Main. For instance, there was both `@@||r7.com^$ghide` and `@@||player.r7.com^$ghide`; as well as both `@@||acortar.*^$ghide` and `@@||acortar.xyz^$ghide`. So I decided to trim them a bit. This affects entries for 6 websites, from what I can see.

### Screenshot(s)

N/A

### Versions

- Browser/version: Chrome 88.0.4324.150 x64
- uBlock Origin version: uBO 1.33.3b1

### Settings

N/A

### Notes

`*$frame,3p,domain=vev.io` was also made superfluous by `*$frame,3p,domain=vev.io|vev.red|vidop.icu|vidup.io`