### PR TITLE
address antiadb

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -7791,3 +7791,6 @@ cam-video.xxx##.ads
 ! antiadb insurance. iptvsetupguide. com
 insurance.iptvsetupguide.com##+js(no-fetch-if, ads)
 insurance.iptvsetupguide.com##+js(nano-sib)
+
+! antiadb bitcoinslink. site
+@@||bitcoinslink.site^$ghide


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://bitcoinslink.site/view/xxcEnt9Bjh` from `khatrimza.bond`

### Describe the issue

antiadblock preventing site access

### Screenshot(s)

https://user-images.githubusercontent.com/20338483/147404828-13bb9dc6-1ed9-43c9-afba-8ad209f1257a.png


### Versions

- Browser/version: firefox
- uBlock Origin version: 1.39.2

### Settings

- uBO's default settings

### Notes