### PR TITLE
update quick

### DIFF
--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -67,3 +67,5 @@ rjno1.com##*:matches-css(max-height:/300px/):style(max-height: none !important;)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/9696
 /techpowerup\.com\/review\/[a-z]+\/images\/[a-z0-9]{8}\-[a-z0-9]{8}\.jpg/$image,1p,domain=techpowerup.com
+techpowerup.com##:not(:matches-path(/forums/)) a[href^="/review/"][href$="?j.jpg"]
+techpowerup.com##:not(:matches-path(/forums/)) .sydbry > div:has(img)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
techpowerup. com
```

### Describe the issue

clickable placeholder at the top and placeholders in the side bar

### Screenshot(s)

### Versions

- Browser/version: firefox developer
- uBlock Origin version: 1.41.8

### Settings

uBlock Origin default + uBlock Origin annoyances + uBlock filters – Quick fixes

### Notes

the trick to limit the filter to logged out users no longer working.