### PR TITLE
Update specific_report_from_ubo.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/specific_report_from_ubo.yml
+++ b/.github/ISSUE_TEMPLATE/specific_report_from_ubo.yml
@@ -25,7 +25,7 @@ body:
           required: true
         - label: I am not using [another content blocker along uBO](https://twitter.com/gorhill/status/1033706103782170625)
           required: true
-        - label: I did not answer truthfully to **all** the above checkpoints
+        - label: I did answer truthfully to **all** the above checkpoints
           required: false
 
   - type: textarea


### PR DESCRIPTION
### Describe the issue

L28 says `I did not answer truthfully to **all** the above checkpoints`, but I think the **not** is incorrect - and thus should be removed - as I guess the aim of this checkbox is to ensure people speak the truth in the above checkpoints.

### Versions

- Browser/version: MS Edge, v96
- uBlock Origin version: 1.39.2

#### Settings

*irrelevant*

### Notes

If I'm incorrect: sorry for your time.
