### PR TITLE
Unblocking the criteo homepage

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4273,3 +4273,7 @@ xunta.gal#@##anuncio
 @@||network-n.com/configs/sites/the-loadout.json$xhr,domain=theloadout.com
 @@||live.primis.tech/live/live*.php$script,domain=theloadout.com
 @@||video.primis.tech$media,domain=theloadout.com
+
+! criteo
+||criteo.com^$badfilter
+||criteo.com^$3p

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4274,6 +4274,6 @@ xunta.gal#@##anuncio
 @@||live.primis.tech/live/live*.php$script,domain=theloadout.com
 @@||video.primis.tech$media,domain=theloadout.com
 
-! criteo
+! To counter `criteo.com` in Peter Lowe's
 ||criteo.com^$badfilter
 ||criteo.com^$3p


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.criteo.com/`

### Describe the issue

Access to criteo.com is strictly-blocked by peter lowes list.