### PR TITLE
Move some filtering rules to Privacy

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -348,3 +348,7 @@ reddit.com##+js(no-xhr-if, method:POST url:/^https:\/\/www\.reddit\.com$/)
 ||alicdn.com/f/pcdn/i.php?
 ||ems.youku.com/event?
 ||pcapp-data-collect.youku.com^
+
+! https://github.com/uBlockOrigin/uAssets/pull/10610
+||statwup.huya.com^
+||va.huya.com^

--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -131,5 +131,3 @@ france.tv##+js(nowebrtc)
 
 ! https://github.com/uBlockOrigin/uAssets/pull/10610
 ||p2p.huya.com^$xhr
-||statwup.huya.com^
-||va.huya.com^

--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -130,4 +130,5 @@ france.tv##+js(nowebrtc)
 ||sdkapi.douyucdn.cn/p2p?$xhr
 
 ! https://github.com/uBlockOrigin/uAssets/pull/10610
-||p2p.huya.com^$xhr
+! ||p2p.huya.com^$xhr
+||a.msstatic.com/huya/*/p2plib.js$script


### PR DESCRIPTION
These two filtering rules are not related to resource abuse, but are related to privacy. Therefore they should be moved to the privacy list.
At the same time, I use `||a.msstatic.com/huya/*/p2plib.js$script` instead of `||p2p.huya.com^$xhr` to fix https://github.com/uBlockOrigin/uAssets/pull/10610