### PR TITLE
address dvdplay. sbs popups

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -1347,3 +1347,10 @@ vudeo.io##+js(acis, JSON.parse, break;case $.)
 
 ! streamingfrance. net popups
 streamingfrance.net##+js(acis, JSON.parse, break;case $.)
+
+! dvdplay. sbs popups
+*$script,3p,domain=dvdplay.sbs
+||mage98rquewz.com^
+dvdplay.sbs##+js(set, D4zz, noopFunc)
+dvdplay.sbs##^script:has-text(decodeURI)
+


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
dvdplay.sbs
https://dvdplay.sbs/page-1269-The-Falcon-and-the-Winter-Soldier-S01-Series/
```

### Describe the issue

popups when clicked anywhere

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox 98
- uBlock Origin version: 1.41.8

### Settings

-  uBO's default settings

### Notes
