### PR TITLE
Remove anti adblock notice on ptable.com

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -5529,3 +5529,6 @@ sexmadeathome.com##+js(aopr, document.dispatchEvent)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10034
 nylondolls.com##+js(aopr, document.dispatchEvent)
+
+! https://github.com/easylist/easylist/issues/9121
+ptable.com##.Notice


### PR DESCRIPTION
### URL(s) where the issue occurs

`ptable.com`

### Describe the issue

Removes anti adblock notice at the top of the screen.

### Versions

- Browser/version: FF92
- uBlock Origin version: 1.37.2

