### PR TITLE
Make calendar.google.com's body takes full width

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -750,6 +750,9 @@ blacklistednews.com,datpiff.com#@#div > iframe
 ! https://github.com/reek/anti-adblock-killer/issues/4010
 @@||google-analytics.com/analytics.js$script,domain=developers.google.com
 
+! https://github.com/uBlockOrigin/uAssets/issues/10020
+calendar.google.com##body:style(width: 100%)
+
 ! https://github.com/uBlockOrigin/uAssets/issues/2101
 ||vidtech.cbsinteractive.com/*/tracking/comscore/comscore.streaming.$script,redirect=noopjs,domain=zdnet.com
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://calendar.google.com/calendar/u/0/r/week/2021/12/3

### Describe the issue

c.f. #10020 

### Screenshot(s)

c.f. #10020

### Versions

- Browser/version: Firefox 92.0
- uBlock Origin version: 1.37.2

### Settings

c.f. #10020

### Notes

c.f. #10020
