### PR TITLE
address popup ads meetdownload.com

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -6965,3 +6965,6 @@ hdonline.co##+js(acis, JSON.parse, break;case $.)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10533
 cricstream.*##+js(acis, JSON.parse, break;case $.)
+
+! meetdownload.com popups
+meetdownload.com##+js(acis, document.querySelectorAll, popMagic)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://meetdownload.com/7ebdfb9642354b8d95d3b5e8df9e4ba0/waploaded-1275-hungama-2-2021-hindi-mp4`
ref link 
`https://download.24baze.com/mp4-movie/hungama-2-2021-hindi/`

### Describe the issue

popups

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox a
- uBlock Origin version: 1.38.6

### Settings

-  uBO's default settings

### Notes
