### PR TITLE
Block kyanhninbwuplxe.com choachim.com css add popups

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1518,3 +1518,7 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 */bouncy.php?*&inPopUp=$all
 ||demnan.com^
 ||1redirc.com^$all
+
+! 2022-04-05 https://mycima.wiki
+||kyanhninbwuplxe.com^
+||choachim.com^


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://mycima.wiki/watch/%d9%85%d8%b4%d8%a7%d9%87%d8%af%d8%a9-%d9%85%d8%b3%d9%84%d8%b3%d9%84-%d8%a7%d9%84%d9%83%d8%a8%d9%8a%d8%b1-%d8%a7%d9%88%d9%8a-%d9%85%d9%88%d8%b3%d9%85-6-%d8%ad%d9%84%d9%82%d8%a9-4/`

### Describe the issue

The first time you visit the site you have no cookies, it somehow uses css to generate a cookie and redirect you to the popup site e.g gearbest 

### Screenshot(s)

![image](https://user-images.githubusercontent.com/15360245/161863056-63d9ab8e-2b72-40c7-b526-2c3c80ea8cd4.png)

![2022-04-05 23_43_25-](https://user-images.githubusercontent.com/15360245/161863122-4bc7ad9c-dc0f-4bf1-ae83-d13c3b39be03.png)

![2022-04-05 23_43_37-Window](https://user-images.githubusercontent.com/15360245/161863140-f62abb07-1d07-4ffb-98d8-0148af3dacb3.png)

### Notes

After blocking 
`kyanhninbwuplxe.com`
It started redirecting to `choachim.com` 
We need a smarter way to detect these weird css iframe popup things. Hoping that we can get a more robust fix through