### PR TITLE
Fix store fix selection on https://www.simon.com/mall/king-of-prussia/stores

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4223,3 +4223,6 @@ myair2.resmed.com##+js(no-xhr-if, cloudflare.com/cdn-cgi/trace)
 
 ! travelerdoor blocked request spam
 travelerdoor.com##+js(no-xhr-if, cloudflare.com/cdn-cgi/trace)
+
+! Store selection broken https://www.simon.com/mall/king-of-prussia/stores
+@@||googletagmanager.com/gtm.js$script,redirect-rule,domain=simon.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.simon.com/mall/king-of-prussia/stores`

### Describe the issue

Unable to select `Mens`  or  `Womens` etc (under the Center Directory)

### Screenshot(s)

![prussia](https://user-images.githubusercontent.com/1659004/140589681-60753eb1-723d-4035-b253-96f66e61f7db.png)

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.38.6


### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Fixes redirect, allows user to select in the Center Directory
