### PR TITLE
Removal of bokarsolutions.co.uk from filters.txt

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -6054,7 +6054,6 @@ seehd.*##+js(nowebrtc)
 seehd.*##+js(nowoif)
 ||seehd.*/sw.js$script,1p
 @@||seehd.*^$ghide
-||bokarsolutions.co.uk^$3p
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=40741
 mangaku.*##+js(nowebrtc)


### PR DESCRIPTION
Is it possible to have the domain removed ?

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`[At least one URL for a web page where the clearly described issue occurs is **mandatory**. The backticks surrounding the URLs is important, it prevents the URL from being clickable. Warn with "NSFW" where applicable.]`

### Describe the issue

I'm not sure how this works, however, I am the owner of bokarsolutios.co.uk and i can assure you we don't publish or promote any advertising through our domain. The domain/PR which is tight too, is a client of ours that used our user behaviour platform to monitor it's website traffic and uptime.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: [here]
- uBlock Origin version: [here]

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes
I can provide proof of the above statement and request, if needed. 