### PR TITLE
files .im popups

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -11234,16 +11234,16 @@ loverscum.com##+js(nostif, nextFunction, 250)
 
 ! https://forums.lanik.us/viewtopic.php?p=145613#p145613
 ! https://github.com/uBlockOrigin/uAssets/issues/10420
-atomixhq.*,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##^script:has-text(break;case $.)
-pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(acis, I833)
-pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(acis, JSON.parse, break;case $.)
-pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(acis, Math, break;case $.)
-pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(aopr, AaDetector)
-pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(aopr, TID)
-atomixhq.*,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(aopw, _pop)
-atomixhq.*,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(aopw, adcashMacros)
-atomixhq.*,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(nowoif, !/download\/|link/)
-atomixhq.*,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##.ads
+atomixhq.*,maxitorrent.com,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##^script:has-text(break;case $.)
+maxitorrent.com,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(acis, I833)
+maxitorrent.com,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(acis, JSON.parse, break;case $.)
+maxitorrent.com,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(acis, Math, break;case $.)
+maxitorrent.com,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(aopr, AaDetector)
+maxitorrent.com,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(aopr, TID)
+atomixhq.*,maxitorrent.com,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(aopw, _pop)
+atomixhq.*,maxitorrent.com,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(aopw, adcashMacros)
+atomixhq.*,maxitorrent.com,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##+js(nowoif, !/download\/|link/)
+atomixhq.*,maxitorrent.com,pctfenix.*,pctmix.com,pctnew.*,pctreload.com##.ads
 *$script,3p,denyallow=cloudflare.net|fontawesome.com|googleapis.com|hwcdn.net|jquery.com,domain=atomixhq.*|maxitorrent.com|pctfenix.*|pctmix.com|pctreload.com
 atomtt.com##+js(nowoif, !/download\//)
 @@||acorta-enlace.com^$ghide
@@ -18955,6 +18955,8 @@ files.im##+js(acis, JSON.parse, break;case $.)
 files.im##+js(aopr, absda)
 files.im##+js(aopr, LieDetector)
 files.im##+js(nowoif)
+files.im##+js(aeld, , break;case $.)
+files.im##+js(acis, document.createElement, 'script')
 ||files.im/ppa
 ||89coins.org^$popup,3p
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://files.im/02rx7sjv2uzz`

### Describe the issue

popup ads opening in new tab randomly

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera/firefox stable
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes
kept `files.im##+js(abort-current-script, JSON.parse, break;case $.)` though similar can be achieved with aeld filter