### PR TITLE
address gomovies. cyou popunders

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -10563,6 +10563,7 @@ gomovies.*,gomoviesc.*##+js(nowoif)
 gostream.*,gomovies.*##+js(set, check_adblock, true)
 gomovies.*##+js(acis, JSON.parse, break;case $.)
 gomovies.*##^script:has-text(break;case $.)
+gomovies.cyou##+js(aopr, mm)
 gomovieshub.io##+js(acis, String.fromCharCode, /btoa|break/)
 gomovieshub.io##+js(acis, document.createElement, 'script')
 gomovieshub.io##[target="_blank"]


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.gomovies.cyou/movie/homeland-season-8/watching.html?ep=1&sv=9`

### Describe the issue

popunders

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera browser stable
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes
