### PR TITLE
[Annoyance] Chinese webpage folded content

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -6258,3 +6258,22 @@ info-beihilfe.de##+js(acis, document.oncontextmenu)
 ! https://github.com/uBlockOrigin/uAssets/issues/9951
 invado.pl##+js(aeld, /contextmenu|copy/)
 invado.pl##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
+
+! https://github.com/uBlockOrigin/uAssets/pull/9989
+! Chinese webpage folded content
+! blog.csdn.net
+blog.csdn.net##.btn_open_app_prompt_div
+blog.csdn.net##.btn_mod  
+blog.csdn.net##.readall_box
+blog.csdn.net##.feed-Sign-span  
+blog.csdn.net##.weixin-shadowboxdiv
+blog.csdn.net#$#.article_content { overflow: auto !important; height: auto !important; }
+
+! jianshu.com
+jianshu.com##.call-app-btn
+jianshu.com##.collapse-tips
+jianshu.com##.download-app-guidance
+jianshu.com##.dt-open-bg[data-scene="leftBtn"]
+jianshu.com##.note-comment-above-ad-wrap
+jianshu.com#$#.collapse-free-content { overflow: auto !important; height: auto !important; }
+jianshu.com#$#body { overflow: auto !important; }


### PR DESCRIPTION
Some Chinese pages collapse their content and when clicking on the "expand all content" widget, an annoying self-promotional message pops up recommending that the user open the app to continue reading (not mandatory).
Therefore, these rules automatically expand all the content of the article, avoiding those annoying self-promotions
Test address (using mobile UA) :
`https://blog.csdn.net/qq_33611327/article/details/104499375`
`https://www.jianshu.com/p/70208fbc8e43`
![Screenshot_2021-09-13-23-02-52-653_org mozilla firefox](https://user-images.githubusercontent.com/66902050/133109512-39d7b42a-02b2-4497-8817-b567a36ac96a.jpg)
![Screenshot_2021-09-13-23-03-10-966_org mozilla firefox](https://user-images.githubusercontent.com/66902050/133110032-13cc7fc6-5e46-454c-a75e-a52a663bcf2d.jpg)
Refence: https://github.com/AdguardTeam/AdguardFilters/pull/89571