### PR TITLE
Address shortenmm. cf antiadblock & ads

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -2669,3 +2669,8 @@ wildfaucets.ml##div.row:nth-of-type(1) > .text-white.bg-primary.col-xs-12
 ! sabishare. com ads
 sabishare.com##+js(aost, Math.floor, /computed|\$\./)
 ##[href^="http://luvaihoo.com"]
+
+! shortenmm. cf antiadblock & ads
+shortenmm.cf##+js(aopr, app_vars.force_disable_adblock)
+shortenmm.cf##+js(aopr, open)
+shortenmm.cf##+js(aopw, atOptions)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://shortenmm.cf/o4KlJM5qc0`

### Describe the issue

Antiadblock and popup ads after captcha page

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera browser stable
- uBlock Origin version: 1.34.1b2

### Settings

-  uBO's default settings

### Notes

