### PR TITLE
address raky.in antiadb

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -7655,3 +7655,7 @@ epainfo.pl##+js(acis, document.addEventListener, adsBlocked)
 ! freedownloadvideo.net anti-adb
 freedownloadvideo.net##+js(acis, eval, replace)
 freedownloadvideo.net##a[href^="https://www.videoproc.com/"]:upward(1)
+
+! raky. in antiadb
+raky.in##+js(no-fetch-if, googlesyndication)
+raky.in##+js(nano-sib)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://raky.in/?go=5431bcc6`

from 

`https://nowmovies.xyz/the-dead-lands-2014-hindi-dubbed-full-movie-download-filmyzila-the-dead-lands-2014-hindi-dubbed-full-movie/`

### Describe the issue

Nondismissable antiadblock preventing site access

### Screenshot(s)

https://user-images.githubusercontent.com/20338483/146061675-38367e8f-c4b4-48c9-be04-337c3966238a.png

### Versions

- Browser/version: firefox a/firefox desktop.stable
- uBlock Origin version: 1.39.2

### Settings

- uBO's default settings

### Notes
