### PR TITLE
Update filters.txt

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -11270,12 +11270,14 @@ foxseotools.com##.iframe-overlay
 ||bloggybro.com^$3p
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4698
-5movierulzfree.*,movierulzfree.*##+js(nowoif)
+movierulzfree.*,moviesrulzfree.*##+js(nowoif)
 movierulzlink.*,newmovierulz.*##+js(aopw, _pop)
 movierulzlink.*,newmovierulz.*##+js(aopr, String.fromCharCode)
-movierulzfree.*##.ad_btn-white
-movierulzfree.*,5movierulzfree.*##.ad_watch_now
+4movierulz.*,4movierulz1.*,movierulz4k.*,movierulzfree.*##.ad_btn-white
+4movierulz.*,4movierulz1.*,moviesrulz.*,movierulz4k.*,movierulzfree.*,moviesrulzfree.*,watchmovierulz.*##.ad_watch_now
 movierulzfree.*##.hd-buttons
+4movierulz.*,4movierulz1.*,moviesrulz.*,movierulz4k.*,moviesrulzfree.*##.btn1
+movierulz.*##+js(acis, Math, break;case $.)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4700
 9kmovies.*##+js(acis, Math, break;case $.)


### PR DESCRIPTION
**address movierulz & its variant ads**

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
5movierulzfree.me
moviesrulzfree.com
moviesrulz.net
movierulz4k.com
4movierulz1.com
4movierulz.live
movierulz.digital
```
### Describe the issue

popup ads, fake buttons
`5movierulzfree.me` redirects to `7movierulzfree.me` => filter not required as of now

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox a stable
- uBlock Origin version: 1.38.6

### Settings

-  uBO's default settings

### Notes
