### PR TITLE
close #10480

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -6820,3 +6820,7 @@ mlsbd.shop##+js(aost, Math.random, inlineScript)
 @@||tinytranslation.xyz^$ghide
 tinytranslation.xyz##.adsbygoogle
 tinytranslation.xyz###HTML5
+
+! https://github.com/uBlockOrigin/uAssets/issues/10480
+pollunit.com##.btn[href$="?feature=ads"]
+pollunit.com##.owl-carousel:has(.carousel-ad)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
`https://pollunit.com/polls/m6y_7gycdn3fjxvuavqvya`

### Describe the issue
Carousel ad and link to buy premium account are present on poll sites

### Screenshot(s)

### Versions

- Browser/version: Chrome 95.0.4638.69
- uBlock Origin version: 1.38.6

### Settings

### Notes

Cannot be added to easylist since generic blocks will break carousel on the main page - `href` regex and `:has` property are mandatory