### PR TITLE
Fix for huya

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -348,3 +348,7 @@ reddit.com##+js(no-xhr-if, method:POST url:/^https:\/\/www\.reddit\.com$/)
 ||alicdn.com/f/pcdn/i.php?
 ||ems.youku.com/event?
 ||pcapp-data-collect.youku.com^
+
+! https://github.com/uBlockOrigin/uAssets/pull/10610
+||statwup.huya.com^
+||va.huya.com^

--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -130,6 +130,4 @@ france.tv##+js(nowebrtc)
 ||sdkapi.douyucdn.cn/p2p?$xhr
 
 ! https://github.com/uBlockOrigin/uAssets/pull/10610
-||p2p.huya.com^$xhr
-||statwup.huya.com^
-||va.huya.com^
+! ||p2p.huya.com^$xhr


### PR DESCRIPTION
Although this domain uses unauthorized P2P technology. However, the blocking may cause lagging in the live stream (several users have already given this feedback). I have not found a suitable filtering rule for the time being, so I have removed it for now.