### PR TITLE
Remove redundant filter

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -2707,7 +2707,6 @@ tipssehatcantik.com##+js(acis, disableSelection, reEnable)
 ! pelismart .com right click - select
 pelismart.com##+js(aopr, document.oncontextmenu)
 pelismart.com##+js(aopr, disableSelection)
-pelismart.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 pelismart.com##+js(aopr, onload)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7811


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
`https://github.com/uBlockOrigin/uAssets/blob/master/filters/annoyances.txt`

### Describe the issue

The filter `pelismart.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)` appears twice without reason.
So I removed it

### Screenshot(s)

Not needed

### Versions

- Browser/version: Mozilla Firefox 94.0.2
- uBlock Origin version: uBlock Origin 1.39.1rc0

### Settings

Not needed. 

### Notes

I used a Python script to go through this, but verified this manually. 
