### PR TITLE
Fix rendering issue on golf.com due to gpt.js

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3922,6 +3922,9 @@ uschovna.cz##body:style(background-image:none !important)
 ! https://www.reddit.com/r/uBlockOrigin/comments/ku0jzx/please_allow_connatix_video_player/gsbkx1h/?utm_source=reddit&utm_medium=web2x&context=3
 @@||cd.connatix.com/connatix.player.js$script,domain=funker530.com
 
+! Fix https://golf.com/news/tour-confidential-match-play-concession-augusta-womens-am/
+@@||securepubads.g.doubleclick.net/tag/js/gpt.js$domain=golf.com 
+
 ! unbreak voe.sx download page
 ||3r1kwxcd.top^$popup,3p,badfilter
 ||3r1kwxcd.top^$popup,badfilter


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://golf.com/news/tour-confidential-match-play-concession-augusta-womens-am/`

### Describe the issue

As the page loads, the rendering will break (see screenshot below)

### Screenshot(s)

**Broken:**
![golfcom-broken](https://user-images.githubusercontent.com/1659004/112782441-8038a200-90a9-11eb-9d83-679139231d44.png)
**Fix via gpt exception:**
![golfcom-fix](https://user-images.githubusercontent.com/1659004/112782520-b83fe500-90a9-11eb-89f5-afa49bac05cd.png)


### Versions

- Browser/version: Brave
- uBlock Origin version: 1.34.0

### Settings

All the default uBO filters

### Notes

Was reported in https://community.brave.com/t/one-particular-webpage-wont-open-properly/224038/2  and in uBO.

Caused by `||securepubads.g.doubleclick.net/tag/js/gpt.js$script,redirect-rule=googletagservices_gpt.js`  Maybe a separate bug report for this? Possibly a bug in the gpt resource replacement.
