### PR TITLE
A: ylilauta.org

### DIFF
--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -149,6 +149,7 @@ search.seznam.cz##[class]:not([style]):matches-css(background-image: /url.*svg/)
 ||lauta.media^$media,redirect=noopmp4-1s,domain=ylilauta.org
 ||plausible.lauta.media/api/event^$xhr
 ||static.ylilauta.org/api/event^$xhr,1p,redirect=nooptext
+ylilauta.org##body.error
 
 ! https://github.com/easylist/easylist/commit/aa0d63b1b7e66b046f29236ee7a0cc9c90cb7de7#commitcomment-71441976
 ||altmetric.com^$3p,badfilter


### PR DESCRIPTION

### URL(s) where the issue occurs

`ylilauta.org`

### Describe the issue

Occasionally when loading the page, there will be a big nag screen about ads that could not be loaded.

### Screenshot(s)

![kuva](https://user-images.githubusercontent.com/17256841/163870570-43a9b303-c121-4e82-948d-9ddcc7ec0067.png)

### Versions

- Firefox 99.0.1
- uBlock Origin version: 1.42.5b1

### Settings

- Defaults

### Notes

The whole iframe cannot be hid without causing the page to notice it but hiding that big screen of text is fine.