### PR TITLE
Punycode domains

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -1881,8 +1881,8 @@ wirkochen.at##.cookiesOverlay2Box
 wirkochen.at##.wrapper.blured:style(filter: none !important;)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5426
-österreich.at##.cookiesOverlay3
-österreich.at##.wrapper.blured:style(filter: none !important;)
+xn--sterreich-z7a.at##.cookiesOverlay3
+xn--sterreich-z7a.at##.wrapper.blured:style(filter: none !important;)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5427
 gesund24.at##.cookiesOverlay2


### PR DESCRIPTION
The domain `österreich.at` can be encoded as `xn--sterreich-z7a.at`, which makes it a _little_ more efficient and, more importantly, consistent with other filters in the same list.