### PR TITLE
Better Target Klaviyo Analytics files

### DIFF
--- a/thirdparties/pgl.yoyo.org/as/serverlist
+++ b/thirdparties/pgl.yoyo.org/as/serverlist
@@ -51,7 +51,6 @@
 127.0.0.1 a-ads.com
 127.0.0.1 a.aproductmsg.com
 127.0.0.1 a.consumer.net
-127.0.0.1 a.klaviyo.com
 127.0.0.1 a.mktw.net
 127.0.0.1 a.muloqot.uz
 127.0.0.1 a.pub.network
@@ -3149,6 +3148,7 @@
 127.0.0.1 static.fmpub.net
 127.0.0.1 static.itrack.it
 127.0.0.1 static.kameleoon.com
+127.0.0.1 static-tracking.klaviyo.com
 127.0.0.1 staticads.btopenworld.com
 127.0.0.1 statistik-gallup.net
 127.0.0.1 statm.the-adult-company.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
Example URL : `https://omniarc-gaming-mouse.myshopify.com/`

### Describe the issue
The current url targets an API Klaviyo uses whereas this target prevents the tracking JS from ever being loaded. The API can be used for other purposes outside of tracking so this solution better targets Klaviyo Tracking.

### Screenshot(s)
<img width="1434" alt="Screen Shot 2021-12-10 at 3 08 09 PM" src="https://user-images.githubusercontent.com/7377088/145635142-6214b597-f529-4872-b1d0-7ecf57e878fc.png">

### Versions

- Browser/version: Chrome Stable
- uBlock Origin version: 1.32.5b10

### Settings

### Notes