### PR TITLE
Fix BAB on torpedogratis.org

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -7293,5 +7293,8 @@ gifhq.com##+js(aopr, exoNoExternalUI38djdkjDDJsio96)
 ibomma.pw##[style="display:none"]:style(display: block !important;)
 ibomma.pw###abEnabled-note
 
+! torpedogratis.org (Bab fix)
+@@||torpedogratis.org^$generichide
+
 ! https://github.com/uBlockOrigin/uAssets/issues/10722
 teevee.asia##+js(nostif, innerHTML)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.torpedogratis.org/`

### Describe the issue

Block adblock warning on viewing `https://www.torpedogratis.org/`

### Screenshot(s)

![bab-war](https://user-images.githubusercontent.com/1659004/144696000-f82f98b6-9aec-45c3-8494-1f66d126e850.png)


### Versions

- Browser/version: Brave	
- uBlock Origin version: 1.32

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

