### PR TITLE
Modify a filter to address ads

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -19818,7 +19818,7 @@ hexupload.net##+js(aopw, _pop)
 hexupload.net##+js(aopw, Fingerprint2)
 hexupload.net##+js(nowoif)
 *$script,3p,denyallow=bootstrapcdn.com|cloudflare.net|google.com|gstatic.com|hwcdn.net|jsdelivr.net|tawk.to,domain=hexupload.net
-||linkedgraceless.com^$3p
+||linkedgraceless.com^
 
 ! popups https://animetak .net/
 animetak.*##+js(acis, Math, zfgloaded)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://naijaray.com.ng/download-cracked-2020-latest-nollywood-blockbuster-movie/`
`https://moviesmaniac.in/download-pagglait-2021-netflix/`
`https://shortenmm.cf/6CxsYYj2Rknk`
### Describe the issue

popup ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera browser stable
- uBlock Origin version: 1.34.1b2

### Settings

-  uBO's default settings

### Notes

