### PR TITLE
Fix https://github.com/easylist/easylist/issues/8173#issuecomment-981723362 - breakage

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -340,9 +340,6 @@ reddit.com##+js(no-xhr-if, method:POST url:/^https:\/\/www\.reddit\.com$/)
 ! https://github.com/easylist/easylist/pull/9687
 ||count.candou.com^
 
-! https://github.com/easylist/easylist/pull/9291
-||live-trace.bilibili.com^
-
 ! https://github.com/uBlockOrigin/uAssets/issues/10615#issuecomment-980221624
 @@||natureetdecouvertes.com^*/pixel.png$~third-party,badfilter
 


### PR DESCRIPTION
This rule results in not getting the little heart gift, please withdraw the PR
This rule is designed to track how long a user is on the air in order to obtain live gifts, not malicious tracking