### PR TITLE
linkshortify.in anti-adblocks and timers

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -694,3 +694,7 @@ drydenwire.com##.modal
 drydenwire.com##.modal-backdrop
 drydenwire.com##[data-track-category="Sponsors"]
 drydenwire.com##.promogrid
+
+! linkshortify. in => studyranks. in, technoflip. in, financeflix. in anti-adblocks and timers
+studyranks.in,technoflip.in,financeflix.in##+js(no-xhr-if, googlesyndication)
+studyranks.in,technoflip.in,financeflix.in##+js(nano-sib, timer)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://linkshortify.in/uzIOZntQ`

### Describe the issue

Anti-adblock overlays and countdown timers in next 3 domains: `studyranks.in,technoflip.in,financeflix.in`

### Screenshot(s)

<details><summary>studyranks.in</summary>

![studyranks](https://user-images.githubusercontent.com/66517106/153154597-916a5c75-0aba-4f82-9d05-cd2474d1038e.png)

</details>

<details><summary>technoflip.in</summary>

![technoflip](https://user-images.githubusercontent.com/66517106/153154858-3381a534-abd2-427a-beee-553e99cbf689.png)

</details>

<details><summary>financeflix.in</summary>

![financeflix](https://user-images.githubusercontent.com/66517106/153155100-f4efe51c-248f-49f7-b998-5766b8acd9cc.png)

</details>

### Versions

- Browser/version: Firefox 97.0
- uBlock Origin version: 1.40.8

### Settings

- ublock's default settings

### Notes