### PR TITLE
Update filters

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -2453,7 +2453,7 @@ atozmath.com##+js(acis, alert, reCAPTCHA)
 @@||atozmath.com/Scripts/advertisement.js$xhr,1p
 atozmath.com##.videoDiscovery
 @@||services.bilsyndication.com/adv1/*$script,domain=atozmath.com
-@@||biltag.bilsyndication.com/v1/*$script,domain=atozmath.com
+@@||biltag.bilsyndication.com^$script,domain=atozmath.com
 @@||assets.bilsyndication.com/prebid/default/*$script,domain=atozmath.com
 ||assets.bilsyndication.com/plugins/*$script,redirect=noopjs,domain=atozmath.com
 ||imasdk.googleapis.com/js/sdkloader/ima3.js$script,redirect=noopjs,domain=atozmath.com


### PR DESCRIPTION
Related issue: [https://github.com/uBlockOrigin/uAssets/issues/10815](https://github.com/uBlockOrigin/uAssets/issues/10815)

Anti-adblock again. I guess `https://biltag.bilsyndication.com/passback/` scripts are bait scripts?

Also the countdown timer stops when out of focus, looks like this inline script causes it.

```js
var hEzRerx = true;
// on focus, set window_focus = true.
$(window).focus(function() {
    hEzRerx = true;
});

// when the window loses focus, set window_focus to false
$(window).blur(function() {
    hEzRerx = false;
});
```

However I don't know how to bypass it, using `+js(set, blur, noopFunc)` or `+js(set, blur, undefined)` is not successful on my side.