### PR TITLE
uploadmoon.com anti adb warning

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -2114,3 +2114,6 @@ nerdy.vn##div[style^="width:320px"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8823
 discoveryplus.in##+js(no-fetch-if, ads)
+
+! uploadmoon.com anti adb warning
+uploadmoon.com##+js(aopr, absda)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://uploadmoon.com/d0zza24u4v51`

### Describe the issue

anti adb warning

### Screenshot(s)


![image](https://user-images.githubusercontent.com/20338483/113263315-3b05b180-92ef-11eb-92b4-dd1538f6defa.png)


### Versions

- Browser/version: Firefox 87
- uBlock Origin version: 1.34

### Settings

-  uBO's default settings

### Notes

