### PR TITLE
update https://github.com/uBlockOrigin/uAssets/issues/7958

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -3794,9 +3794,7 @@ asiansex.life###spot-holder
 eztvtorrent.org##+js(aopr, exoJsPop101)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7958
-*$script,3p,domain=moviesverse.*
-*$script,3p,denyallow=addtoany.com,domain=hdmovieshub.*
-*$script,3p,denyallow=addtoany.com,domain=hdmovieshubz.*
+moviesverse.*##+js(acis, parseInt, break;case $.)
 
 ! manga-raw.club ads
 manga-raw.club##+js(acis, document.createElement, '+d+')


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://moviesverse.club/download-barry-lyndon-1975-english-bluray-480p-720p-1080p/`

### Describe the issue

popups
not required as such as of now
```
*$script,3p,domain=moviesverse.*
*$script,3p,denyallow=addtoany.com,domain=hdmovieshub.*
*$script,3p,denyallow=addtoany.com,domain=hdmovieshubz.*
```

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.5b0


### Settings

- uBO's default settings

### Notes
