### PR TITLE
Address sonyliv.com antiadblock

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -6137,3 +6137,6 @@ dofusports.xyz##+js(aopw, _pop)
 dofusports.xyz##+js(nostif, debugger)
 ||rajabets.xyz^
 ||salync.com^
+
+! sonyliv. com antiadblock
+@@||sonyliv.com^$ghide


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.sonyliv.com/shows/taarak-mehta-ka-ooltah-chashmah-1700000084/sweater-day-1000047059?watch=true`


### Describe the issue

antiadblock preventing site access

### Screenshot(s)

![Screenshot_20211022-174504~2](https://user-images.githubusercontent.com/20338483/138459930-0851f325-bff9-4afa-9251-75b19b546311.png)


### Versions

- Browser/version: firefox android stable
- uBlock Origin version: 1.38.6

### Settings

-  uBO's default settings

### Notes

