### PR TITLE
Unbreak mpsconline .gov.in

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4398,3 +4398,6 @@ pearsonclinical.com##.aligner
 ! https://github.com/uBlockOrigin/uAssets/issues/12143
 /adw.$domain=~adw.be|~adw.olsztyn.pl|~adw.org|~adw.org.pl|~valadoc.org,badfilter
 /adw.$domain=~adw.be|~adw.olsztyn.pl|~adw.org|~adw.org.pl|~valadoc.org|~adw.amsterdam.nl
+
+! mpsconline. gov.in breakage
+@@||mpsconline.gov.in^$ghide


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://mpsconline.gov.in/candidate/main#`

### Describe the issue

when login ,when applied for online application ,page turns out to be blank means i can't see options eg adv no ,posts
logger shows nothing blocked

### Screenshot(s)

i can't share sensitive things ,whoever in teams want i will contact them

### Versions

- Browser/version: google chrome Version 99.0.4844.51 (Official Build) (64-bit)
- uBlock Origin version: 1.41.8

### Settings

-  uBO's default settings

### Notes
It seems whoever using ublock origin on this gov site will face this issue