### PR TITLE
vegaview .xyz ads

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -2336,3 +2336,7 @@ acrackstreams.com##+js(nowoif)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/12834
 ||mathwarehouse.com/sitefiles/*/js/fixblock.js?$script,1p
+
+! vegaview .xyz ads
+vegaview.xyz##+js(acis, parseInt, break;case $.)
+vegaview.xyz##^script:has-text(break;case $.)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://vegaview.xyz/vgwp58193367/`
from `https://vegamovies.run/download-k-g-f-chapter-2-2022-hq-hdcamrip-hindi-dubbed-movie-480p-720p-1080p/`

### Describe the issue

popups

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera/firefox
- uBlock Origin version: 1.42.4
 
### Settings

-  uBO's default settings

### Notes
