### PR TITLE
Fixes uBO legacy ping support

### DIFF
--- a/filters/legacy.txt
+++ b/filters/legacy.txt
@@ -134,3 +134,7 @@ danica.no,danicapension.dk,danskebank.co.uk,danskebank.com,danskebank.dk,danskeb
 danica.no,danicapension.dk,danskebank.co.uk,danskebank.com,danskebank.dk,danskebank.fi,danskebank.no,danskebank.se,danskeci.com#@#.cookie-consent-banner:not(body)
 danica.no,danicapension.dk,danskebank.co.uk,danskebank.com,danskebank.dk,danskebank.fi,danskebank.no,danskebank.se,danskeci.com#@#.cookie-consent-banner-modal
 danica.no,danicapension.dk,danskebank.co.uk,danskebank.com,danskebank.dk,danskebank.fi,danskebank.no,danskebank.se,danskeci.com#@##cookie-text
+
+! unblock ping
+$ping,third-party,badfilter
+$other,third-party,badfilter


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://agoniarecords.bandcamp.com/album/garden-of-storms`

### Describe the issue

$ping,3p is being translated into $other,3p and causing issues

### Screenshot(s)

![521f114f-a4d0-4f53-8887-dffb9e486de9](https://user-images.githubusercontent.com/1659004/150242544-a8e9a497-248b-4c87-96ed-b25cbfaca720.png)

### Versions

- Browser/version: Safari
- uBlock Origin version: 1.16.0 

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Was reported by a user emailing EL directly. Happy to tweak the PR if it's incorrect.
