### PR TITLE
update filter

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -6420,4 +6420,4 @@ coolwallpapers.me##+js(nosiif, dfgh-adsbygoogle)
 freshersnow.com##.adsbygoogle
 
 ! playerx.stream devtools detector
-/devtools-detector$script,domain=beastx.top|chillx.top|playerx.stream
+beastx.top,chillx.top,playerx.stream##+js(aopr, devtoolsDetector)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
https://playerx.stream/v/HkolwMLvagD3/
https://chillx.top/v/HkolwMLvagD3/
```

### Describe the issue

With ublock annoyances filter enabled, page redirects to `google.com` instead of intended website

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera browser stable
- uBlock Origin version: 1.41.8

### Settings

-  uBO's default settings

### Notes
