### PR TITLE
Attempted fix for https://github.com/easylist/easylist/issues/5204

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4193,3 +4193,8 @@ unito.life##+js(acis, KeenTracking)
 ! Reported through email
 @@||googletagmanager.com^$redirect-rule,domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com
 @@||google-analytics.com^$redirect-rule,domain=invisibleoranges.com|nj1015.com|tasteofcountry.com|wyrk.com|xxlmag.com
+
+!#if env_firefox
+! https://github.com/easylist/easylist/issues/5204
+@@||gstaticadssl.l.google.com^$cname
+!#ifend


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://github.com/easylist/easylist/issues/5204`

### Describe the issue

I'm trying to demonstrate to the EasyList team that I should (and quite probably *must*) [be added to the EasyList GitHub team](https://github.com/easylist/easylist/issues/8430). Therefore, I'm going through very old EasyList reports to showcase that they really need me, and I found a report that seems to be specific to CNAME-blocking environments, thus would be better to re-delegate to uAssets Unblock.

### Screenshot(s)

N/A

### Versions

- Browser/version: Unknown
- uBlock Origin version: Unknown (Also unclear if the reporter was using uBlock Origin or AdGuard Home)

### Settings

N/A

### Notes

None that weren't covered in the issue description above.
