### PR TITLE
address antiadb iptvjournal .com

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -2036,3 +2036,7 @@ playtamil.*##+js(acis, JSON.parse, break;case $.)
 !#if env_mobile
 ||playtamil.*^$csp=default-src 'self' *.imgur.com
 !#endif
+
+! antiadb iptvjournal. com
+iptvjournal.com##+js(no-fetch-if, googlesyndication)
+iptvjournal.com##+js(nano-sib, timer)

--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -2039,4 +2039,5 @@ playtamil.*##+js(acis, JSON.parse, break;case $.)
 
 ! antiadb iptvjournal. com
 iptvjournal.com##+js(no-fetch-if, googlesyndication)
-iptvjournal.com##+js(nano-sib, timer)
+iptvjournal.com###wpsafe-generate,#wpsafe-link:style(display: block !important;)
+iptvjournal.com##div[id^="wpsafe-wait"]


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://insurance.iptvjournal.com/how-to-apply-for-credit-cards/`

`https://khatrimaza.miami/?aHR0cHM6Ly9pbnN1cmFuY2UuaXB0dmpvdXJuYWwuY29tLz93cHNhZmVsaW5rPXU2OXQ2TWF0Z0x3QXBic0NhZGZFZUZsZ2lIbmlrV2l0cFRVSjNUalIzZW1SNE4zZHZaVEl3ZEcxTFYxVnZUbVJaYlZGalZqRnVTMmxLUTNKTlowY3ZkRUZ6ZVROb1VVeG1WbEpxV0VOM04yZ3JUbFJ4THc9PQ--`


### Describe the issue

antiadblock preventing site access

### Screenshot(s)

https://user-images.githubusercontent.com/20338483/161926073-58c5d579-9f33-4e40-b4c3-37a14116e005.png

### Versions

- Browser/version: firefox 99
- uBlock Origin version: 1.42.3b0

### Settings

- uBO's default settings

### Notes
