### PR TITLE
Remove domains added to EasyList

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -7792,9 +7792,6 @@ codecap.org##+js(aopr, Request)
 ! https://github.com/uBlockOrigin/uAssets/issues/11076
 fusedgt.com##+js(no-xhr-if, googlesyndication)
 
-! https://github.com/easylist/easylist/pull/10287
-||anymind360.com^
-
 ! https://forums.lanik.us/viewtopic.php?t=47064
 gayteam.club##+js(acis, document.querySelectorAll, popMagic)
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
`anymind360.com`
### Describe the issue
https://github.com/easylist/easylist/pull/10287
Now that the pull request has been merged into easylist.
we can remove the filter on the ublock side.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: [here]
- uBlock Origin version: [here]

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
