### PR TITLE
update https://github.com/uBlockOrigin/uAssets/issues/10447

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -4294,8 +4294,8 @@ embed.streamx.me##+js(noeval-if, debugger)
 @@||illink.net^$ghide
 illink.net##+js(acis, Math, break;case)
 illink.net##+js(aeld, click, popMagic)
-illink.net##+js(aopr, app_vars.force_disable_adblock)
 illink.net##+js(aopr, absda)
+illink.net##+js(aopr, open)
 illink.net##+js(aopw, _pop)
 illink.net##+js(set, blurred, false)
 illink.net##.banner


### PR DESCRIPTION
`illink.net##+js(aopr, app_vars.force_disable_adblock)` - redundant due to `@@||illink.net^$ghide`