### PR TITLE
Add https://ww1.putlocker-website.com/

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -1854,8 +1854,8 @@ putlockers.cr##a[href^="/download-4k/"]
 ||susm0q6jys.com^$3p
 ! https://forums.lanik.us/viewtopic.php?f=62&t=40397
 ! https://www.reddit.com/r/uBlockOrigin/comments/aqcoi3/annoying_ads_on_putlockertv/
-putlockertv.*##+js(nowoif)
-putlockers.*##+js(acis, JSON.parse, break;case $.)
+putlocker-website.com,putlockertv.*##+js(nowoif)
+putlocker-website.com,putlockers.*##+js(acis, JSON.parse, break;case $.)
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=41466
 ! https://github.com/uBlockOrigin/uAssets/issues/7884


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://ww1.putlocker-website.com/`

### Describe the issue

Popup ads 


### Versions

- Browser/version: Brave
- uBlock Origin version: 1.41.8

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Just add another putlocker-website.com mirror
