### PR TITLE
Remove obsolete filters

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -1470,9 +1470,6 @@ thewirecutter.com#@#.deals-love
 @@||wlne.images.worldnow.com/ads/*.jpg?auto=web$image,domain=abc6.com
 @@||wlne.images.worldnow.com/ads/*.png$image,domain=abc6.com
 
-! https://forums.lanik.us/viewtopic.php?f=64&t=42718&p=146190#p146190
-||production.airswap.io^$badfilter
-
 ! https://github.com/easylist/easylist/issues/2935
 @@||src.fedoraproject.org/static/issues_stats.js$script,1p
 
@@ -1487,10 +1484,6 @@ thewirecutter.com#@#.deals-love
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5127
 @@||cdn.taplytics.com/taplytics.min.js$script,domain=es.wallapop.com
-
-! https://github.com/uBlockOrigin/uAssets/issues/5132
-@@||googletagmanager.com/gtm.js$script,domain=theatlantic.com
-@@||google-analytics.com/analytics.js$script,domain=theatlantic.com
 
 ! https://github.com/NanoMeow/QuickReports/issues/9#issuecomment-473751320
 |https://$xhr,domain=pornhub.com|redtube.com|redtube.com.br|tube8.com|tube8.es|tube8.fr|youporn.com|youporngay.com,badfilter


### PR DESCRIPTION
- `||production.airswap.io^` was removed from EP by https://github.com/easylist/easylist/commit/3f97440cc288f6cd9e71687b35162defcb56fe1e

- I can't reproduce https://github.com/uBlockOrigin/uAssets/issues/5132 now.