### PR TITLE
address metro.co.uk anti-adb

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -5318,3 +5318,6 @@ quizlet.com##.StickyAdz
 quizlet.com##+js(rc, has-sidebar-adz|DashboardPage-inner, div[class^="DashboardPage-inner"], stay)
 quizlet.com##+js(rc, hasStickyAd, div[class^="SetPage"], stay)
 quizlet.com##+js(rc, has-adz, div, stay)
+
+! metro.co.uk anti-adb
+||cdn.metro.co.uk/base/metro-ab-dialog-v2/metroFeAdblockDialog.js$script,1p


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://metro.co.uk/`

### Describe the issue

Anti-adblock present

### Screenshot(s)

Before: 
![image](https://user-images.githubusercontent.com/17378596/131862621-d4eee37b-46ac-4ed7-9a4e-7a3574fcab3f.png)

After:
![image](https://user-images.githubusercontent.com/17378596/131862728-415e0f02-2b90-4384-bfd4-4501e7032841.png)

### Versions

- Browser/version: Google Chrome Version 93.0.4577.63 (Official Build) (64-bit)
- uBlock Origin version: uBlock Origin 1.37.2

### Settings

Default

### Notes

N/A