### PR TITLE
kiuruvesilehti.fi & urjalansanomat.fi scrolling limitation removal

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -5681,4 +5681,5 @@ nodejs.libhunt.com##[data-ref="saashub"]:upward(div.feed-item)
 instaanime.com##+js(nostif, length)
 instaanime.com##+js(nowoif)
 
+! https://github.com/uBlockOrigin/uAssets/pull/10087
 kiuruvesilehti.fi,urjalansanomat.fi##+js(acs, cm_limit)

--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -5682,4 +5682,4 @@ instaanime.com##+js(nostif, length)
 instaanime.com##+js(nowoif)
 
 ! https://github.com/uBlockOrigin/uAssets/pull/10087
-kiuruvesilehti.fi,urjalansanomat.fi##+js(acs, cm_limit)
+kiuruvesilehti.fi,urjalansanomat.fi##+js(aeld, scroll, innerHeight)

--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -5680,3 +5680,5 @@ nodejs.libhunt.com##[data-ref="saashub"]:upward(div.feed-item)
 ! https://www.reddit.com/r/uBlockOrigin/comments/px0zwg/antiadblock_detected_instaanimecom/
 instaanime.com##+js(nostif, length)
 instaanime.com##+js(nowoif)
+
+kiuruvesilehti.fi,urjalansanomat.fi##+js(acs, cm_limit)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://kiuruvesilehti.fi/`
`https://urjalansanomat.fi/`

### Describe the issue

When cookies are not accepted on these sites, they will limit your scrolling so that you can only scroll and view a small part of the site.

I know uAssets won't handle GDPR messages itself (I'm not asking) but hopefully this kind of anti user behavior will be dealt with.

### Versions

Firefox 92.0.1
uBo 1.38.1b2

### Settings

No need to change defaults

### Notes

Can be found from the DOM tree:

```
function cm_limit(elh) {
	window.scrollTo(0,0);
	var vh = window.innerHeight;
	if (vh > elh) elh = vh;
	cm_elh = elh;
	var doc = document.documentElement;
	window.addEventListener('scroll',function(e) {
		var vh = window.innerHeight;
		var allow = cm_elh; /* - vh + 0; */
		var top = (window.pageYOffset || doc.scrollTop)  - (doc.clientTop || 0);
		if (top > allow) 
			window.scrollTo(0, allow);
	});
}
```