### PR TITLE
Anti-adblock for zkillboard.com

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -4417,3 +4417,8 @@ new.gdtot.me##+js(acis, Math, break;case $.)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/9601
 viserve.com##^responseheader(location)
+
+! https://github.com/uBlockOrigin/uAssets/issues/9602
+zkillboard.com##+js(set, showAds, 0)
+zkillboard.com##+js(set, knowledgeCheck, noopFunc)
+


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`zkillboard.com

### Describe the issue

The website shows a fullscreen popup when an adblocker is detected

### Versions

- Browser/version: Firefox Nightly 92.0a1 (2021-07-18)
- uBlock Origin version: 1.36.2

### Settings

- Running default settings.
