### PR TITLE
address vidsaver. net popup ads

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -7244,3 +7244,7 @@ sohexo.org###go-popup:remove()
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10699
 @@||themoviesboss.org^$ghide
+
+! vidsaver. net ads
+vidsaver.net##+js(acis, Math, /btoa|break/)
+vidsaver.net##^script:has-text(break;case $.)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://vidsaver.net/private-video-downloader`

### Describe the issue

popup ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox a stable
- uBlock Origin version: 1.39

### Settings

-  uBO's default settings

### Notes
