### PR TITLE
add to exp

### DIFF
--- a/filters/exp.txt
+++ b/filters/exp.txt
@@ -12,6 +12,30 @@ money.pl#@#+js()
 ||v.wpimg.pl/*.html$frame
 money.pl##:xpath(//*[string-length(@href) > 1600])
 money.pl#@#.ads
+! wp.pl company anti adblock overlay and ads
+wp.pl,money.pl,o2.pl,parenting.pl,pudelek.pl,autokult.pl,gadzetomania.pl,fotoblogia.pl,komorkomania.pl##body:has(button:has-text(Zaloguj)) > [id] > [class]:matches-css(z-index:/2147483647/)
+wp.pl,money.pl,o2.pl,parenting.pl,pudelek.pl,autokult.pl,gadzetomania.pl,fotoblogia.pl,komorkomania.pl##body:has(button:has-text(Zaloguj)) > div:style(filter: none !important)
+wp.pl,money.pl,o2.pl,parenting.pl,pudelek.pl,autokult.pl,gadzetomania.pl,fotoblogia.pl,komorkomania.pl##html, body:has(button:has-text(Zaloguj)):style(overflow: auto !important)
+wp.pl,money.pl,pudelek.pl,gadzetomania.pl,fotoblogia.pl##body:has(button:has-text(Zaloguj)) div > style:has-text(flex: 0 0 100%) + div
+autokult.pl,fotoblogia.pl,kafeteria.pl,komorkomania.pl##body:has(button[id="ol-widget-login-button"]) a[href^="https://www.wp.pl"] > img[src^="https://v.wpimg.pl/"]:upward(3)
+fotoblogia.pl,kafeteria.pl##body:has(button:has-text(Zaloguj)) .article-sidebar-wrapper + div:has(a[href^="https://www.wp.pl"] > img[src^="https://v.wpimg.pl/"])
+gadzetomania.pl##body:has(button:has-text(Zaloguj)) > [id] > [class]:matches-css(z-index:/2147483647/)
+gadzetomania.pl##body:has(button:has-text(Zaloguj)) > div:style(filter: none !important)
+gadzetomania.pl##html, body:has(button:has-text(Zaloguj)):style(overflow: auto !important)
+gadzetomania.pl##body:has(button:has-text(Zaloguj)) div > style:has-text(flex: 0 0 100%) + div
+www.wp.pl##body:has(button[id="ol-widget-login-button"]) #site-header > div:not(:has(#logo)):has(img[src^="https://v.wpimg.pl"])
+www.wp.pl##body:has(button[id="ol-widget-login-button"]) #app-content > div > div:not([class]):not([id])
+www.wp.pl##body:has(button[id="ol-widget-login-button"]) #app-content > div > div:has(#glonews) > div:not([id]):has(img[src^="https://v.wpimg.pl/"][role="presentation"])
+www.wp.pl##body:has(button[id="ol-widget-login-button"]) aside > div:not([class]) > div:has(img[src^="https://v.wpimg.pl/"]):not([data-testid])
+www.wp.pl##body:has(button[id="ol-widget-login-button"]) div > img[src^="https://v.wpimg.pl/"][role="presentation"] + div > div > div + div > a[href^="https://www.wp.pl"] > img[src^="https://v.wpimg.pl/"]:upward(5)
+www.wp.pl##body:has(button[id="ol-widget-login-button"]) a[href^="https://www.wp.pl"]:Not([title]) > img[src^="https://v.wpimg.pl/"]:upward(3)
+www.wp.pl##body:has(button[id="ol-widget-login-button"]) div[style="width:100%;height:100%"]:has(img[src^="https://v.wpimg.pl/"][role="presentation"]):upward(1)
+wp.pl##body:has(button:has-text(Zaloguj)) div[style*="top: 0px; left: 320px; background-position: center 0px; background-color: transparent; background-repeat: no-repeat; margin-left: -8.5px; z-index: -1; width: 1920px; height: 1080px"]
+wp.pl##body:has(button:has-text(Zaloguj)) > div[class]:has(div[style*="height: 184"]:has(a[href^="https://wiadomosci.wp.pl"]))
+wp.pl##body:has(button:has-text(Zaloguj)) a[style="background:#e1261c;"][href^="https://www.wp.pl?src"] > div + div + div:style(display: none !important)
+wp.pl##body:has(button:has-text(Zaloguj)) div[class] > div[class] + img[width="56"][height="45"][alt][src^="https://v.wpimg.pl"] + div[class]
+autokult.pl##body:has(button[id="ol-widget-login-button"]) iframe[src^="https://v.wpimg.pl/"]
+autokult.pl##body:has(button[id="ol-widget-login-button"]) .article-wrapper > [class]:not(.content-wrapper)
 
 ! next-episode anti adb
 @@||next-episode.net^$script,1p


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
www.wp.pl
wp.pl
o2.pl
money.pl
parenting.pl
pudelek.pl
autokult.pl
gadzetomania.pl
fotoblogia.pl
komorkomania.pl
```
and the wp subdomains

### Describe the issue

ads and anti adblock

### Screenshot(s)

<img width="1222" alt="Unbenannt" src="https://user-images.githubusercontent.com/48647394/158202667-1bac7d4d-f043-48aa-9beb-81f331e0a8b2.PNG">
<img width="470" alt="Unbenannt1" src="https://user-images.githubusercontent.com/48647394/158202825-a7f8691a-4381-42f0-ae2a-198284c30cbc.PNG">


### Versions

- Browser/version: windows developer
- uBlock Origin version: 1.41.8

### Settings

uBlock Origin default + uBlock Origin Annoyances + POL regional filter lists

### Notes

Issue: https://github.com/uBlockOrigin/uAssets/issues/12214

Experemential, not deep checked. It hides the anti adblock overlay and ads, also many placeholders get removed but not all. All filters affect non logged in users, hope the a.d.m.i.n.s are logged in and not seing this.
