### PR TITLE
fix(urlhaus-filter): replace download link

### DIFF
--- a/tools/update-3rdparties.sh
+++ b/tools/update-3rdparties.sh
@@ -12,7 +12,7 @@ assets=(
     ['thirdparties/easylist-downloads.adblockplus.org/easyprivacy.txt']='https://easylist.to/easylist/easyprivacy.txt'
     ['thirdparties/pgl.yoyo.org/as/serverlist']='https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=1&startdate%5Bday%5D=&startdate%5Bmonth%5D=&startdate%5Byear%5D=&mimetype=plaintext'
     ['thirdparties/publicsuffix.org/list/effective_tld_names.dat']='https://publicsuffix.org/list/public_suffix_list.dat'
-    ['thirdparties/urlhaus-filter/urlhaus-filter-online.txt']='https://gitlab.com/curben/urlhaus-filter/raw/master/urlhaus-filter-online.txt'
+    ['thirdparties/urlhaus-filter/urlhaus-filter-online.txt']='https://curben.gitlab.io/urlhaus-filter/urlhaus-filter-online.txt'
 )
 
 for i in "${!assets[@]}"; do


### PR DESCRIPTION
- https://gitlab.com/curben/urlhaus-filter/-/commit/8c94ddba40d794b194f614091a84f5fc1d00a4b0
- filter update is no longer pushed to repo
