### PR TITLE
Update badware

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1471,6 +1471,20 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||hmzapc.com^$doc
 ||9to5crack.com^$doc
 ||vstserial.com^$doc
+||greencracks.com^$doc
+||procrackerz.com^$doc
+||crackfix.net^$doc
+||zcracked.com^$doc
+||cracksoftware.org^$doc
+||downloadpc.net^$doc
+||pcfullcrack.org^$doc
+||serialkey.info^$doc
+||keygenpc.com^$doc
+||up4pc.com^$doc
+||hitproversion.com^$doc
+||cracktube.net^$doc
+||funnow45.xyz^$doc
+||137.184.159.42^$doc
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11394
 ||theannoyingsite.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
greencracks.com
procrackerz.com
crackfix.net
zcracked.com
cracksoftware.org
downloadpc.net
pcfullcrack.org
serialkey.info
keygenpc.com
up4pc.com
hitproversion.com
cracktube.net
funnow45.xyz
137.184.159.42
```

### Describe the issue

fake cracks, just redirect to virus

### Screenshot(s)

### Versions

- Browser/version: Firefox developer
- uBlock Origin version: 1.41.2

### Settings

uBlock Origin default + uBlock Origin Annoyances

### Notes

Example for the last entry: `http://137.184.159.42/?620b9ea8ad483=4ba23360a759f467be8c80eb2d0a265a&620b9ea8ad486=2878&620b9ea8ad487=1_ccleaner-pro-5-89-9401-crack-full-serial-key-latest-repack-2022&gkss=572575&620b9ea8ad488=2` get used by multiply sites and is stable