### PR TITLE
update last commit

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -1861,6 +1861,7 @@ piraproxy.app,theproxy.*##+js(aopr, _wm)
 
 ! xxxvideotube. net popunder
 xxxvideotube.net##+js(aopr, decodeURI)
+xxxvideotube.net##+js(set, D4zz, noopFunc)
 
 ! whats-on-netflix.com anti adb
 whats-on-netflix.com##+js(acis, eval, replace)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`xxxvideotube.net` &other videos

### Describe the issue

`xxxvideotube.net##+js(aopr, decodeURI)`
doesn't work

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox stable
- uBlock Origin version: 1.41.8

### Settings

- uBO's default settings

### Notes
