### PR TITLE
watchseries9. cc popunders

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -2202,3 +2202,6 @@ traderepublic.community##+js(nostif, show)
 vidhdthe.online##+js(aopr, JSON.parse)
 ||numbtoobly.com^
 ||edstever.com^
+
+! watchseries9. cc popups
+watchseries9.*##+js(aopr, mm)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://watchseries9.cc/watch-online/the-batman/episode/001`

### Describe the issue

popups/unders in page

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera 
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes
