### PR TITLE
Update instagram.com annoyances

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -1357,11 +1357,6 @@ androidcentral.com##.swal-overlay
 ! https://github.com/uBlockOrigin/uAssets/issues/5030
 instagram.com##.ZUqME:has(a[href^="/accounts/emailsignup/"])
 
-! https://old.reddit.com/r/uBlockOrigin/comments/dimzi2/how_to_block_login_pop_up_on_instagram/
-! https://github.com/uBlockOrigin/uAssets/issues/6481
-instagram.com##body[style*="overflow: hidden;"]:style(overflow-y: scroll !important;)
-instagram.com##body[style*="overflow: hidden;"] .XQXOT:style(width: calc(100% - 12px) !important; padding-right: 0 !important;)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/6481#issuecomment-615294565
 instagram.com##+js(set, _sharedData.is_whitelisted_crawl_bot, true)
 ! https://github.com/uBlockOrigin/uAssets/issues/7758


### PR DESCRIPTION

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://www.instagram.com

### Describe the issue

Instagram will now redirect to the login page and not showing a popup. This is now deprecated.
This current filters will break article/post padding view: go to instagram and click view more comments on any post, a post popup(?) will be shown with incorrect padding on the right.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/49080794/161635695-9bcb6d32-e10e-4433-bca0-e845769a556d.png)

### Versions

- Browser/version: Firefox/98.0.2
- uBlock Origin version: 1.42.0

### Settings

None

### Notes

None
