### PR TITLE
unbreak download

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -775,7 +775,7 @@ financeflix.in,studyranks.in,technoflip.in##+js(nano-sib, timer)
 linkshortify.site##+js(set, blurred, false)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11667
-chillx.top##+js(nowoif)
+chillx.top##+js(nowoif, !/d/)
 chillx.top###theotherads
 
 ! https://github.com/easylist/easylist/commit/7a6130a149d0b832928bf5e8fc6d007aebce7ae6

--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -882,7 +882,7 @@ megafilmeshdonline.org##+js(aopr, __Y)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/12476
 beastx.top,playerx.stream###theotherads
-beastx.top,playerx.stream##+js(nowoif)
+beastx.top,playerx.stream##+js(nowoif, !/d/)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/srza8x/changing_domain_name_every_hour_same_ip_address/
 wat32.tv##+js(acis, JSON.parse, break;case $.)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://chillx.top/v/JLOmqFnz8URE/`

from `https://movierulztvv.com`

### Describe the issue

not able to download due to `chillx.top##+js(nowoif)`

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes

Even this can be removed as an alternative 

`chillx.top##+js(nowoif)`  without requiring above tweak