### PR TITLE
ldjam 49 sponsor footer

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -5585,3 +5585,8 @@ unsplash.com##div[style^="--row-gutter"] > div a[href="/brands"]:upward(div[styl
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10055
 milanworld.net##+js(acis, $, test)
+
+! https://ldjam.com/events/ludum-dare/49 footer
+ldjam.com###sponsored-by
+ldjam.com###sponsored-by + p:has(img)
+ldjam.com###sponsored-by + p:has(img) + p:has(img)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://ldjam.com/events/ludum-dare/49`

### Describe the issue

Sponsor footer at the bottom of the event page

### Screenshot(s)

![image](https://user-images.githubusercontent.com/12688112/134433834-fe29af26-435c-4399-bf10-e6ec6bdc88f9.png)

### Reasoning

PR to uAssets due to the use of `:has()`. This is used in case text is added below the sponsor images.