### PR TITLE
address https://github.com/AdguardTeam/AdguardFilters/issues/96022

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -16371,9 +16371,11 @@ videos.giga.de##+js(set, requirejs.s.contexts._.defined.homad, noopFunc)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/39692#issuecomment-530184367
 hindimetoons.net##+js(aopw, adBlockDetected)
 
+! https://github.com/AdguardTeam/AdguardFilters/issues/96022
 ! https://github.com/NanoMeow/QuickReports/issues/1821
 birdurls.com##+js(acis, String.fromCharCode, /btoa|break/)
 birdurls.com##+js(aopr, app_vars.force_disable_adblock)
+birdurls.com##+js(nosiif, visibility, 1000)
 birdurls.com##+js(aopr, AaDetector)
 birdurls.com##+js(nowoif)
 birdurls.com###bg_popup


### PR DESCRIPTION
The reason I added `birdurls.com##+js(nosiif, visibility, 1000)` instead of adding `@@||birdurls.com^$ghide` and removing `birdurls.com##+js(aopr, app_vars.force_disable_adblock)` is because I wasn't sure if `@@||birdurls.com^$ghide` would create issues (like popups).