### PR TITLE
fix ymovies/yseries ads

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -9046,10 +9046,9 @@ bisceglielive.it##+js(nostif, #rbm_block_active, 1000)
 bisceglielive.it##.mkt-300x250
 bisceglielive.it##.mkt-728x90
 
-! https://github.com/NanoMeow/QuickReports/issues/4730
-ymovies.*##+js(acis, Math, break;case $.)
+! ymovies. to/ yseries. tv popups
+ymovies.*,yseries.tv##+js(acis, JSON.parse, break;case $.)
 ymovies.*###banner_publi
-!*$script,3p,denyallow=cloudflare.com|google.com|facebook.net|fbcdn.net,domain=ymovies.*
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3853
 @@||townmoneysaver.com^$ghide


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`ymovies.to`
`yseries.tv`

### Describe the issue

popup ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox stable
- uBlock Origin version: 1.38.6

### Settings

- uBO's default settings

### Notes

filter from easylist
```
/^https?:\/\/.*.(club|bid|biz|xyz|site|pro|info|online|icu|monster|buzz|fun|website|biz|re|me|casa|top|one|space|network|live|work|systems|me|ml|world|life)\/.*/$3p,domain=123movies-one.com|123proxy.biz|2embed.ru|9xupload.xyz|baomay01.com|bdupload.asia|databasegdriveplayer.co|desiupload.co|dood.la|dood.to|dood.watch|dood.ws|downloadpirate.com|embedstream.me|filmesviatorrents.tv|flashx.net|flashx.tv|gogoplay1.com|moviepapa.sbs|pkcast123.me|powvideo.net|powvldeo.me|slreamplay.cc|sportsbayk.xyz|steanplay.cc|streamtape.com|streanplay.cc|vidembed.cc|videobin.co|yseries.tv
```
blocks 3p embed, reporting same to ryanbr

test link
`https://yseries.tv/foundation-s1-e8-the-missing-piece-625509/watching/`

click VSpider source