### PR TITLE
addresses https://www.reddit.com/r/uBlockOrigin/comments/oagwfe/roblox_sponsored_ads_on_search_results/

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -4180,3 +4180,6 @@ igggames.unblocker.pro##.adstg
 
 ! https://github.com/uBlockOrigin/uAssets/pull/9517
 skidrow-games.com##+js(acis, JSON.parse, break;case $.)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/oagwfe/roblox_sponsored_ads_on_search_results/
+roblox.com##.game-tile.game-card:has-text(/Sponsored Ad/i)


### PR DESCRIPTION
I already reported this to EasyList -- https://github.com/easylist/easylist/issues/8267

Example of an ad encountered after searching "tycon" on Roblox.com while being logged-in: 
![image](https://user-images.githubusercontent.com/86536735/124325235-08d54b80-db8d-11eb-9d8a-bc05bfe04575.png)
