### PR TITLE
desiupload. co annoyance

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -4701,6 +4701,7 @@ insidemarketing.it##.homeBannerMax
 
 ! https://github.com/uBlockOrigin/uAssets/issues/1835
 desiupload.*,9xupload.*##+js(nano-stb)
+desiupload.*##+js(acis, eval, String.fromCharCode)
 desiupload.*##[href*="desifile.in/404"]
 /glx_*.js$script
 ||beigeiros.pw^


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
https://dl1.desiupload.to/i4c9lzki1sga
https://desiupload.co/i4c9lzki1sga
```

### Describe the issue

while going to page ,intermediate ad pages like verify observed
above fillter skips annoyance and enable direct download

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes

