### PR TITLE
files. im popups

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -18955,6 +18955,8 @@ files.im##+js(acis, JSON.parse, break;case $.)
 files.im##+js(aopr, absda)
 files.im##+js(aopr, LieDetector)
 files.im##+js(nowoif)
+files.im##+js(aeld, , break;case $.)
+files.im##+js(acis, document.createElement, 'script')
 ||files.im/ppa
 ||89coins.org^$popup,3p
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://files.im/02rx7sjv2uzz`

### Describe the issue

popup ads opening in new tab randomly

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera/firefox stable
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes
kept `files.im##+js(abort-current-script, JSON.parse, break;case $.)` though similar can be achieved with aeld filter