### PR TITLE
Update 1337x vpn ads filter

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -705,6 +705,7 @@ money.cnn.com##section.column:has(:scope > #moneySponsors)
 1337x.*##a[href^="/spyoff"]
 1337x.*##a[href*="//steepto.com/"]
 1337x.*##[href*="vpn"]
+1337x.*##[href*="v-pn2dl"]
 1337x.*##.no-top-radius div > a[href]:has-text(VPN)
 1337x.*##a[href][style="text-decoration:none; border-bottom:none; color:none;"]
 ! https://github.com/uBlockOrigin/uAssets/issues/635


### PR DESCRIPTION
Block new VPN ads from 1337x

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`1337x.*`

### Describe the issue

They changed the link their ads link to, it no longer includes "vpn", so "v-pn2dl" should take care of that.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/14346945/156839357-c58dad90-2271-4113-a92c-253990df04ff.png)
![image](https://user-images.githubusercontent.com/14346945/156839427-4e1ba02d-1e3d-4028-be39-163793975128.png)
![image](https://user-images.githubusercontent.com/14346945/156839384-b14e15a9-750c-4bd8-b6e9-0494d118eac5.png)
