### PR TITLE
Redundant filter

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -1617,9 +1617,6 @@ kzstock.blogspot.com#@##ad-target
 ! https://github.com/uBlockOrigin/uAssets/issues/5395
 @@||app.tallo.com/assets/javascripts/app/studentstats/statCount.$script,1p
 
-! https://github.com/NanoMeow/QuickReports/issues/1059
-@@||kolumbus.fi/cgi-bin/counter.cgi$image,1p
-
 ! https://forums.lanik.us/viewtopic.php?f=64&t=42965
 ||olx.com.br^*/lurker.$badfilter
 


### PR DESCRIPTION
kolumbus.fi is not in use anymore, and the new domain it redirects, has no issues.

Related report: https://github.com/NanoMeow/QuickReports/issues/1059