### PR TITLE
Address bigyshare.com ads

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -7045,3 +7045,7 @@ gospeljingle.com##+js(aost, String.prototype.charCodeAt, [$.)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10584
 studybullet.com##+js(set, adsBlocked, false)
+
+! bigyshare .com popups
+bigyshare.com##+js(nowoif)
+||agaenteitor.com^


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://bigyshare.com/file/618f60e1962e5/Red-Notice-Full-Movie-Noregret-com-ng-mp4`

### Describe the issue

popup ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox stable
- uBlock Origin version: 1.38.6

### Settings

-  uBO's default settings

### Notes
