### PR TITLE
Redundant rule

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -222,9 +222,6 @@
 ||emarketer.com^$badfilter
 ||emarketer.com^$3p
 
-! https://github.com/uBlockOrigin/uAssets/issues/86
-@@||snoobi.com^$script,domain=sato.fi
-
 ! https://twitter.com/bdarfler/status/768540430988378112
 ! To counter Peter Lowe's `tapad.com`
 ||tapad.com^$badfilter


### PR DESCRIPTION
This entry, related to https://github.com/uBlockOrigin/uAssets/issues/86 seems to redundant.

That site doesn't use Snoopi anymore.