### PR TITLE
update https://github.com/uBlockOrigin/uAssets/issues/8112

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -4632,7 +4632,7 @@ forum.lunarisx.com##+js(acis, $, .test)
 ! https://github.com/uBlockOrigin/uAssets/issues/8112
 hubstream.in##+js(nostif, mdpDeBlocker)
 downloadhub.*,hubstream.*##+js(nowoif)
-downloadhub.*##+js(acis, Math, break;case $.)
+downloadhub.*##+js(acis, JSON.parse, break;case $.)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8116
 vvc.vc##+js(aopr, app_vars.force_disable_adblock)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://downloadhub.cfd/warning-2021-full-punjabi-movie-download/`

### Describe the issue

popups

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox a
- uBlock Origin version: 1.38.6

### Settings

-  uBO's default settings

### Notes