### PR TITLE
Clickhouse Database now uses Clickhouse.com

### DIFF
--- a/thirdparties/pgl.yoyo.org/as/serverlist
+++ b/thirdparties/pgl.yoyo.org/as/serverlist
@@ -1442,7 +1442,6 @@
 127.0.0.1 clickedyclick.com
 127.0.0.1 clickfuse.com
 127.0.0.1 clickhereforcellphones.com
-127.0.0.1 clickhouse.com
 127.0.0.1 clickhype.com
 127.0.0.1 clicklink.jp
 127.0.0.1 clickmate.io


### PR DESCRIPTION
### URL(s) where the issue occurs

Trying to visit https://clickhouse.tech redirects to https://clickhouse.com. The content is clearly very similar if not identical to what was previously at https://clickhouse.tech.

### Describe the issue

Users of this filter list are greeted with a nasty error message when they try to read the legitimate documentation for this database product. It should be nonthreatening to read the docs for this database product.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Firefox 92.0
- uBlock Origin version: uBlock Origin 1.37.2

### Settings

No changes made.

### Notes

Previously, this address was used for something unsavory. Now, it hosts the documentation of a very popular open source database. Accessing the old address of clickhouse.tech redirects to clickhouse.com. It appears clickhouse database purchased the domain on 2021-09-09T13:19:20Z. This coincides roughly with their blog post about creating a separate company to house clickhouse as its own product: https://github.com/ClickHouse/ClickHouse/blob/master/website/blog/en/2021/clickhouse-inc.md