### PR TITLE
Malicious website

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1033,5 +1033,5 @@ thepiratebay3.com^$all
 ! https://github.com/uBlockOrigin/uAssets/issues/10116
 ||hentai-tube.me^$doc
 
-! https://uBlockOrigin/uAssets/pull/
+! https://uBlockOrigin/uAssets/pull/10142
 ||skyblockmods.com^$doc

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1032,3 +1032,6 @@ thepiratebay3.com^$all
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10116
 ||hentai-tube.me^$doc
+
+! https://uBlockOrigin/uAssets/pull/
+||skyblockmods.com^$doc


### PR DESCRIPTION
Malicious site: `skyblockmods.com`
this site distributes a Malicious jar that contains a RAT and is run by the same person that made `hypixelskyblock.net` (changed site because google sites shut their site down)

here is decompiled jar for proof (as its a jar using VirusTotal wont give much detections)
![image](https://user-images.githubusercontent.com/80456351/136024127-c5f8e61d-9990-47e9-b111-e0506c032264.png)

Site was deleted when i was working on this pr but knowing that person it will be back up soon