### PR TITLE
Update filters.txt

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -17575,9 +17575,8 @@ darmowa-telewizja.online##+js(acis, Math, zfgloaded)
 qoshe.com##+js(nostif, adBlock)
 yandexcdn.com##+js(nowoif)
 @@||yandexcdn.com^$ghide
-@@||yandexcdn.com^$script,xhr,1p
-@@||cdn.jsdelivr.net/npm/videojs-contrib-ads/$domain=yandexcdn.com
-@@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=yandexcdn.com
+@@||yandexcdn.com^$script,1p
+||yandexcdn.com/cdn-cgi/trace$xhr,1p
 
 ! https://github.com/NanoMeow/QuickReports/issues/1807
 filmux.org##+js(nowebrtc)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Direct url leads to 404 found error
1st need to go to `https://filmlinks4u.pro/the-girl-on-the-train-2021-movie-online-on-filmlinks4u/`
then `server 2`

### Describe the issue

update filters for `yandexcdn.com` ,removed some whitelist filters

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera browser stable
- uBlock Origin version: 1.34.1b2

### Settings

-  uBO's default settings

### Notes

review for all browsers pls 
