### PR TITLE
Prime activation scams

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1523,3 +1523,8 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||demnan.com^
 ||1redirc.com^$all
 ||nutrientassumptionclaims.com^$all
+
+! Prime activation scam. Runs PPC ads for typos of the URL to activate Amazon prime in order to trick victims into calling and paying money for things they don't need
+||tvmounting/sample1/errorpage.php?phone=$all
+||stepform/wallmounttv/stepthree.html^$all
+||/step(one|two|three)\.php\?text=.*\&submit=Register\+Device/


### PR DESCRIPTION
### URL(s) where the issue occurs

I have a large list of the URLs here, but many of the sites already got suspended:
https://scammer.info/t/amazon-prime-scammers/83882

I have a few active ones here, though:
```
https://jacobtvmountingservice.com/activate/
https://streamwebx.online/services/
http://ziltzwebsol.online/tvmounting/
http://ziltzwebsol.online/tvmounting/sample1/secondpage.php?phone=%2B1-808-210-3358&status=1
```

### Describe the issue

These scammers run PPC ads for the URL to activate your Amazon prime account using a certain code. They then make websites that look very similar to the real Amazon Prime activation page, but ultimately leads to a fake page telling users to call a number to activate their account.

The call center answering the call will generally be different from the individual creating the fake scam page, however, most of them follow the format of something along the lines of "Your Prime account got hacked and the subscription was accidentally canceled, would you like to sign up again?" (the scammer then proceeds to steal credit card information, and sometimes tries to get access to the victim's account)

### Screenshot(s)

![image](https://user-images.githubusercontent.com/98493235/162830502-0ecc7b42-4fc3-47a0-bb57-d6561981cace.png)
![image](https://user-images.githubusercontent.com/98493235/162830600-c3f03197-9682-49c8-a874-67a20d1229e3.png)
![image](https://user-images.githubusercontent.com/98493235/162830610-0ab1d7cc-50d1-42f0-a621-7839e0a83b7d.png)
