### PR TITLE
remove linksmore.xyz filter

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -1878,7 +1878,7 @@ filmeonlinehd.biz,onlinework4all.com,saveshared.com##+js(acis, Math, zfgloaded)
 123moviesme.*,asianembed.com,fsapi.*,la123movies.org,web.livecricket.is##+js(acis, JSON.parse, break;case $.)
 123moviesme.*##+js(aopr, decodeURI)
 123moviesme.*##+js(aopw, _pop)
-123moviesfree4u.com,123moviesla.*,afilmyhouse.blogspot.com,allmovieshub.*,attvideo.com,daddylive.*,filmyzillafilmywap.*,foreverwallpapers.com,gtrmovies.com,hitmovies4u.com,linksmore.*,livecricket.*,pirlotv.*##^script:has-text(break;case $.)
+123moviesfree4u.com,123moviesla.*,afilmyhouse.blogspot.com,allmovieshub.*,attvideo.com,daddylive.*,filmyzillafilmywap.*,foreverwallpapers.com,gtrmovies.com,hitmovies4u.com,livecricket.*,pirlotv.*##^script:has-text(break;case $.)
 jattmate.com,simpledownload.net##+js(aopr, String.fromCharCode)
 
 ! 123films. cc antiadb & ads


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://linksmore.xyz/view/bB7XgkNxZd`


### Describe the issue

seems to stop popups at final download page but disables `unlock links` button initially

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox stable
- uBlock Origin version: 1.39.2

### Settings

-  uBO's default settings

### Notes

