### PR TITLE
update badware

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1489,7 +1489,12 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||hitproversion.com^$doc
 ||cracktube.net^$doc
 ||funnow45.xyz^$doc
-||137.184.159.42^$doc
+||abbaspc.net^$doc
+||bicfic.com^$doc
+||freecrackdownload.com^$doc
+||cracka2zsoft.com^$doc
+||crackdownload.org^$doc
+||miancrack.com^$doc
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11394
 ||theannoyingsite.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
abbaspc.net
bicfic.com
freecrackdownload.com
cracka2zsoft.com
crackdownload.org
miancrack.com
```

### Describe the issue

fake cracks, just redirect to virus

### Screenshot(s)

### Versions

- Browser/version: Firefox developer
- uBlock Origin version: 1.41.2

### Settings

uBlock Origin default + uBlock Origin Annoyances

### Notes

`137.184.159.42` is clean now.