### PR TITLE
Bypass adblock detection on galaxyfirmware.com

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4410,3 +4410,6 @@ leboncoin.fr#@#div[class^="styles_ad__"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/12196
 @@||chanrycz.com/cdn-cgi/apps/head/*.js|$script,1p
+
+! This bypasses adblock detection on download link fetching
+galaxyfirmware.com#@#.textad


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://galaxyfirmware.com/model/SM-A530F/NZC/A530FXXULCUK6`

### Describe the issue

After verifying the captcha and clicking "Generate Download Link", instead of the download links, a message appears stating "Ad Blocker Detected".

### Screenshot(s)

N/A

### Versions

- Browser/version: Microsoft Edge 95.0.1020.53 (Official build) (64-bit)
- uBlock Origin version: 1.41.8

### Settings

- N/A

### Notes

When fetching the download link, JS code on this site detects whether `.textad` is visible, and if so sets `adblock` to `1`. With this filter, no ad is displayed but fetching of the link is successful.

The offending filter is `##.textad` from EasyList (line 29326 as of `202203140554`)