### PR TITLE
Address videovard.sx antiadblock

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -5450,6 +5450,7 @@ videovard.sx##.jw-reset.jw-wrapper:style(z-index:2147483647 !important)
 videovard.sx##div[style="position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;"] > div[class]:first-child
 videovard.sx##div[style="position: absolute; left: 0px; top: 0px; width: 100%; height: 100%;"] > div[class]:nth-child(2)
 videovard.sx##+js(no-xhr-if, advert)
+videovard.sx##+js(aopr, FuckAdBlock)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/9971
 burakgoc.com##+js(aost, String.prototype.charCodeAt, ai_)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://videovard.sx/d/0hfd40eio9zv`

### Describe the issue

Antiadblock preventing download

### Screenshot(s)

https://user-images.githubusercontent.com/20338483/141647023-4a9d510d-567e-471a-b752-4c60dcdc662b.png


### Versions

- Browser/version: firefox android stable
- uBlock Origin version: 1.38.6

### Settings

-  uBO's default settings

### Notes
