### PR TITLE
Update filters-2021.txt

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -1163,9 +1163,13 @@ fastcoin.ga##div[style="height: 90px;"]
 sunhope.it##+js(nosiif, document.getElementById, 10000)
 
 ! propeller crap & adshares
-1080phds.com,123-watch.com,123moviesco.site,1kmovies.org,1movies.is,afilmyhouse.blogspot.com,antmovies.tv,antsmovies.com,europix.us,fmoviess.site,freeload.*,hdmoviehubs.in,keepv.id,la123movies.site,linkswhat.com,maamusiq.com,movi.pk,rdxhd.thesouthflix.com,shortlinkto.top,soap2day.to,thelinkbox.*,timesofurdu.website,tnmoviez.net,veryfastdownload.pw,watch4hd.*,watchfullmovies.pk,yify.stream,ylink.bid,yt1s.com##+js(acis, String.fromCharCode, break;case)
-1jalshamoviez.*,9animez.com,bitlypro.xyz,driveapp.in,filmygod.live,gdrive4pro.xyz,gdshare.xyz,gpfast.xyz,hblinks.*,hdmoviehubs.in,indidrive.in,linkrit.*,linksfire.*,moviesflix.net.in,moviesflix.one,moviespur.club,thelinkbox.*,themoviesverse.com,urlflix.*##+js(acis, Math.imul)
-1jalshamoviez.*,9animez.com,bitlypro.xyz,driveapp.in,filmygod.live,gdrive4pro.xyz,gdshare.xyz,gpfast.xyz,hblinks.*,hdmoviehubs.in,indidrive.in,linkrit.*,linksfire.*,moviesflix.net.in,moviesflix.one,moviespur.club,thelinkbox.*,themoviesverse.com,urlflix.*##^script:has-text(Math.imul)
+1080phds.com,123-watch.com,123moviesco.site,1kmovies.org,afilmyhouse.blogspot.com,antsmovies.com,europix.us,fmoviess.site,freeload.*,hdmoviehubs.*,keepv.id,linkswhat.com,maamusiq.com,movi.pk,rdxhd.thesouthflix.com,shortlinkto.top,soap2day.*,thelinkbox.*,timesofurdu.website,tnmoviez.net,veryfastdownload.pw,watch4hd.*,yify.stream,ylink.bid,yt1s.com##+js(acis, String.fromCharCode, break;case)
+1jalshamoviez.*,9animez.com,bitlypro.xyz,driveapp.in,filmygod.live,gdrive4pro.xyz,gdshare.xyz,gpfast.xyz,hblinks.*,hdmoviehubs.*,indidrive.in,linkrit.*,linksfire.*,moviesflix.net.in,moviesflix.one,moviespur.club,thelinkbox.*,themoviesverse.com,urlflix.*##+js(acis, Math.imul)
+1jalshamoviez.*,9animez.com,bitlypro.xyz,driveapp.in,filmygod.live,gdrive4pro.xyz,gdshare.xyz,gpfast.xyz,hblinks.*,hdmoviehubs.*,indidrive.in,linkrit.*,linksfire.*,moviesflix.net.in,moviesflix.one,moviespur.club,thelinkbox.*,themoviesverse.com,urlflix.*##^script:has-text(Math.imul)
+
+!#if env_mobile
+rdxhd.thesouthflix.com##^script:has-text(break;case $.)
+!#endif
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8589
 pcgamer.com##+js(aopr, _sp_._networkListenerData)
@@ -1753,3 +1757,6 @@ grabitbd.xyz##+js(acis, document.addEventListener, innerHTML)
 ! https://github.com/easylist/easylist/issues/7400
 bhaskar.com##[id^="Ad"]:upward([style])
 divyabhaskar.co.in##[id^="Ad"]:upward([style])
+
+!propeller crap/ads
+5xmovies.icu,linksmore.site,gdirect.site,animeheaven.ru,123films.cc,123moviesfx.live,akmm.linksme.xyz,filmy4wap1.online,uploadmaza.com,moviesmon.cyou,mp3songsdownloadf.blogspot.com,jattmate.com,dailymovieshub.com,vevoyoutube.com,linkshere.work,marvel.to,s2dfree.*##+js(acis, Math, break;case $.)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`5xmovies.icu,linksmore.site,gdirect.site,animeheaven.ru,123films.cc,123moviesfx.live,akmm.linksme.xyz,filmy4wap1.online,uploadmaza.com,moviesmon.cyou,mp3songsdownloadf.blogspot.com,jattmate.com,dailymovieshub.com,vevoyoutube.com,linkshere.work,marvel.to,s2dfree.*`

& changes to some sites in filters

### Describe the issue

propeller crap and popups

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera browser stable and firefox nightly android
- uBlock Origin version: 1.34

### Settings

-  uBO's default settings

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
