### PR TITLE
address https://github.com/AdguardTeam/AdguardFilters/issues/96109

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -5737,3 +5737,9 @@ reddit.com##.adLinkBar:upward(article[style="z-index: 1;"])
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10104
 @@||xtremestream.co^$ghide
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/96109
+melodelaa.link##+js(nosiif, visibility, 1000)
+melodelaa.link##p:not(.post-excerpt)
+melodelaa.link###HTML7
+melodelaa.link###HTML20


### PR DESCRIPTION
I chose `melodelaa.link##+js(nosiif, visibility, 1000)` instead of `@@||melodelaa.link^$ghide` due to the fact that I encountered an annoyance 