### PR TITLE
fix uploadever. in ads

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -1744,7 +1744,7 @@ poki-gdn.com##+js(aopr, alert)
 klubsports.xyz##+js(acis, JSON.parse, break;case $.)
 
 ! https://github.com/easylist/easylist/issues/11449
-uploadever.in##+js(acis, eval, String.fromCharCode)
+uploadever.in##+js(acis, getCookie, onload)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/tnow27/adblock_detected_at_chimicamoorg/
 chimicamo.org##+js(no-xhr-if, ads)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://uploadever.in/rtcb9lgfyevt`

### Describe the issue

redirection to crap intermediate site

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes
