### PR TITLE
Fix page lockups on https://apps.texas.aaa.com/aceapps/authenticate2/login

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3997,6 +3997,9 @@ youpouch.com##.native-ad
 ! https://github.com/uBlockOrigin/uAssets/issues/9016
 @@||powr.io/powr.js$script,3p
 
+! https://community.brave.com/t/aaa-texas-insurance-is-unresponsive-on-brave/243303/2 (Page timeouts)
+@@||tags.tiqcdn.com/utag/aaa/main/prod/utag.sync.js$script,domain=aaa.com
+
 ! https://github.com/uBlockOrigin/uAssets/issues/9018
 @@||fluid.4strokemedia.com/www/delivery/asyncspc.php^$xhr,domain=formulapassion.it
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js^$script,domain=formulapassion.it


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Loading `https://apps.texas.aaa.com/aceapps/authenticate2/login` will cause page timeouts/lockups

### Describe the issue

Page will lock up and stop working

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.34.0

### Settings

Caused by Peter Lowes list, `tiqcdn.com`

### Notes

Reported: https://community.brave.com/t/aaa-texas-insurance-is-unresponsive-on-brave/243303
