### PR TITLE
Update badware.txt

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1030,6 +1030,8 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||rockcabs247.in^$all
 
 ! https://www.huorong.cn/info/1627034201698.html
+! https://bbs.kafan.cn/thread-2217785-1-1.html
+||win.zjwhr.top^$all
 ||win.xzhyl.top^$all
 
 ! https://github.com/uBlockOrigin/uAssets/pull/9656
@@ -1199,3 +1201,15 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ! https://github.com/uBlockOrigin/uAssets/pull/10620
 ||mcdupe.com^$all
 ||shadyclient.net^$all
+
+! https://github.com/uBlockOrigin/uAssets/pull/10774
+! https://bbs.kafan.cn/thread-2222478-1-1.html
+||a1475.com^$all
+! https://bbs.kafan.cn/thread-2221903-1-1.html
+||twitter.anlytisc.com^$all
+! https://bbs.kafan.cn/thread-2221781-1-1.html
+||shibatokenclaim.net^$all
+! https://bbs.kafan.cn/thread-2220230-1-1.html
+||ts-group.com^$all
+! https://bbs.kafan.cn/thread-2221419-1-1.html
+||2345.eyunsou.com^$all


### PR DESCRIPTION
`http://www.a1475.com/`

The files downloaded from this webpage are malicious programs and the webpage also lies to the user that these files are false positives

`https://twitter.anlytisc.com/about`

Obvious phishing page with spelling errors in the domain name

`https://shibatokenclaim.net`

Phishing

https://user-images.githubusercontent.com/66902050/144887431-1bca84fc-e77b-45bf-840f-3f753c2775ea.jpg


`https://ts-group.com/wp-admin/super/china/?login=123@qq.com`

Phishing page, spoofing users to enter passwords

`http://2345.eyunsou.com/`

Blocked by Bing search, and the downloaded file is apparently a malicious program
