### PR TITLE
update propeller ads filters

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -1319,9 +1319,6 @@ babytorrent.*,eztv-torrent.net##+js(aopr, decodeURI)
 ! https://github.com/uBlockOrigin/uAssets/issues/8599
 brbushare.*##+js(acis, Math, break)
 
-! 123moviesla. haus popups - crap
-123moviesla.*##+js(acis, Math, zfgloaded)
-
 ! pops.tv anti-adb
 pops.tv#@##adsContainer
 pops.tv#@#.ad-placement


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
```
123-watch.com,123moviesla.sbs,123moviesprime.com,247movie.net,7025a.com,afilmyhouse.blogspot.com,antsmovies.com,attvideo.com,bioskopq.com,cinema.cimatna.com,convertitoremp3.download,crackevil.com,europix.*,foreverwallpapers.com,freeload.*,hdmoviehubs.*,keepv.id,maamusiq.com,megafilmestop.com,neomovies.net,saff-tv.net,shortlinkto.*,soap2day.*,thelinkbox.*,veryfastdownload.pw,watch4hd.*,yify.stream,ylink.bid,yt1s.com
```

### Describe the issue

popup ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox stable
- uBlock Origin version: 1.38.6

### Settings

- uBO's default settings

### Notes
