### PR TITLE
Adblock nag on high.fi, download.fi, muropaketti.com

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -4156,7 +4156,7 @@ hoodsite.com##+js(aopw, _pop)
 
 ! Brave and Firefox issue google funding
 ! https://github.com/uBlockOrigin/uAssets/pull/9636
-afterdawn.com,alternativeto.net,globo.com,high.fi,latimes.com,muropaketti.com##+js(nostif, f.parentNode.removeChild(f), 100)
+afterdawn.com,alternativeto.net,download.fi,globo.com,high.fi,latimes.com,muropaketti.com##+js(nostif, f.parentNode.removeChild(f), 100)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7970
 avimobilemovies.net,hackiee.mobi##+js(nowebrtc)

--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -4156,7 +4156,7 @@ hoodsite.com##+js(aopw, _pop)
 
 ! Brave and Firefox issue google funding
 ! https://github.com/uBlockOrigin/uAssets/pull/9636
-afterdawn.com,alternativeto.net,globo.com,latimes.com##+js(nostif, f.parentNode.removeChild(f), 100)
+afterdawn.com,alternativeto.net,globo.com,high.fi,latimes.com,muropaketti.com##+js(nostif, f.parentNode.removeChild(f), 100)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7970
 avimobilemovies.net,hackiee.mobi##+js(nowebrtc)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://high.fi/`
`https://www.download.fi/`
`https://muropaketti.com/`

### Describe the issue

The same as: https://github.com/uBlockOrigin/uAssets/pull/9636

### Screenshot(s)

The same as: https://github.com/uBlockOrigin/uAssets/pull/9636

### Versions

Firefox 90.0.2
Ubo 1.37.1b1

### Settings

Default

### Notes

The same as https://github.com/uBlockOrigin/uAssets/pull/9636.

Could there be some kind of universal solution to counter this on all websites? I believe this is even more widely used.
