### PR TITLE
Fix anti-adblock on slate.com

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -5140,6 +5140,7 @@ lovepedia.net##+js(nobab)
 ! https://github.com/uBlockOrigin/uAssets/issues/1895
 slate.com##.adblock-message
 slate.com##body:style(overflow: visible !important;)
+||tinypass.com^$domain=slate.com
 
 ! https://github.com/uBlockOrigin/uAssets/issues/1897
 ! https://github.com/uBlockOrigin/uAssets/issues/2397


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Fix `slate.com` Anti-adblock overlay

### Describe the issue

Open slate.com, and open an article.

### Screenshot(s)

![slate com](https://user-images.githubusercontent.com/1659004/117558023-4fe31b00-b0cd-11eb-8801-6cbd1a06b951.png)


### Versions

- Browser/version: Brave
- uBlock Origin version: 1.35.2

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Tinypass serving up anti-adblock messages, and no way around it.