### PR TITLE
Update badware.txt

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -912,6 +912,7 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||atnpx.com^
 ||bestoffer2021.info^
 ||best-prizehouse15.info^
+||best-winplace.life^
 ||checkup08.biz^
 ||getvottak.com^
 ||herdcowhas.icu^

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -912,7 +912,7 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||atnpx.com^
 ||bestoffer2021.info^
 ||best-prizehouse15.info^
-||best-winplace.life^
+||best-winplace.life^$all
 ||checkup08.biz^
 ||getvottak.com^
 ||herdcowhas.icu^


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://navdrillnet.com/hungama-2-2021-bollywood-movie/`
or searching google for hungama 2 movie free download brings some fake domains

### Describe the issue

going above url leads to malicious domain 
reports here `https://www.virustotal.com/gui/url/83b72889f652083a5b54a1c866f4dddc46628178aa42b34051deebb39a118991`

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox stable
- uBlock Origin version: 1.38.6

### Settings

-  uBO's default settings

### Notes
