### PR TITLE
Remove arc.io from the resource abuse list. They switched from default opt in to require explicit user permission before using bandwidth.

### DIFF
--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -11,8 +11,6 @@
 
 ! https://github.com/uBlockOrigin/uAssets/issues/659
 /edgemesh.*.js$script,domain=~edgemesh.com|~edgeno.de
-! https://github.com/uBlockOrigin/uAssets/issues/5771
-||arc.io^$3p
 
 ! https://github.com/uBlockOrigin/uAssets/issues/803
 ||safelinkconverter.com^$script,3p


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://exploreatlas.co.uk/`
`https://arc.io/`

### Describe the issue

Hi guys! :wave:

I'm Ansgar. We (`https://arc.io/team`) build Arc (`https://arc.io/`), a
peer-to-peer bandwidth exchange and delivery network (CDN) that runs in
the browser.

Previously, Arc automatically connected to Arc's network and both
contributed/uploaded content to, and received/downloaded content from,
Arc's peer-to-peer network. No user action or permission was required.
And it was for this automatic, default behavior that Arc was added to
uBlock's resource abuse list.

However, six months months ago we changed Arc's behavior such that, in
the presence of adblock, Arc **requires user permission** and **doesn't
use any bandwidth** until the user explicitly opts in.

I created a page that showcases what this looks like here:

  * `https://arc.io/adblockDemo/`

So, what changed? Arc now

  1. Requests and requires explicit user opt in.

and

  2. No content is shared, or bandwidth used, until the user opts in.

And a user's opt in isn't permanent, either, of course. After opting in,
users can always later opt out through the widget, too. And Arc's widget
is always visible and interactible in the lower left corner of the page.

Since Arc no longer uses bandwidth without explicit user opt in, I
created this PR to remove Arc from uBlock's resource abuse list.

Thank you!

### Screenshot(s)

`http://i.imgur.com/8OI3XzA.png`

### Versions

- Browser/version: Chrome v87.0.4280.88
- uBlock Origin version: v1.34.0

### Settings

- Removed `arc.io` from uBlock's resource abuse list.

### Notes

Referencing Issue #5771.