### PR TITLE
Fixes popups on https://crichd.tv/ipl-t20-2022-live-streaming

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -1959,6 +1959,10 @@ doomovie-hd.com##[data-ultimate-banana-map-id]
 doomovie-hd.com###ekcdnplayer > div[style]
 doomovie-hd.com##+js(set, adSettings, [])
 
+! https://crichd.tv/ipl-t20-2022-live-streaming
+noob4cast.com##+js(acis, JSON.parse, break;case $.)
+noob4cast.com##+js(aopw, _pop)
+
 ! https://note1s.com/notes/LZ9U4J timer
 note1s.com##.countdown
 note1s.com##+js(ra, disabled, button)


### PR DESCRIPTION
[<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://crichd.tv/ipl-t20-2022-live-streaming`

### Describe the issue

Popads + Propeller ads.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave
- uBlock Origin version: 1.41.8

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes
