### PR TITLE
naszemargo.pl anti-adblock removal

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -6296,3 +6296,7 @@ cda-hd.cc,hqq.to##+js(set, document.oncontextmenu, null)
 ! https://github.com/uBlockOrigin/uAssets/issues/10040
 blogpascher.com##.CampaignFullscreen__bravoLayer
 blogpascher.com##html.om-position-popup body:style(overflow:auto !important)
+
+! ad block warning hover
+www.naszemargo.pl##+js(rc, rekl_test)
+


### PR DESCRIPTION
Removes anti-ablock warning on item hover in naszemargo.pl

### URL(s) where the issue occurs

`naszemargo.pl`

### Describe the issue

The site replaces item descriptions with a warning about using an ad-blocker.

### Screenshot(s)

![Zrzut ekranu 2021-09-20 194248](https://user-images.githubusercontent.com/65077813/134049043-5f278413-5d9f-41b3-a5d8-7a601ab9ecdd.png)

### Versions

- Browser/version: Chromium 93.0.4577.63
- uBlock Origin version: 1.37.2

### Notes

The site detects if an item of class "rekl_test" that contains the ads has height 0 or is invisible and if it's true it replaces all item descriptions with an ad-block notice. Removing the class fixes the issue.

```js
if (0 === $(".rekl_test").height() || 0 === $(".rekl_test").filter(":visible"))
...
```