### PR TITLE
Add bbc [data-e2e="advertisement"]

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -22096,6 +22096,9 @@ techdracula.com##.adsbygoogle
 ! https://github.com/easylist/easylist/issues/6476
 /^https?:\/\/[0-9a-z]{7,16}\.(?:com|pw|site)\/[a-z](?=[0-9A-Z]{0,15}[a-z])(?=[0-9a-z]{0,14}[A-Z])(?=[a-z]{0,13}[0-9A-Z])[0-9a-zA-Z]{10,16}\/(?:[1-3]\d{4}|[4-9]\d{3})(\?_=\d+)?$/$script,3p,match-case
 
+! bbc data-e2e
+www.bbc.com##[data-e2e="advertisement"]
+
 ! As of 2020-04-09, new filters will be added to year-based sublists
 
 !#include filters-2020.txt


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

www.bbc.com


### Describe the issue

Blocks the elements with `data-e2e` attribute being set to `advertisement`.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/56330238/124267467-e6e0b800-dafd-11eb-83e9-4ce90039f1b4.png)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: all
- uBlock Origin version: the latest as of now

### Settings

The defaults

### Notes

