### PR TITLE
Fix CNAME on https://online-booking.jaeger-lecoultre.com/domaine/theme7

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4257,3 +4257,6 @@ coolmathgames.com##+js(set, network_user_id, '')
 ! https://github.com/Yuki2718/adblock/issues/33 blocked by PL
 ||anrdoezrs.net^$badfilter
 ||anrdoezrs.net^$3p
+
+! CNAME breakage by Peter Lowe's 
+||smart-traffik.com^$badfilter

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4258,5 +4258,5 @@ coolmathgames.com##+js(set, network_user_id, '')
 ||anrdoezrs.net^$badfilter
 ||anrdoezrs.net^$3p
 
-! CNAME breakage by Peter Lowe's 
+! https://github.com/uBlockOrigin/uAssets/pull/10005 CNAME breakage by Peter Lowe's 
 ||smart-traffik.com^$badfilter


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://online-booking.jaeger-lecoultre.com/domaine/theme7`

### Describe the issue

CNAME breaking on website due to `smart-traffik.com`

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave and Firefox
- uBlock Origin version: `1.37.2`

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Filter was removed in [Easyprivacy](https://github.com/easylist/easylist/commit/68c4616b97b98e72ac59126ba80eddaad0b97107), no tracking seen on examples. 
