### PR TITLE
Update privacy.txt

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -358,3 +358,6 @@ reddit.com##+js(no-xhr-if, method:POST url:/^https:\/\/www\.reddit\.com$/)
 /cfga/jquery.js?$image
 /npm/sks@0.*/lazyload.js$script,3p
 ||skk.moe/*.js?$image
+
+! https://github.com/uBlockOrigin/uAssets/pull/11160
+bing.com##+js(cookie-remover, MUIDB)


### PR DESCRIPTION
From AdGuard, this Cookie sets a unique user id for tracking how the user uses the site.
https://github.com/AdguardTeam/AdguardFilters/blob/32ed0d5ebce26a82e98de76186c64c07fff89a2c/SpywareFilter/sections/cookies.txt#L407
However, even though I added this line of filter, the cookie still exists and I don't know if it works.
![image](https://user-images.githubusercontent.com/66902050/147844104-f591572d-b672-432e-9a27-a54f7105774a.png)
![image](https://user-images.githubusercontent.com/66902050/147844121-57c41429-ea81-4ac0-9406-768b2de6b50b.png)
