### PR TITLE
Remove unnecessary whitespace

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -746,7 +746,7 @@ thepiratebay3.com^$all
 ||heartmedia.biz^$all
 ||beta-news.org^$all
 ||news-back.org^$all
- 
+
 ! https://github.com/NanoMeow/QuickReports/issues/4581
 ||installnow.xyz^
 


### PR DESCRIPTION
There's unnecessary whitespace in `badware.txt` which causes an error in the [linter](https://github.com/mjethani/flint).