### PR TITLE
update 123hulu.com ads

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -12729,7 +12729,7 @@ link-to.net##.ad-block-1
 @@||the-hermeneutic-of-continuity.blogspot.com^$ghide
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4962
-123hulu.com##+js(acis, Math, zfgloaded)
+123hulu.com##+js(acis, Math, break;case $.)
 123movies.*##+js(acis, document.getElementsByTagName, setAttribute)
 123movies.*##+js(aopr, open)
 123movies.*##+js(set, lck, true)
@@ -12739,6 +12739,8 @@ link-to.net##.ad-block-1
 ||d13jhr4vol1304.cloudfront.net^
 ||oppfiles.com/common/scriptjs.php
 /jquery.watch.js|$script,1p,important,domain=~dekrantvantoen.nl
+||gompoozu.net^
+||taigrooh.net^
 
 ! https://forums.lanik.us/viewtopic.php?p=145787#p145787
 ! https://github.com/uBlockOrigin/uAssets/issues/7644


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`123hulu.com`

### Describe the issue

popup ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera stable
- uBlock Origin version: 1.34.1b2

### Settings

-  uBO's default settings

### Notes

