### PR TITLE
Update resource-abuse.txt

### DIFF
--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -137,5 +137,5 @@ douyu.com##+js(set, webkitRTCPeerConnection.prototype.addStream, noopFunc)
 ||a.msstatic.com/huya/*/p2plib.js$script
 
 ! Block some web pages from using P2P (from https://github.com/xinggsf/Adblock-Plus-Rule)
-v.qq.com,dandanzan.top,nunuyy.*##+js(set, RTCPeerConnection, undefined)
-v.qq.com,dandanzan.top,nunuyy.*##+js(set, webkitRTCPeerConnection, undefined)
+bilibili.com,dandanzan.top,nunuyy.*,v.qq.com##+js(set, RTCPeerConnection, undefined)
+bilibili.com,dandanzan.top,nunuyy.*,v.qq.com##+js(set, webkitRTCPeerConnection, undefined)

--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -137,5 +137,4 @@ douyu.com##+js(set, webkitRTCPeerConnection.prototype.addStream, noopFunc)
 ||a.msstatic.com/huya/*/p2plib.js$script
 
 ! Block some web pages from using P2P (from https://github.com/xinggsf/Adblock-Plus-Rule)
-bilibili.com,dandanzan.top,nunuyy.*,v.qq.com##+js(set, RTCPeerConnection, undefined)
-bilibili.com,dandanzan.top,nunuyy.*,v.qq.com##+js(set, webkitRTCPeerConnection, undefined)
+bilibili.com,dandanzan.top,nunuyy.*,v.qq.com##+js(nowebrtc)


### PR DESCRIPTION
Test link: `https://www.bilibili.com/kuawan/2021zmdy/pc/`
The web page uses P2P technology without permission and takes up a lot of upload broadband. After testing, this filter does not cause live streaming lag.
![image](https://user-images.githubusercontent.com/66902050/147817386-25f53970-89f9-4861-929d-3d48e69ff5e2.png)