### PR TITLE
Fix Slingtv.com plan changes due to tags.tiqcdn.com

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4233,3 +4233,6 @@ xunta.gal#@##anuncio
 ! https://github.com/easylist/easylist/pull/9356
 /adtech-$badfilter
 /adtech-$domain=~adtech-tokyo.com
+
+! Fix Slingtv, Adjust plan changes
+@@||tags.tiqcdn.com^$domain=sling.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`[At least one URL for a web page where the clearly described issue occurs is **mandatory**. The backticks surrounding the URLs is important, it prevents the URL from being clickable. Warn with "NSFW" where applicable.]`

### Describe the issue

Unable to change plans on slingtv.

### Screenshot(s)
![slingtv-changeservices](https://user-images.githubusercontent.com/1659004/136892698-59ce4398-0aca-4004-a5e7-acef002368d3.png)

Also a walkthrough in Brave (with/with sheilds enabled) (with tiqcdn blocked, then without)
![sling](https://user-images.githubusercontent.com/1659004/136892488-6e8853b0-8224-48e0-a71a-27e9ff32bea0.gif)

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.38.2

### Settings

Brave and/or UbO

### Notes

Caused by Peter Lowes block on `tiqcdn.com`
![image (13)](https://user-images.githubusercontent.com/1659004/136892371-94d3fb20-19aa-46b9-aa16-7d8f69cab5de.png)


