### PR TITLE
2 more badware urls

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1176,3 +1176,7 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||fasterfiles.net^$all
 ||steamkeygiveaway.net^$all
 ||yunosurveys.com^$all
+
+! https://github.com/uBlockOrigin/uAssets/pull/
+||mcdupe.com^$doc
+||shadyclient.net^$dox

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1177,6 +1177,6 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||steamkeygiveaway.net^$all
 ||yunosurveys.com^$all
 
-! https://github.com/uBlockOrigin/uAssets/pull/
+! https://github.com/uBlockOrigin/uAssets/pull/10620
 ||mcdupe.com^$doc
 ||shadyclient.net^$dox


### PR DESCRIPTION
`shadyclient.net` and `mcdupe.com`
are distributing Minecraft Session token stealers
Related to #10163 and #10142 (same person)

### Proof:
#### mcdupe.com 
![java_yD0WpLrRwB](https://user-images.githubusercontent.com/80456351/143620775-ee8acd1b-0ac0-4be8-b61c-1235037f1c4f.png)
Classes are named Class`some number here` because i used a Auto Rename plugin that makes code more readable
Used forge 1.8.9 mappings to make code more readable
#### shadyclient.net
![java_absoJXdooI](https://user-images.githubusercontent.com/80456351/143621242-dd80598f-0eb1-49d6-8c25-3b5aa0f8f578.png)
Used forge 1.8.9 mappings to make code more readable