### PR TITLE
Fix blank screens showing on ultimateclassicrock.com

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4163,6 +4163,10 @@ taiju-life.co.jp#@#.spLinks
 ! https://github.com/uBlockOrigin/uAssets/issues/9576
 @@||boots.*/wcsstore/eBootsStorefrontAssetStore/javascript/Analytics.js$xhr,1p
 
+! Fix blank screens on ultimateclassicrock.com
+@@||google-analytics.com/analytics.js$script,redirect-rule=google-analytics.com/analytics.js,domain=ultimateclassicrock.com
+@@||googletagmanager.com/gtm.js$script,redirect-rule=googletagmanager.com/gtm.js,domain=ultimateclassicrock.com
+
 ! unito.life infinite call to keentracking
 unito.life##^script:has-text(KeenTracking)
 unito.life##+js(acis, KeenTracking)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Opening `https://ultimateclassicrock.com/` will display blanks screens

### Describe the issue

Loading site will initially show, then goes completely black.

### Screenshot(s)

Webpage is black

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.36.2

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Will Black screen on load and another a few seconds later, both filters are needed. Was reported in the forums https://community.brave.com/t/web-page-displayed-for-a-second-then-goes-black/265975/2

