### PR TITLE
Add Twitch.tv analytics

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -377,3 +377,6 @@ endbasic.dev,jmmv.dev##+js(no-xhr-if, method:POST)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11895
 ||serasaexperian.com.br/dist/scripts/fingerprint2.js^$redirect=fingerprint2.js,script,important
+
+! Twitch.tv analytics
+twitch.tv##+js(no-fetch-if, /video-edge-[^/]+ttvnw.net/ method:POST)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.twitch.tv/`

### Describe the issue

This blocks Twitch's usage tracking, analytics and bunch of other information sent to video delivery servers. None of this is needed for Twitch to work and only compromise user privacy.

You can see what data is sent by tracking post requests to `ttvnw.net`

