### PR TITLE
Adblock nag on afterdawn.com and alternativeto.net

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -4155,7 +4155,7 @@ ohmygirl.ml##+js(nosiif, visibility, 1000)
 hoodsite.com##+js(aopw, _pop)
 
 ! brave issue google funding
-globo.com,latimes.com##+js(nostif, f.parentNode.removeChild(f), 100)
+afterdawn.com,alternativeto.net,globo.com,latimes.com##+js(nostif, f.parentNode.removeChild(f), 100)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7970
 avimobilemovies.net,hackiee.mobi##+js(nowebrtc)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.afterdawn.com/`
`https://alternativeto.net/`

### Describe the issue

These sites have started to use adblock nag

### Screenshot(s)

![kuva](https://user-images.githubusercontent.com/17256841/126971112-40b14f80-4bc3-4853-8efa-dc56b39a7f9d.png)

![kuva](https://user-images.githubusercontent.com/17256841/126971170-c169b158-f099-40df-b613-ada4fac5025f.png)

### Versions

Firefox 90.0.2 
Ubo 1.37.1b1

### Settings

Default

### Notes

Nag seems to appear due to this is filter: `||fundingchoicesmessages.google.com^$3p`. I wonder if there were an universal solution to counter that for all domains that try to connect to that address? I hardly believe those two are the only ones using Google's funding choice.