### PR TITLE
Fix amp.reddit.com app popup request

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -2818,6 +2818,9 @@ cnbc.com##+js(nostif, nrWrapper, 0)
 ! https://github.com/uBlockOrigin/uAssets/issues/6826
 reddit.com##.XPromoPopup
 reddit.com##body.scroll-disabled:style(overflow: visible!important; position: static!important;)
+reddit.com##.XPromoInFeed
+amp.reddit.com##.AppSelectorModal__body
+amp.reddit.com##.upsell_banner
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/42495#issuecomment-574761083
 @@||metropoles.com^$ghide


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Fix mobile app requirement for amp.reddit.com` (mobile UA needed)

### Describe the issue

[Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder.]
Visiting `https://amp.reddit.com/r/Hololive/comments/m0ylz9/nice_to_meet_you/`  stop overlay and popup 



### Versions

- Browser/version: Brave
- uBlock Origin version: 1.33.2

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Popup is slightly different on amp vs www.