### PR TITLE
Fix Mixpanel 1p issues on https://github.com/easylist/easylist/issues/9920

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -285,7 +285,7 @@ ppss.kr##.ppss-title-banner:remove()
 ||g.jwpsrv.com/g/gcid-*?notrack$frame
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10012
-homedepot.com,tacobell.com##+js(set, bmak.js_post, false)
+tacobell.com##+js(set, bmak.js_post, false)
 
 ! https://github.com/easylist/easylist/pull/9136
 ||cloudflare.com/ajax/libs/fingerprintjs2/$script,redirect=fingerprint2.js,important,domain=gamebox.gesoten.com

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -285,7 +285,7 @@ ppss.kr##.ppss-title-banner:remove()
 ||g.jwpsrv.com/g/gcid-*?notrack$frame
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10012
-tacobell.com##+js(set, bmak.js_post, false)
+homedepot.com,tacobell.com##+js(set, bmak.js_post, false)
 
 ! https://github.com/easylist/easylist/pull/9136
 ||cloudflare.com/ajax/libs/fingerprintjs2/$script,redirect=fingerprint2.js,important,domain=gamebox.gesoten.com

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4245,3 +4245,7 @@ saitama-np.co.jp#@#[id^="div-gpt-ad"]:style(width:1px!important;height:1px!impor
 ! https://www.reddit.com/r/uBlockOrigin/comments/qyx7en/
 ! Can be removed once 1.39.0 is widespread
 @@||amazon-adsystem.com/aax2/apstag.js$script,domain=sky.it
+
+! fix mixpanel 1p issues (Peter Lowes)
+! https://github.com/easylist/easylist/issues/9920
+||mixpanel.com^$badfilter


### PR DESCRIPTION


<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://mixpanel.com/project/2138137/view/290551/app/dashboards#id=639383`

### Describe the issue

Due to Peter Lowes list, blocking `mixpanel.com` causing first-party issues.

### Screenshot(s)

<img width="1430" alt="144368125-596d2790-4214-4ba6-a78b-0c00700df87e" src="https://user-images.githubusercontent.com/1659004/144507038-9fca4c9c-683e-47ed-9e79-aad0ac3def5c.png">
### Versions

- Browser/version: Brave
- uBlock Origin version: 1.38

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Easyprivacy blocks mixpanel already, so just badfiltering is best option here
