### PR TITLE
A: ylilauta.org (new ad image)

### DIFF
--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -135,6 +135,7 @@ search.seznam.cz##[class]:not([style]):matches-css(background-image: /url.*svg/)
 *$image,domain=fcdn.lauta.media,redirect-rule=32x32.png
 ||adform.net^$domain=fcdn.lauta.media,script,xhr,redirect-rule=noopjs
 ||es.ylilauta.org/files/f0/d5/f0d5a578a9853e15.jpg
+||es.ylilauta.org/files/84/d3/84d37bcf7c1656d4.jpg
 @@||adform.net/banners/scripts/adx.js^$xhr,domain=lauta.media|ylilauta.org
 @@||adx.adform.net/adx/$script,xhr,domain=lauta.media|ylilauta.org
 @@||ads.ylilauta.org^$frame,1p


### PR DESCRIPTION
### URL(s) where the issue occurs

`ylilauta.org`, on random page refreshes, inside the ad container at the top

### Describe the issue

Ad image inside the ad container. (The graphics makes it look like a joke but it contains the same stuff as the first ad picture that's already listed).

### Screenshot(s)

![kuva](https://user-images.githubusercontent.com/17256841/163724608-07014da3-e85b-42cd-a9d6-95af972fb46c.png)

### Versions

FF 99.0.1
1.42.5b0

### Settings

Can repro with defaults

### Notes