### PR TITLE
Remove redundant filters

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -3895,24 +3895,8 @@ cracksone.com##*:style(-webkit-touch-callout: default !important; -webkit-user-s
 ! indiatimes .com selection invisible
 indiatimes.com##*::selection:style(background-color:#338FFF!important)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/60172
-mt2dosyalar.com##.notice
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/60248
-pressherald.com##.pum[data-popmake*="cookies"]
-pressherald.com##html:style(overflow:auto !important)
-
 ! railf.jp and https://spectank.jp/sl0060045.html right click
 railf.jp,spectank.jp##+js(ra, oncontextmenu|oncopy)
-
-! cookie consent with scroll locked
-analog.com###cookie-consent-container.modal
-analog.com##.modal-backdrop
-analog.com##body.modal-open:style(overflow:auto !important)
-
-! cookie consent with scroll locked
-germany.travel##.consent
-germany.travel##body.consent-overlay:style(overflow:auto !important)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/60183
 liga.net##.modal-backdrop
@@ -3935,9 +3919,6 @@ coop-land.ru##+js(nostif, .fadeIn)
 brighteon.com##body:style(overflow:auto !important)
 brighteon.com##div.overlay, .bottom-banner
 
-! viget.com cookie-notice
-viget.com##[class^="gpdr-banner__"]
-
 ! humanbenchmark .com warning anti adb
 *$script,3p,domain=humanbenchmark.com
 
@@ -3954,10 +3935,6 @@ koreanaddict.net##+js(aopw, document.oncontextmenu)
 
 ! mesquitaonline .com anti right click, select
 mesquitaonline.com##+js(aeld, , mdp)
-
-! https://forums.lanik.us/viewtopic.php?p=156018#p156018
-nieuwsblad.be###didomi-host
-nieuwsblad.be##body:style(overflow: auto !important;)
 
 ! movieston .com anti right click / select / copy
 movieston.com##+js(acis, document.oncontextmenu)


### PR DESCRIPTION
Dead domain
```
! https://github.com/AdguardTeam/AdguardFilters/issues/60172
mt2dosyalar.com##.notice
```

No longer used on the domain
```
! https://github.com/AdguardTeam/AdguardFilters/issues/60248
pressherald.com##.pum[data-popmake*="cookies"]
pressherald.com##html:style(overflow:auto !important)
```

Analog is fixed in https://github.com/easylist/easylist/commit/b9acb719c0276c381c843a119e4ebc0a25a695b9
```
! cookie consent with scroll locked
analog.com###cookie-consent-container.modal
analog.com##.modal-backdrop
analog.com##body.modal-open:style(overflow:auto !important)
```


germany.travel already covered in ELC
```
! cookie consent with scroll locked
germany.travel##.consent
germany.travel##body.consent-overlay:style(overflow:auto !important)
```

viget.com already covered in ELC
```
! viget.com cookie-notice
viget.com##[class^="gpdr-banner__"]
```

Filters adjusted, only needed for newsletter overlay. https://github.com/easylist/easylist/commit/c4ebfaa25f6468710e588d0ec387cadfd56116f6
```
! https://forums.lanik.us/viewtopic.php?p=156018#p156018
nieuwsblad.be###didomi-host
nieuwsblad.be##body:style(overflow: auto !important;)

```