### PR TITLE
Moved some workaround legacy-specific Nordic entries to here

### DIFF
--- a/filters/legacy.txt
+++ b/filters/legacy.txt
@@ -86,3 +86,30 @@ translatum.gr##+js(remove-attr, style, html[style="display: none;"])
 
 ! https://github.com/DandelionSprout/adfilt/issues/63#issuecomment-813028969
 bt.no##.disable-cogwheel
+
+! Previous workarounds for $domain wildcards in Dandelion Sprout's Nordic Filters
+/_bm/abd$script,domain=eurosport.no|eurosport.dk
+/entag.js$script,domain=eniro.no|eniro.dk|proff.no|proff.dk
+/insert_grtv_stats.$xhr,domain=gamereactor.no|gamereactor.dk
+/prerolls/*$domain=gamereactor.no|gamereactor.dk
+/videojs.ima.$script,domain=gamereactor.no|gamereactor.dk
+@@||fwmrm.net/ad/$image,xhr,domain=viafree.no|viafree.dk
+@@||fwmrm.net/crossdomain.xml$xhr,domain=viafree.no|viafree.dk
+@@||imasdk.googleapis.com/js/sdkloader/ima3.$script,domain=gamereactor.no|gamereactor.dk
+@@||mparticle.com^*/login$domain=discoveryplus.no|discoveryplus.dk
+@@||openx.gamereactor.dk/www/delivery/fc.php$xhr,domain=gamereactor.no|gamereactor.dk
+||akamai.net^$script,domain=eniro.no|eniro.dk
+||akamaihd.net^$media,domain=discoveryplus.no|discoveryplus.dk
+||client-stream-events.mtg-api.com^$domain=viafree.no|viafree.dk
+||dnitv.com^$media,domain=discoveryplus.no|discoveryplus.dk
+||freewheel-mtgx-tv.akamaized.net^$media,redirect=noopmp4,domain=viafree.no|viafree.dk
+||media.gamereactor.dk/*Promo$redirect=noopmp4,domain=gamereactor.no|gamereactor.dk
+||media.gamereactor.dk/prerolls$redirect=noopmp4,domain=gamereactor.no|gamereactor.dk
+||openx.gamereactor.dk/multi.php?$important,script
+||ssl.p.jwpcdn.com^*/freewheel.js$important,script,domain=eurosport.no|eurosport.dk
+||ssl.p.jwpcdn.com^*/jwpsrv.js$important,script,domain=eurosport.no|eurosport.dk|gamereactor.no|gamereactor.dk|vg.no
+||ssl.p.jwpcdn.com^*/sharing.js$important,script,domain=eurosport.no|eurosport.dk|gamereactor.no|gamereactor.dk
+||ssl.p.jwpcdn.com^*/vast.js$important,script,domain=eurosport.no|eurosport.dk|gamereactor.no|gamereactor.dk|vg.no
+!#if env_chromium
+||prod-adops-proxy.dnitv.net^$empty,domain=discoveryplus.no|discoveryplus.dk
+!#endif


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt`

### Describe the issue

Since https://github.com/gorhill/uBlock-for-firefox-legacy/issues/236 and https://github.com/gorhill/uBlock-for-firefox-legacy/issues/281 have been in limbo for 6 and 5 months respectively, I've chose to end my grace period today for when I've had [a temporary workaround](https://github.com/DandelionSprout/adfilt/blob/98c9520f04e7fa2de222e93eb59f9d665dc5b279/uBO%20list%20extensions/TemporaryWaterfoxClassicFixForNordicFilters.txt) `!#include` file for them.

I have thus chose to move such workaround entries to uAssets Legacy instead.

### Screenshot(s)

N/A

### Versions

N/A

### Settings

N/A

### Notes

There is technically the potential to extend the `Gamereactor` and `Eurosport` entries to their *many* other continental European domains as well. I'm no longer confident that the same would be possible for `Discovery Plus`, due to many AdGuard users in particular having problems with their sites.
