### PR TITLE
update

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -5580,13 +5580,6 @@ hindustantimes.com##[amp-access^="NOT"]
 newdmn.*##+js(nowoif, !newdmn, 1)
 newdmn.*###overlay
 
-! https://github.com/uBlockOrigin/uAssets/issues/8342
-*$script,3p,denyallow=fastly.net|fastlylb.net|jquery.com|hwcdn.net|hcaptcha.com|recaptcha.net|cloudflare.com|cloudflare.net|google.com|googleapis.com|gstatic.com|sharethis.com|stackpathcdn.com|blogger.com|googleusercontent.com|rawgit.com|rawgitcdn.b-cdn.net|githack.com,domain=isaiminiweb.*
-isaiminiweb.*##^meta[http-equiv="refresh"]
-isaiminiweb.*##+js(aost, Math, inlineScript)
-isaiminiweb.*##^script:has-text(break;case)
-||isaiminiweb.*^$csp=script-src *
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/k9duxq/white_popup_and_new_page_ad_on_soccer_stream/
 givemeredditstreams.com##+js(aopw, _pop)
 givemeredditstreams.com##+js(noeval-if, debugger)


### PR DESCRIPTION
site redirects to new site

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`isaiminiweb.online`

### Describe the issue

site redirects to a new site `https://moviesda.fun/`, html filter prevents refresh

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox stable
- uBlock Origin version: 1.40.8

### Settings

- uBO's default settings

### Notes
