### PR TITLE
update badware

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1500,6 +1500,8 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||cracka2zsoft.com^$doc
 ||crackdownload.org^$doc
 ||miancrack.com^$doc
+||softserialskey.com^$doc
+||134.122.122.217^$all
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11394
 ||theannoyingsite.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
softserialskey.com
134.122.122.217
```

### Describe the issue

fake cracks, just redirect to virus

### Screenshot(s)

### Versions

- Browser/version: Firefox developer
- uBlock Origin version: 1.41.2

### Settings

uBlock Origin default + uBlock Origin Annoyances

### Notes

Example for `134.122.122.217` - `http://134.122.122.217/?6211605a62913=7f0727da2e5a35cc1e45dbc4828085cf&6211605a62933=112&6211605a62935=1_ccleaner-pro-5-89-9401-full-crack-serial-key-2022-free-download&gkss=324442&6211605a62939=2`
