### PR TITLE
Update https://github.com/uBlockOrigin/uAssets/issues/5468

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -12832,6 +12832,7 @@ uploadbox.cc##.hopa
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5468
 pandafiles.com##+js(aopw, _pop)
+||careerqna.com^$3p
 ||grumft.com^$3p
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5469


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://pandafiles.com/8dn6zzfx47d0`

### Describe the issue

on clicking free download, it redirects to soralink site
filter enables direct download from parent site 

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes