### PR TITLE
Unblocks first-party `clustrmaps.com` requests

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4416,3 +4416,7 @@ leboncoin.fr#@#div[class^="styles_ad__"]
 ! https://github.com/uBlockOrigin/uAssets/issues/12244
 ||mixpanel.com^$badfilter
 ||mixpanel.com^$3p
+
+! Counters `clustrmaps.com` from Peter Lowe's List
+||clustrmaps.com^$badfilter
+||clustrmaps.com^$3p


### PR DESCRIPTION
I think the site can be useful, and having strict for `clustrmaps.com` blocking could impede a less-accustomed-to-uBO's-filtering user, I think.