### PR TITLE
Revert "Adblock nag on high.fi and muropaketti.com (#9637)"

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -4157,7 +4157,7 @@ hoodsite.com##+js(aopw, _pop)
 
 ! Brave and Firefox issue google funding
 ! https://github.com/uBlockOrigin/uAssets/pull/9636
-afterdawn.com,alternativeto.net,download.fi,globo.com,high.fi,latimes.com,muropaketti.com##+js(nostif, f.parentNode.removeChild(f), 100)
+afterdawn.com,alternativeto.net,globo.com,latimes.com##+js(nostif, f.parentNode.removeChild(f), 100)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7970
 avimobilemovies.net,hackiee.mobi##+js(nowebrtc)


### PR DESCRIPTION
fixed in https://github.com/gorhill/uBlock/commit/f392d09a13640cd41fee091e6329421c36eaf63f