### PR TITLE
obsolete filter

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -11387,9 +11387,6 @@ couchtuner.*##+js(set, atob, trueFunc)
 ||chidsimp.com^
 ||chograud.com^
 
-! https://github.com/NanoAdblocker/NanoFilters/issues/261
-@@||eneba.com^$ghide
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4713
 acortar.xyz##+js(aopr, adBlockDetected)
 acortar.xyz##+js(aeld, mousedown, trigger)


### PR DESCRIPTION
the filter added in response https://github.com/NanoAdblocker/NanoFilters/issues/261 is not needed as of typing this