### PR TITLE
Redundancies

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -9469,11 +9469,6 @@ multporn.net##+js(aopr, document.dispatchEvent)
 @@||ncaa.com^$ghide
 @@||adobedtm.com/*/satelliteLib-$script,domain=ncaa.com
 
-! https://github.com/uBlockOrigin/uAssets/issues/4039
-! https://forums.lanik.us/viewtopic.php?f=64&t=42161
-||nelonenmedia.fi/ads/$media
-@@||fwmrm.net/ad/$script,domain=ruutu.fi|nelonen.fi
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4040
 @@||itpro.co.uk^$ghide
 


### PR DESCRIPTION
These entries are not needed anymore, they are old and besides, adblocking for these domains are handled by the Finnish Easylist which is Ubo's stocklist these days.