### PR TITLE
address antiadblock

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -7287,3 +7287,7 @@ gifhq.com##+js(aopr, exoNoExternalUI38djdkjDDJsio96)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/101821
 1337xx.to##+js(acis, globalThis, break;case)
+
+! ibomma. pw antiadblock
+ibomma.*###abEnabled:style(display: none !important;)
+ibomma.*###abDisabled:style(display: block !important;)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://ww6.ibomma.pw/a/manchi-rojulochaie-2021-watch-online.html`


### Describe the issue

Antiadblock preventing video access

### Screenshot(s)

https://user-images.githubusercontent.com/20338483/144671539-be46e121-17e2-4d1b-8dc4-040f67f16ddf.png


### Versions

- Browser/version: firefox a stable/firefox
- uBlock Origin version: 1.39

### Settings

-  uBO's default settings

### Notes