### PR TITLE
Update unbreak.txt

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4444,3 +4444,6 @@ docer.pl#@#[class^="ad-"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/12503
 @@||outbrain.com^$script,domain=welt.de
+
+! 2022-03-31 https://outlook.live.com Fix blank space after the ad is removed from above the Inbox mail list
+outlook.live.com##.yZRhrkgSvfIJft2hDX0A.pX_v1fcFEGaM6uhNozvY


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://outlook.live.com/mail/`

### Describe the issue

The uBlock Origin extensions blocks the ad placed above the email list in Outlook but it remains a blank space.

### Screenshot(s)

Before

![image](https://user-images.githubusercontent.com/13287878/160996598-78f99b21-c216-48b0-b02e-ab685d4dd74a.png)


After

![image](https://user-images.githubusercontent.com/13287878/160996852-7dc8f3a3-9883-4624-965f-b71615f3ef67.png)


### Versions

- Browser/version: Microsoft Edge Linux / 99.0.1150.55 (Official build) (64-bit)
- uBlock Origin version: 1.42.0

### Settings

- Added `outlook.live.com##.yZRhrkgSvfIJft2hDX0A.pX_v1fcFEGaM6uhNozvY` to the list

### Notes

