### PR TITLE
m4ufree. tv popups

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -5416,6 +5416,7 @@ m4ufree.*##+js(nostif, debugger)
 srtaem.bar##+js(aopr, absda)
 m4ufree.*,streamm4u.*##+js(nowebrtc)
 m4ufree.*##+js(acis, Promise, JSON.parse)
+m4ufree.*##+js(aopr, mm)
 ##[href^="//look.ufinkln.com/"]
 ##[href*="https://recommendedforyou.xyz/"]
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://ww1.m4ufree.tv/watch-yite7-what-do-men-want-1921-movie-online-free-m4ufree.html`

### Describe the issue

unblocked popups

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox stable
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes