### PR TITLE
Fix Anti-adblock on metro.style

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -2046,7 +2046,7 @@ cargurus.com##[id^="bannerAdLEADERBOARD_INLINE_"]:upward(1)
 filmiseriali.com##+js(set, noAdBlock, true)
 
 ! Anti-adblock https://community.brave.com/t/metro-style-anti-adblock/224281
-@@||metro.style^$generichide 
+@@||metro.style^$ghide 
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/78704
 1link.vip##+js(set, blurred, false)

--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -2045,6 +2045,9 @@ cargurus.com##[id^="bannerAdLEADERBOARD_INLINE_"]:upward(1)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/78720
 filmiseriali.com##+js(set, noAdBlock, true)
 
+! Anti-adblock https://community.brave.com/t/metro-style-anti-adblock/224281
+@@||metro.style^$generichide 
+
 ! https://github.com/AdguardTeam/AdguardFilters/issues/78704
 1link.vip##+js(set, blurred, false)
 taisv.com##+js(nano-sib, counter)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://metro.style/people/digital-covers/metro-andrea-brillantes-18th-birthday-debut-shoot/29449` and wait a few seconds/click on a various links
 
### Describe the issue

Anti-adblock shows up

### Screenshot(s)

Overlay will show.

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.34.0

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
