### PR TITLE
obsolete filter

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -3931,12 +3931,8 @@ themeslide.com##+js(nano-stb)
 ! https://github.com/NanoMeow/QuickReports/issues/25
 ! https://github.com/uBlockOrigin/uAssets/pull/6696
 @@||aternos.org^$ghide
-aternos.org##+js(set, atob, noopFunc)
 aternos.org##[style*="opacity:  0"]
 aternos.org##.header-ad
-aternos.org##.ad-detect:style(position:absolute !important;left:-9999px !important)
-aternos.org##.ad-label:remove()
-aternos.org##.ad
 ||tech426.com^$3p
 ||ultra-rv.com^$3p
 ||atom-ds.com^$3p


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`aternos. org`

### Describe the issue

obsolete filter which only triggers anti adblock

### Screenshot(s)

### Versions

- Browser/version: firefox developer
- uBlock Origin version: 1.41.8

### Settings

uBlock Origin default + uBlock Origin annoyances

### Notes