### PR TITLE
Iltalehti.fi quiz unbreak

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4207,4 +4207,4 @@ coolmathgames.com##+js(set, network_user_id, '')
 @@||player.avplayer.com/script/*/libs/hls.min.js$script,domain=bdnewszh.com
 
 ! https://github.com/uBlockOrigin/uAssets/pull/9811
-@@||www.googletagmanager.com/gtm.js$script,domain=www.iltalehti.fi
+@@||www.googletagmanager.com/gtm.js$script,domain=iltalehti.fi

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4206,5 +4206,5 @@ coolmathgames.com##+js(set, network_user_id, '')
 @@||player.avplayer.com/script/*/avcplayer.js$script,domain=bdnewszh.com
 @@||player.avplayer.com/script/*/libs/hls.min.js$script,domain=bdnewszh.com
 
-! Lowe's list blocks loading of quiz
+! https://github.com/uBlockOrigin/uAssets/pull/9811
 @@||www.googletagmanager.com/gtm.js$script,domain=www.iltalehti.fi

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4205,3 +4205,6 @@ coolmathgames.com##+js(set, network_user_id, '')
 ! https://github.com/uBlockOrigin/uAssets/issues/9802
 @@||player.avplayer.com/script/*/avcplayer.js$script,domain=bdnewszh.com
 @@||player.avplayer.com/script/*/libs/hls.min.js$script,domain=bdnewszh.com
+
+! Lowe's list blocks loading of quiz
+@@||www.googletagmanager.com/gtm.js$script,domain=www.iltalehti.fi


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.iltalehti.fi/kotimaa/a/7bda0d36-ad9d-4221-9f71-371881a1eb4f`

### Describe the issue

This rule `||googletagmanager.com^` in Lowe's list prevents loading of Cookie accept banner and thus prevents loading of a quiz.

### Screenshot(s)

![kuva](https://user-images.githubusercontent.com/17256841/130303614-806cee55-beac-4330-82e6-8d64056c13da.png)

After whitelisting:

![kuva](https://user-images.githubusercontent.com/17256841/130303657-9428882a-6522-4e37-945b-7f1113f79408.png)


### Versions

- Browser/version: Firefox 91.0.1
- uBlock Origin version: 1.37.2

### Settings

None, tested in clean Ubo

### Notes

```
Sisältöä ei voida näyttää evästeasetusten vuoksi. Nähdäksesi sisällön,
hyväksy evästeiden käyttö.
```

Translation:

```
Content can't be shown due to cookie settings. In order to see the content,
please accept cookies.
```

Whitelisting googletagmanager fixes the issue (cookies have to be accepted as well too).