### PR TITLE
address solarmovies .movie ads

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -2181,7 +2181,7 @@ oceanplay.org##+js(nostif, devtool)
 oceanplay.org##+js(aopr, __Y)
 
 ! new-propeller popups
-1rowsports.com,clipconverter.cc,dailyuploads.net,dood.*,fzlink.*,gogoplay5.com,goload.pro,happy2hub.org,songspk.*,stream4free.live,tamilguns.org,webseries.club##+js(aeld, , break;case $.)
+1rowsports.com,clipconverter.cc,dailyuploads.net,dood.*,fzlink.*,gogoplay5.com,goload.pro,happy2hub.org,solarmovies.*,songspk.*,stream4free.live,tamilguns.org,webseries.club##+js(aeld, , break;case $.)
 
 ! uploadbaz. me ,uploader. trade,uploadraja. com, uploadingsite.com intermediate ad
 uploadbaz.*,uploader.*,uploadraja.com,uploadingsite.com##+js(acis, onload)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www1.solarmovies.movie/film/the-taming-of-the-shrew-2022/watching.html?ep=0`

### Describe the issue

popup ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes

`solarmovies.*##+js(aopr, XMLHttpRequest)`
or 
`solarmovies.*##+js(aost, Object, inlineScript)`

also work