### PR TITLE
Address Adware

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1006,3 +1006,6 @@ thepiratebay3.com^$all
 ||serialkey89.com^$doc
 ||goharpc.com^$doc
 ||free4pc.org^$doc
+
+! https://github.com/uBlockOrigin/uAssets/pull/10017
+||flash.cn^$all


### PR DESCRIPTION
Adware link: `https://www.flash.cn/`(VPN to China may be required to prevent redirection)
The Chinese special version of Flash has an adware program bundled with it, if this program is removed, then Flash will not work
Report: `https://www.virustotal.com/gui/file/486c2ef133ea7fb96b8ac244ee3bb54b9a0536ac713608155070a622522fcbea`
![图片](https://user-images.githubusercontent.com/66902050/133544660-b5d4da4a-0c78-4460-8be8-82b02f7a7269.png)
