### PR TITLE
pogolinks.website popups

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -2588,3 +2588,7 @@ elitemacx86.com##+js(acis, $, samAdBlockAction)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8916
 movieverse.co#@#.ads_single_center
+
+! pogolinks. website popups
+pogolinks.*##+js(aost, Math.random, /\st\.[a-zA-Z]*\s/)
+


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://pogolinks.website/movies/pagglait-2021`
link came from `bollyholic.icu`

### Describe the issue

popup ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox Android nightly
- uBlock Origin version: 1.34

### Settings

- uBO's default settings

### Notes

