### PR TITLE
Add a new loadout.tf filter

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -6495,6 +6495,7 @@ zilinak.sk##+js(nostif, offsetHeight)
 @@||loadout.tf^$ghide
 loadout.tf##.loadout-application-advertisement-header
 loadout.tf##.adsbygoogle:upward(2):style(left-3000px !important;position:absolute !important)
+loadout.tf###aswift_0
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/71225
 ||raw.githack.com/Raqmedia/adblock/$script,3p


### PR DESCRIPTION
Previously, a random gray square would randomly appear to me. I think it is a leftover from the ad that was removed. Anyway, I am using this filter for more than three months and it did not cause any problems at all, so I think it is a good idea to add my filter to the global filter list.