### PR TITLE
www.elitepvpers.com

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -1704,7 +1704,6 @@ elitepvpers.com##[href="https://skyredirect1.com/"]
 elitepvpers.com##[src^="https://f00f00.bar/"]
 ||playorigin.com^$3p
 ||f00f00.bar^
-*$3p,image,domain=elitepvpers.com,denyallow=gstatic.com
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8706
 send.cm##+js(aopw, decodeURIComponent)


### PR DESCRIPTION
### URL(s) where the issue occurs

- everywhere
- `https://www.elitepvpers.com/forum/sro-pserver-advertising/ (pick one thread, you need to be registered to see images)`

### Describe the issue

This rule blocks all external images. It basically breaks every thread in the trading and advertising forums.

### Versions

ublock only

OS/version: Mac OS Catalina
Browser/version: Chrome 91.0.4472.77
Adblock Extension/version: ublock v1.36.2

### Settings

ublock defaults

### Notes

Hopefully this gets fixed before the inboxes of sellers (like me) explode again. It's really exhausting when rules are implemented without checking their impact, this one should have been obvious.
