### PR TITLE
Another Malicious Site

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1042,8 +1042,11 @@ thepiratebay3.com^$all
 ! https://github.com/uBlockOrigin/uAssets/issues/10116
 ||hentai-tube.me^$doc
 
-! https://uBlockOrigin/uAssets/pull/10142
+! https://github.com/uBlockOrigin/uAssets/pull/10142
 ||skyblockmods.com^$doc
 
 ! https://github.com/uBlockOrigin/uAssets/commit/5832dfebb4021c639b90c2973946ff7638c2290f#commitcomment-57642161
 ||foxmods.xyz^$doc
+
+! https://github.com/uBlockOrigin/uAssets/pull/
+||hypixel.run^$doc


### PR DESCRIPTION
Badware site: `hypixel.run`
Related: #10142 

I literary have no idea what to use a proof other then the screenshot of the site because the download url is not working and when it was working the jar was heavily obfuscated with branchlock

but i know its a SessionID/Token stealer

Screenshot of the site (ignore the outline)
![image](https://user-images.githubusercontent.com/80456351/136599283-83497519-4812-400b-a023-9fc30d2a5a5c.png)

Obfucated jar (Only thing that i found was a lot of fake webhooks and a lot of webhook send code)
![image](https://user-images.githubusercontent.com/80456351/136599664-c14ee8fb-2c54-4a64-b06b-bb3cdf2f9b92.png)
