### PR TITLE
Fixes https://github.com/Crystal-RainSlide/AdditionalFiltersCN/issues/1

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -332,3 +332,6 @@ reddit.com##+js(no-xhr-if, method:POST url:/^https:\/\/www\.reddit\.com$/)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/qohky0/sfgatecom_images_blocked_when_using_the_ublock/
 ||cqrvwq.com^
+
+! https://github.com/Crystal-RainSlide/AdditionalFiltersCN/issues/1
+||ga.giuem.com^


### PR DESCRIPTION
> `ga.giuem.com` is a domain that hold google analysis proxy service, so users in china mainland can be tracked by google analysis. However, many users are not aware of being tracked by this.