### PR TITLE
obsolete filter for bemiraculous.tk

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -1446,9 +1446,6 @@ xtube.com##.panelBottomSpace > li.pull-right
 xtube.com##.removeAds
 xtube.com##body.desktopView.hasFooterAd .mainSection:style(margin-bottom: 0!important;padding-bottom: 0!important;)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/76548
-||googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect-rule=noop.js:10,domain=bemiraculous.tk
-
 ! https://github.com/AdguardTeam/AdguardFilters/issues/76681
 link.ltc24.com##+js(aopr, app_vars.force_disable_adblock)
 link.ltc24.com##+js(acis, String.fromCharCode, break)


### PR DESCRIPTION
There's also an obsolete filter for bemiraculous.tk in uBO's 'uBlock filters -- Annoyances'. I made a pull request the addresses it (https://github.com/uBlockOrigin/uAssets/pull/9034).