### PR TITLE
Address ads at flixtor. stream

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -1284,3 +1284,7 @@ blognews.in###wpsafe-generate:style(display: block !important)
 blognews.in###wpsafe-link:style(display: block !important)
 blognews.in###wpsafe-wait1
 blognews.in###wpsafe-wait2
+
+! flixtor. stream ads
+flixtor.stream##+js(nowoif)
+||stream.vidzstore.com/popembed.php


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://flixtor.stream/fresh-2022/`

### Describe the issue

popup which is closed automatically
 ad before video

### Screenshot(s)

https://user-images.githubusercontent.com/20338483/157476907-30897eb3-d869-47f1-8d2a-2cc1eac09cf4.png

### Versions

- Browser/version: opera browser stable
- uBlock Origin version: 1.41.8

### Settings

- uBO's default settings

### Notes
