### PR TITLE
Trim redundant cookie filters

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -4249,10 +4249,6 @@ routinehub.co###ethad
 darktranslation.com##+js(aopw, stopPrntScr)
 darktranslation.com##*::selection:style(background-color:#338FFF!important)
 
-! https://www.reddit.com/r/uBlockOrigin/comments/j02lnx/block_adcookie_prompt_on_medicalnewstodaycom/
-medicalnewstoday.com###modal-host
-medicalnewstoday.com##body:style(overflow:auto !important)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/7960
 www.google.*##+js(set, rwt, noopFunc)
 
@@ -5204,9 +5200,6 @@ tritinia.com##+js(acis, jQuery, keydown)
 tritinia.com##+js(aopr, document.oncontextmenu)
 tritinia.com##+js(aopr, disable_copy)
 tritinia.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! nyaa.net cookie consent by ghide
-nyaa.net###cookie-warning
 
 ! https://github.com/DandelionSprout/adfilt/issues/63#issuecomment-812837952
 fakechatapp.com##.banner
@@ -6165,11 +6158,6 @@ scrolller.com##+js(aeld, contextmenu)
 hollywoodmask.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 hollywoodmask.com##+js(aeld, /copy|cut|paste|selectstart/)
 hollywoodmask.com##+js(nostif, pop)
-
-! https://github.com/uBlockOrigin/uAssets/issues/10902
-arctic.de##.acris-cookie-consent
-arctic.de##body:style(overflow: auto !important;)
-arctic.de##.show.fade.modal-backdrop
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10938
 phimdinhcao.com##+js(acis, oncontextmenu, keydown)

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -12043,8 +12043,6 @@ sslproxies24.top##.adsbygoogle, .Feed.widget, #HTML1, #HTML3, [href^="https://br
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5168
 @@||nyaa.*^$ghide
-*$script,3p,domain=sukebei.nyaa.net
-||z.zz.ht^$domain=nyaa.*
 sukebei.nyaa.si##div[class*="-"] > ins.adsbyexoclick:upward(1)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5174


### PR DESCRIPTION
Trimming the following; `medicalnewstoday.com` & `arctic.de` already in ELC

nyaa.net dead domain, and removed unused filters