### PR TITLE
Peacebanana tracking

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -267,3 +267,6 @@ kruidvat.nl##.async-hide:style(opacity:1.0 !important)
 
 ! https://search.brave.com/search?q=Chromium
 ||search.brave.com/api/feedback?t=telemetry^
+
+! Tracking
+||flaming.peacebanana.com^


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.vpnmentor.com/tools/test-the-great-china-firewall/`

### Describe the issue

flaming.peacebanana.com appears to be a tracking/analytics endpoint

### Screenshot(s)

![](https://cdn.riverside.rocks/a/clematis-jaw-cuticle.png)

### Versions

- Browser/version: Firefox/89
- uBlock Origin version: v1.36.0

### Settings

- Add flaming.peacebanana.com
