### PR TITLE
Redundant filter

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -317,9 +317,6 @@ kinopoisk.ru###image:style(opacity: 1 !important;)
 ||sumo.com^$3p,badfilter
 ||sumo.com^$3p,domain=~beewits.com|~dante-ri.hr
 
-! https://github.com/uBlockOrigin/uAssets/issues/420
-@@||sat.sanoma.fi^$script,domain=xxl.fi
-
 ! https://twitter.com/iSachinMaharana/status/870303158198611968
 ! To counter `sumo.com`, `sumome.com` in Peter Lowe's
 @@||sumo.com^$domain=shopify.com


### PR DESCRIPTION
Redundant filter, no connections to mentioned address.

Original report: https://github.com/uBlockOrigin/uAssets/issues/420

The given link in that issue report leads to a category that has no products. New sample link: https://www.xxl.fi/urheilu-ja-pallopelit/pelit/tikka/c/161402?sort=campaign

No issues whatsoever.