### PR TITLE
Update https://github.com/uBlockOrigin/uAssets/issues/4700

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -11090,7 +11090,7 @@ movierulzfree.*##.hd-buttons
 movierulz.*##+js(acis, Math, break;case $.)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4700
-9kmovies.*##+js(acis, Math, break;case $.)
+9kmovies.*##+js(acis, JSON.parse, break;case $.)
 ||ewerhodub.com^
 ||9xmovies.*/sw.js$script,1p
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://9kmovies.homes/radhe-shyam-2022-hindi-dubbed-480p-predvdrip-400mb-download/`

### Describe the issue

popup ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera browser stable
- uBlock Origin version: 1.41.8

### Settings

- uBO's default settings

### Notes