### PR TITLE
obsolete filter

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -11747,6 +11747,10 @@ animeyt.org###dimmed
 ! https://github.com/NanoMeow/QuickReports/issues/657
 @@||pencurimovie.*^$ghide
 
+! https://github.com/uBlockOrigin/uAssets/issues/4847
+mozdream.live##+js(aopr, app_vars.force_disable_adblock)
+*$frame,domain=mozdream.live
+
 ! https://github.com/uBlockOrigin/uAssets/issues/4850
 arab-dollar.com##+js(aopr, app_vars.force_disable_adblock)
 
@@ -13007,7 +13011,6 @@ egydead.com##.FooterAds
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5274
 earnwithshortlink.com##+js(aopr, app_vars.force_disable_adblock)
-earnwithshortlink.com##+js(aopw, _pop)
 earnwithshortlink.com##+js(nowebrtc)
 earnwithshortlink.com##+js(set, blurred, false)
 *$script,3p,denyallow=google.com|gstatic.com|recaptcha.net,domain=earnwithshortlink.com


### PR DESCRIPTION
`earnwithshortlink.com##+js(aopw, _pop)` is obsolete unless there is a popup or a popunder that gets closed very fast.