### PR TITLE
address vtube .to popups and anti debugger

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -909,3 +909,8 @@ hakie.net##+js(nowoif)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/110867
 jav247.top##+js(aopr, __Y)
+
+! vtube .to ads
+vtube.to##+js(nowoif)
+vtube.to##+js(acis, RegExp, debugger)
+vtube.to##+js(aeld, popstate)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://vtube.to/1g66sj2eyg55.html`

 from `skymovieshd.tel`

### Describe the issue

popups when clicked anywhere and paused on debugger on opening console

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version:  opera browser stable
- uBlock Origin version: 1.41.2

### Settings

-  uBO's default settings

### Notes
