### PR TITLE
Make it domain specific

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -9141,8 +9141,8 @@ wordgames.com###skyscraper-container
 ! https://github.com/NanoMeow/QuickReports/issues/306
 nandatrio.com##+js(aopw, adBlockDetected)
 
-! 123movies.net popups
-123movies.*##+js(aopr, XMLHttpRequest)
+! 123movies.net/tc popups
+123movies.tc##+js(aopr, XMLHttpRequest)
 123movies.*##^script:has-text(break;case $.)
 123movies.*##+js(acis, Math, break;case $.)
 123movies.*##+js(aopr, AaDetector)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://wwv.123movies.wiki/movie/shang-chi-and-the-legend-of-the-ten-rings-TcTfIM/`

### Describe the issue

on above domain ,embed is blocked so make filter domain specific

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera stable
- uBlock Origin version: 1.42.4

### Settings

- uBO's default settings

### Notes
