### PR TITLE
Further update

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -1152,7 +1152,7 @@ thedigitalfix.com##.sticky_rail600:remove()
 ! moviewatchonline. com.pk ads
 moviewatchonline.com.pk##+js(acis, JSON.parse, break;case $.)
 moviewatchonline.com.pk##+js(aopw, atOptions)
-*$3p,frame,denyallow=adblockstreamtape.art|dood.so|jetpack.wordpress.com|mixdrop.ch|ok.ru|pkspeed.net|playersb.com|streamtape.com|widgets.wp.com,domain=moviewatchonline.com.pk
+*$3p,frame,denyallow=adblockstreamtape.art|dood.so|jetpack.wordpress.com|mixdrop.ch|ok.ru|pkspeed.net|playersb.com|streamtape.com|streamtapeadblock.art|widgets.wp.com,domain=moviewatchonline.com.pk
 moviewatchonline.com.pk##[href^="https://angularconstitution.com/"]
 moviewatchonline.com.pk##[href*="?key="]
 ||deserterstrugglingdistil.com^


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://moviewatchonline.com.pk/rrr-2022-watch-online-free-full-movie-hindi-dubbed-1080p-hdrip-download/`

### Describe the issue

streamtape changed its mirror for adblock users hence update of denyallow filter

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera browser stable
- uBlock Origin version: 1.41.8

### Settings

-  uBO's default settings

### Notes
