### PR TITLE
obsolete filters

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -1543,14 +1543,8 @@ hpaudiobooks.*##^script:has-text('shift')
 gaydelicious.com##+js(aost, String.prototype.charCodeAt, ai_)
 gaydelicious.com##+js(aopw, _pop)
 
-! https://github.com/NanoMeow/QuickReports/issues/4045
-comandotorrents.org##+js(acis, Math, break;case $.)
-
 ! cinemablend.com anti-adb
 cinemablend.com##.affiliate_streaming_banner
-
-! eztvking .com ads
-eztvking.com##+js(acis, Math, zfgloaded)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/56923
 mondainai.moe##+js(nosiif, visibility, 1000)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
```
comandotorrents.org
eztvking.com
```
### Describe the issue

`comandotorrents.org` seized domain
`eztvking.com` redirects to adware sites

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox stable
- uBlock Origin version: 1.38.6

### Settings

- uBO's default settings

### Notes