### PR TITLE
crackwatch.com - obsolete annoyance filter

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -394,9 +394,6 @@ experts-exchange.com##.navigationWrapper:style(top: 0px !important;)
 digitalsynopsis.com##+js(aopr, disableSelection)
 digitalsynopsis.com##+js(aopr, document.oncontextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/issues/2805
-crackwatch.com##.ab.row
-
 ! https://forums.lanik.us/viewtopic.php?f=62&t=41301
 filefox.cc##+js(aeld, blur)
 


### PR DESCRIPTION
If they were added for a banner about ad blocking or whatever, then they are useless.