### PR TITLE
Update filters for paramountplus.com

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -1889,16 +1889,11 @@ syriancivilwarmap.com##+js(aopw, lockMap)
 ||cloudfront.net/ads/img/*$image,redirect=1x1.gif,domain=cbs.com
 ||fastly.net^$image,important,redirect=2x2.png,domain=cbs.com
 ||fastly.net^$script,important,redirect=noopjs,domain=cbs.com
+@@||paramountplus.com^$ghide
 @@||cbs.com^$ghide
-cbs.com##+js(set, cbsplayer.hasAdBlocker, false)
-*$3p,script,redirect-rule=noopjs,domain=cbs.com
-@@||vidtech.cbsinteractive.com^$script,domain=cbs.com
-@@||cbsi.com^$script,domain=cbs.com
-@@||cbsstatic.com^$script,domain=cbs.com
-@@||recurly.com/*/recurly.js$script,domain=cbs.com
-@@||gstatic.com/cv/js/sender/v1/cast_sender.js$script,domain=cbs.com
+cbs.com,paramountplus.com##+js(set, hasAdBlocker, false)
+*$3p,script,redirect-rule=noopjs,domain=cbs.com|paramountplus.com
 @@||s0.2mdn.net/instream/html5/ima3.js$script,domain=cbs.com|paramountplus.com
-@@||optimizely.com/js/geo2.js$script,domain=cbs.com
 ! CNAME
 !#if env_firefox
 ||fastly.net^$script,important,domain=cbs.com,badfilter


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Testing the new `paramountplus.com` and previous `cbs.com` videos.

`https://www.cbs.com/shows/face-the-nation/video/FUKHMXtmgxfShWFqi364v3oEadoHCHFs/3-7-strassmann-fauci-murphy-justice-crump-palmer-gottlieb/`

and `https://www.paramountplus.com/shows/the-late-show-with-stephen-colbert/video/x1gpE9i_RZIkK4ia5SOGt3o9i4C0OaqG/bahamas-ft-lucius-less-than-love-/`

### Describe the issue

Prevent Anti-adblock on Paramount plus

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave
- uBlock Origin version: `1.33.2`

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Just a clean up of previous cbs all access, which is used on some videos. Most clips/videos are now on Paramount Plus.

generichide for paramountplus is needed here. The rest of the filters aren't needed
