### PR TITLE
Update streameast filters

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -13704,21 +13704,22 @@ hqcelebcorner.net##+js(aopw, _pop)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5527
 ! https://github.com/uBlockOrigin/uAssets/issues/9710
-streameast.live##+js(acis, $, adblocker)
-streameast.live##+js(aeld, /^/, 0x)
-streameast.live##+js(aeld, DOMContentLoaded, showModal)
-streameast.live##+js(aopr, popjs.init)
-streameast.live##+js(nosiif, visibility, 1000)
-streameast.live##+js(nowebrtc)
-@@||streameast.live^$ghide
-@@||streameast.live^$script,1p
-*$xhr,redirect-rule=nooptext,domain=streameast.live
-streameast.live##[id^="Advertisement"]
+streameast.*##+js(acis, $, adblocker)
+streameast.*##+js(aeld, /^/, 0x)
+streameast.*##+js(aeld, DOMContentLoaded, showModal)
+streameast.*##+js(aopr, popjs.init)
+streameast.*##+js(nosiif, visibility, 1000)
+streameast.*##+js(nowebrtc)
+@@||streameast.$ghide
+@@||streameast.$script,1p
+*$xhr,redirect-rule=nooptext,domain=streameast.*
+streameast.*##[id^="Advertisement"]
 sportlive.*##+js(ra, onclick)
 hdstream365.com##+js(nowoif)
 streameast.live##div[class^="qddd"],div[class^="xddd"]
-*$image,redirect-rule=32x32.png,domain=streameast.live
-@@||club^$script,domain=streameast.live
+*$image,redirect-rule=32x32.png,domain=streameast.*
+@@||club^$script,domain=streameast.*
+@@||space^$script,domain=streameast.*
 livesport4u.com,pcast.pw,sportlive.site###localpp
 pcast.pw###ads
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.streameast.io/nba/los-angeles-lakers-golden-state-warriors-2/`
and 
`https://www.streameast.io/`

### Describe the issue

Convert to domain wildcard to cover streameast

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

![stream-anti](https://user-images.githubusercontent.com/1659004/138020032-92578610-7c52-45e3-a22a-76bdd0869322.png)
### Versions

- Browser/version: Brave
- uBlock Origin version: 1.38.6

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Just converted existing filters to cover the new domain.
