### PR TITLE
obsolete filter

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -7126,9 +7126,6 @@ undeniable.info##+js(acis, document.getElementById, testadblock)
 @@||3bmeteo.com^$ghide
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=3bmeteo.com
 
-! https://github.com/uBlockOrigin/uAssets/issues/2822
-morgenweb.de##+js(set, blockAdBlock, true)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/2821
 @@||mackie100projects.altervista.org^$ghide
 mackie100projects.altervista.org##.adsbygoogle


### PR DESCRIPTION
I think I got redirected from `https://www.morgenweb.de` to `https://www.mannheimer-morgen.de/`.