### PR TITLE
fix techpowerup. com tracking

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -381,3 +381,6 @@ endbasic.dev,jmmv.dev##+js(no-xhr-if, method:POST)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/tihpyw/oldredditcom_outbound_tracking_via_out_reddit_com/i1f290z/?context=3
 old.reddit.com##+js(ra, data-outbound-url, .outbound)
+
+! techpowerup.com analytics
+||techpowerup.com/_log$xhr


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`techpowerup. com`

### Describe the issue

Screensize tracking xhr

### Screenshot(s)

<img width="1024" alt="Unbenannt" src="https://user-images.githubusercontent.com/48647394/159985690-d90bcab8-5654-4a55-aa07-8c5fce3800e4.PNG">

### Versions

- Browser/version: firefox developer
- uBlock Origin version: 1.41.8

### Settings

uBlock Origin default + uBlock Origin annoyances

### Notes