### PR TITLE
obsolete filters

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -1091,11 +1091,6 @@ kissasian.*###leftside .adsbyvli:upward(div[style$="height: 90px;"])
 ||wedgeenclosed.com^
 gaobook.*##+js(aopr, Date.prototype.toUTCString)
 
-! https://www.reddit.com/r/uBlockOrigin/comments/bcpexv/australianfrequentflyercomau_ad_detector/
-! https://github.com/NanoMeow/QuickReports/issues/2384
-australianfrequentflyer.com.au##+js(nobab)
-australianfrequentflyer.com.au##+js(acis, $, adsBlocked)
-
 ! admiral
 ! https://github.com/uBlockOrigin/uAssets/issues/6897
 ! https://github.com/NanoMeow/QuickReports/issues/3083


### PR DESCRIPTION
I added 
```
australianfrequentflyer.com.au#@#+js(nobab)
australianfrequentflyer.com.au#@#+js(acis, $, adsBlocked)
```
to 'My filters' and did not encounter any anti adb afterwards.