### PR TITLE
address ads/popups at ninjashare. to

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -919,3 +919,7 @@ vtube.to##+js(aeld, popstate)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/svkkgn/anti_adblock_on_website_98zerocom_how_can_i_solve/
 98zero.com##+js(aopr, adBlockDetected)
+
+! ninjashare. to ads/popups
+ninjashare.to##+js(aopr, console.clear)
+ninjashare.to##+js(aeld, , break;case $.)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://ninjashare.to/download/5Z91qtvcAekqAM3sj8rMp4?t=a521f50e769ccef47b80e3403697a659)`

from `https://tinyzonetv.to/watch-movie/watch-fistful-of-vengeance-2022-free-77413.8106868` one of the download button

### Describe the issue

popups

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera browser stable
- uBlock Origin version: 1.41.2
- 
### Settings

-  uBO's default settings

### Notes