### PR TITLE
Hide outlook.live.com anti adblock nag column

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -6239,3 +6239,6 @@ ijr.com##+js(acis, document.createElement, admiral)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/9895
 *$image,redirect-rule=1x1.gif,domain=guardian.gg
+
+! https://github.com/uBlockOrigin/uAssets/pull/9925
+outlook.live.com##div[class][tabindex="-1"][role=region][aria-label][data-min-width][data-max-width] ~ div[class][data-max-width="2400"] + div[class]

--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -377,10 +377,6 @@ digitalsynopsis.com##+js(aopr, document.oncontextmenu)
 ! https://forums.lanik.us/viewtopic.php?f=62&t=41301
 filefox.cc##+js(aeld, blur)
 
-! https://github.com/uBlockOrigin/uAssets/issues/3948
-! https://github.com/NanoMeow/QuickReports/issues/525
-outlook.live.com##a[href="https://windows.microsoft.com/outlook/ad-free-outlook"]:upward(4)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/3096 right click
 visionias.net##+js(acis, $, contextmenu)
 

--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -5342,3 +5342,5 @@ short.bestwego.xyz##+js(acis, eval, replace)
 
 ! https://github.com/uBlockOrigin/uAssets/pull/9919
 @@/wp-content/plugins/dh-anti-adblocker/*$script,1p
+
+outlook.live.com##div[class][tabindex="-1"][role=region][aria-label][data-min-width][data-max-width] ~ div[class][data-max-width="2400"] + div[class]

--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -5343,4 +5343,5 @@ short.bestwego.xyz##+js(acis, eval, replace)
 ! https://github.com/uBlockOrigin/uAssets/pull/9919
 @@/wp-content/plugins/dh-anti-adblocker/*$script,1p
 
+! https://github.com/uBlockOrigin/uAssets/pull/9925
 outlook.live.com##div[class][tabindex="-1"][role=region][aria-label][data-min-width][data-max-width] ~ div[class][data-max-width="2400"] + div[class]

--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -5364,6 +5364,3 @@ dinamalar.com##+js(aopr, checkAdBlocker)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/93501
 gagaltotal666.my.id##+js(acis, addEventListener, nextFunction)
-
-! https://github.com/uBlockOrigin/uAssets/pull/9925
-outlook.live.com##div[class][tabindex="-1"][role=region][aria-label][data-min-width][data-max-width] ~ div[class][data-max-width="2400"] + div[class]


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://outlook.live.com/mail/0/inbox`

### Describe the issue

There's a huge anti adblock nag column in Outlook. That column consists originally ads but when they are blocked, that column changes into a anti adblock nagging column, that takes a lot of space and prevents the full width usage of screen (it prevented it before as well though).

### Screenshot(s)

![kuva](https://user-images.githubusercontent.com/17256841/132086422-4ae04d0e-8712-4a3e-b20a-d490cef2a7d7.png)


After hiding you have the whole screen width available:

![kuva](https://user-images.githubusercontent.com/17256841/132086870-a16dfb07-9960-40f5-a99b-69d5d9a9c1bf.png)

Sorry, a lot of censorship :D...


### Versions

- Browser/version: [Firefox 91.0.2]
- uBlock Origin version: [1.37.3b21]

### Settings

The column will be visible with default uBO settings.

### Notes

That column is currently handled through uBO Annoaynce list, but I think that as that column prevents me from using the full width to read my emails, it should be considered rather as intrusive stuff, instead of a harmless Annoyance. But whatever way you decide to go with this, the current hiding rule in Annoyance list is very slow to hide it. My filter will hide it pretty quickly. It's safe to use, I have used a similar rule to hide it for a long time without any issues. I used a language specific version, but I made now a language neutral version of my rule.

My rule I have used for the Finnish UI Outlook:

`outlook.live.com##div[aria-label=Siirtymisruutu] ~ div[data-max-width="2400"] + div[class]`

English-language specific version of my rule original rule would be:

`outlook.live.com##div[aria-label="Navigation pane"] ~ div[data-max-width="2400"] + div[class]`

Language neutral, suggested rule:
`outlook.live.com##div[class][tabindex="-1"][role=region][aria-label][data-min-width][data-max-width] ~ div[class][data-max-width="2400"] + div[class]`

DOM tree if you don't have an account on MS services and you don't want to create a test account:

![kuva](https://user-images.githubusercontent.com/17256841/132087421-41bdb49a-cbeb-45b2-8e97-29a5338591eb.png)

The selected element is the one that I target.