### PR TITLE
Add domains

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1208,3 +1208,8 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||bit.ly/3p8kN5V^$document
 ||mediafire.com/file/at2tvnao5x6ivdo/EngineOwning.rar/$all
 ||download2264.mediafire.com/pnk44f5ci9rg/at2tvnao5x6ivdo/EngineOwning.rar^$all
+
+! same as above - hxxpx[:]//momupd[.]enuguhomes[.]com/download-winrar-crack/
+||momupd.enuguhomes.com^$all
+||fifxuq.granddidrepeat.top^$all
+||granddidrepeat.top^$document

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1201,3 +1201,10 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||oaesso.info^$document
 ||abcwkv.naturaloffsteam.top^$document
 ||bestlifeoffer20.com^$document
+
+! https://scammer.info/t/password-stealer/84348
+! https://bazaar.abuse.ch/sample/462a689d171f543c10efa08e963996d382585b67a6b298ec40d64f924adfb47a/
+||youtube.com/watch?v=8nY7SnvNxH4^$all
+||bit.ly/3p8kN5V^$document
+||mediafire.com/file/at2tvnao5x6ivdo/EngineOwning.rar/$all
+||download2264.mediafire.com/pnk44f5ci9rg/at2tvnao5x6ivdo/EngineOwning.rar^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1185,3 +1185,19 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ! https://github.com/uBlockOrigin/uAssets/pull/10620
 ||mcdupe.com^$all
 ||shadyclient.net^$all
+
+! https://github.com/iam-py-test/investigations/blob/main/2021/11/28/1.md
+||updsec.builtfromzero.com^$all
+||money-mod.com^$document
+||gospelchor.info^$document
+||smwgwa.brownbrothersilver.top^$document,popup
+||new.bestlifeoffer20.com^$document
+||reykijnoac.com^$document
+||totalnicefeed.com^$all
+||omnatuor.com^$all
+
+! https://github.com/iam-py-test/investigations/blob/main/2021/11/28/2.md
+||riteupd.mimanduca.co^$all
+||oaesso.info^$document
+||abcwkv.naturaloffsteam.top^$document
+||bestlifeoffer20.com^$document


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
https://updsec.builtfromzero.com/minecraft-apk-download-hack-version/
https://riteupd.mimanduca.co/minecraft-hack-game-free-download/
https://momupd.enuguhomes.com/download-winrar-crack/
https://www.youtube.com/watch?v=8nY7SnvNxH4
```

### Describe the issue

Unblocked scam websites, and a password-stealing trojan

### Screenshot(s)
![image](https://user-images.githubusercontent.com/84232764/143779546-829f4440-04dc-4cf7-9e86-9033f19805f7.png)
![image](https://user-images.githubusercontent.com/84232764/143779538-b69ec0e8-71c2-4108-9972-6332695d22d8.png)
![image](https://user-images.githubusercontent.com/84232764/143781677-771084f3-a163-46ab-959c-495d278b0a95.png)


### Steps to reproduce (for the first three):
- Go to the url
- Click Download
- Wait as it counts down
- Once done, click the download button in the popup
### Steps to reproduce (3)
- Go to the YouTube video
- Click on the Bit.ly link in the description and download the file from Mediafire
- Unarchive the file using the password _11111_
- Upload the files inside to VirusTotal and note that they are password-stealing trojans

### Versions

- Browser/version: Firefox 94.0.2
- uBlock Origin version: uBlock Origin 1.39.1b1

### Settings

- Advanced user mode: Enabled
- Dynamic filtering mode: Hard
- uBlock filters: All enabled
- Ads: All enabled
- Filterlists:
![image](https://user-images.githubusercontent.com/84232764/143779729-51472450-8996-4787-9f62-632c4e01bff4.png)
![image](https://user-images.githubusercontent.com/84232764/143779734-5c246b79-6c75-40d9-b084-ecc12f143f5d.png)


### Notes

More info at https://github.com/iam-py-test/investigations/blob/main/2021/11/28/1.md and https://github.com/iam-py-test/investigations/blob/main/2021/11/28/2.md. 
Judging by the fact that these two have the same UI & use the same domains in their redirects, they probably are related

The third one is the same as the two above, even redirects to the same domains:
![image](https://user-images.githubusercontent.com/84232764/143860232-92babac9-29b9-496c-9483-b29b50588d13.png)


The trojan is from https://scammer.info/t/password-stealer/84348 and has been reported at https://bazaar.abuse.ch/sample/462a689d171f543c10efa08e963996d382585b67a6b298ec40d64f924adfb47a/. For verification, look at https://bazaar.abuse.ch/sample/7984602d945d527e03c32cab6c7471ebf34ac8c74c400e318245a3ef24e419af/#intel