### PR TITLE
Address hdonline .co ads

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -6956,3 +6956,7 @@ flixmaza.*##+js(aopw, _pop)
 linkshere.*##+js(acis, JSON.parse, break;case $.)
 ||ymqcupkmpf.xyz^
 ||cqptijdeqvdpcpl.xyz^
+
+! hdonline. co ads
+hdonline.co##+js(acis, JSON.parse, break;case $.)
+||djdkgiwtgm.xyz^


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`hdonline.co`

### Describe the issue

popup ads in new tab

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox a
- uBlock Origin version: 1.38.6

### Settings

-  uBO's default settings

### Notes
