### PR TITLE
Update epvp

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -1712,8 +1712,6 @@ elitepvpers.com##a[rel*="epvp"]
 ||elitepvpers.com/*/proofcore_*_ss.gif$image
 ||elitepvpers.com/*/origin_*_pvp_*.gif$image
 
-
-
 ! https://github.com/uBlockOrigin/uAssets/issues/8706
 send.cm##+js(aopw, decodeURIComponent)
 send.cm##+js(acis, Promise, JSON.parse)

--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -1698,12 +1698,21 @@ elitepvpers.com##[href="https://www.skycheats.com/"]
 elitepvpers.com##[href^="https://funpay.com/"]
 elitepvpers.com##[href="https://proofcore.io/"]
 ||playorigin.com^$3p
-*$3p,image,domain=elitepvpers.com,denyallow=gstatic.com|ghostaim.com|imgur.com|imagebanana.com|imgbb.com|giphy.com|epvpimg.com|discord.com|discordapp.com|discordapp.net|postimages.org|directupload.net|imageupload.io|ibb.co|gyazo.com
+*$image,3p,denyallow=gstatic.com|ghostaim.com|imgur.com|imagebanana.com|imgbb.com|giphy.com|epvpimg.com|discord.com|discordapp.com|discordapp.net|postimages.org|directupload.net|imageupload.io|ibb.co|gyazo.com|imgbox.de|images.weserv.nl|ipv4.imgur.map.fastly.net|snipboard.io|netdna-cdn.com,domain=elitepvpers.com
 elitepvpers.com##[style*="margin"]:has-text(/Advertise/i) + a[href]
-||elitepvpers.com/iii/$image
-elitepvpers.com##a[rel*="ss"]
-elitepvpers.com##div[style="background-color:#ededed;padding:0"]
 elitepvpers.com#@#img[height="60"]
+elitepvpers.com##[style*="margin"]:has-text(/Ad/i) + a[rel]:has(img)
+elitepvpers.com##div[style]:has-text(/Advertise/i) + div[align="center"]
+elitepvpers.com##a[rel*="epvp"]
+||elitepvpers.com/iiii/$image
+||elitepvpers.com/*/aimex_*_*.gif$image
+||elitepvpers.com/*/*_general.gif$image
+||elitepvpers.com/*/funpay_poe_full_width.gif$image
+||elitepvpers.com/*/aimhelper_cod_lead.gif?1$image
+||elitepvpers.com/*/proofcore_*_ss.gif$image
+||elitepvpers.com/*/origin_*_pvp_*.gif$image
+
+
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8706
 send.cm##+js(aopw, decodeURIComponent)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.elitepvpers.com/forum/fortnite/4992751-free-permanent-fortnite-spoof-2-drives-needed.html`

### Describe the issue

Ads and breakage (images are hidden)

### Screenshot(s)

### Versions

- Browser/version: Firefox developer
- uBlock Origin version: 1.40.8

### Settings

default + uBlock filters – Annoyances

### Notes

The image denyallow filter seems very problematic
