### PR TITLE
Update AdShield for uBO users

### DIFF
--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -95,6 +95,7 @@ inven.co.kr#@#section.ad-right2
 googleads.g.doubleclick.net###google-center-div
 googleads.g.doubleclick.net###abgc
 googleads.g.doubleclick.net##html[i-amphtml-no-boilerplate][amp4ads][class="i-amphtml-inabox"]
+loawa.com,ygosu.com,inven.co.kr,ppss.kr##+js(set, innerHeight, undefined)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11152
 *$script,redirect-rule=noopjs,domain=rjno1.com


### PR DESCRIPTION
### URL(s) where the issue occurs

- loawa.com
- ygosu.com
- inven.co.kr
- ppss.kr

### Describe the issue

AdShield ad container appears on sites that addressed before.

### Screenshots

<details>

<summary>ppss.kr</summary>

![ppss kr_](https://user-images.githubusercontent.com/30369714/164070114-19c4d07d-d393-41bf-8e79-09bd90c2d904.png)

![ppss kr_ (1)](https://user-images.githubusercontent.com/30369714/164070195-b1c396dd-9c1c-4d39-bbe4-cfacb6218c65.png)

</details>

<details>

<summary>loawa.com</summary>

![loawa com_](https://user-images.githubusercontent.com/30369714/164070323-2b7e0f76-e2ec-42b0-ae5d-5be284106aad.png)

![loawa com_ (1)](https://user-images.githubusercontent.com/30369714/164070345-a85f4ee2-b58c-4068-9583-3add2b13ecab.png)

![loawa com_ (2)](https://user-images.githubusercontent.com/30369714/164070371-02b849dd-5960-40cf-a0a5-9b2643a1c184.png)

</details>

<details>

<summary>ygosu.com</summary>

![ygosu com_](https://user-images.githubusercontent.com/30369714/164070441-65103e50-8bde-460e-9d5f-d2a480bf8265.png)

![ygosu com_ (1)](https://user-images.githubusercontent.com/30369714/164070471-1a671315-017a-4088-bde7-f74629513424.png)

</details>

<details>

<summary>inven.co.kr</summary>

![www inven co kr_](https://user-images.githubusercontent.com/30369714/164070559-9e5328e4-bca0-455e-b3f7-4a7744d38b51.png)

![www inven co kr_ (1)](https://user-images.githubusercontent.com/30369714/164070589-2c62f01d-7b4a-410b-9576-c67a7e878a47.png)

</details>

### Versions

- uBlock Origin: 1.42.4
- Chromium: 100

### Settings

<details>

```
uBlock Origin: 1.42.4
Chromium: 100
filterset (summary): 
  network: 135978
  cosmetic: 175525
  scriptlet: 32566
  html: 0
listset (total-discarded, last updated): 
  added: 
    https://github.com/seia-soto/filter-kr/raw/master/filter.txt: 119-0, 1h.42m
    https://github.com/seia-soto/filter-kr/raw/master/filters-specific/namuwiki.useless.txt: 4-0, 21m
    https://github.com/seia-soto/filter-kr/raw/master/filters-specific/twitter.useless.txt: 2-0, 21m
    JPN-1: 6591-7, 1d.1h.37m
    adguard-annoyance: 52023-174, 1d.1h.37m
    adguard-generic: 63845-707, 1d.1h.37m
    adguard-mobile: 7585-70, 1d.1h.37m
    adguard-social: 16827-854, 1d.1h.37m
    adguard-spyware: 26224-1009, 1d.1h.37m
    adguard-spyware-url: 556-13, 1d.1h.37m
    block-lan: 43-0, 1d.1h.37m
    curben-phishing: 12770-0, 21m
    curben-pup: 275-0, 21m
    fanboy-cookiemonster: 30018-2357, 1d.1h.37m
    fanboy-thirdparty_social: 68-3, 1d.1h.37m
  default: 
    user-filters: 6-0, never
    KOR-1: 8197-5, 1d.1h.37m
    easylist: 66009-1270, 1d.1h.37m
    easyprivacy: 26830-10404, 1d.1h.37m
    plowe-0: 3682-970, 1d.1h.37m
    ublock-abuse: 74-0, 1d.1h.37m
    ublock-badware: 4077-290, 1d.1h.37m
    ublock-filters: 30609-3482, 1d.1h.37m
    ublock-privacy: 211-40, 1d.1h.37m
    ublock-quick-fixes: 171-9, 21m
    ublock-unbreak: 1762-106, 1d.1h.37m
    urlhaus-1: 7454-1, 21m
filterset (user): [array of 3 redacted]
switchRuleset: 
  added: [array of 1 redacted]
modifiedUserSettings: 
  advancedUserEnabled: true
modifiedHiddenSettings: [none]
supportStats: 
  allReadyAfter: 286 ms (selfie)
  maxAssetCacheWait: 402 ms
```

</details>

### Notes

Note that this filter is already added to List-KR which is default Korean filter of AdGuard. However, to support most of uBO users who enabled YousList as an only local filter list, I think it's better to put the rule on uAssets.

```css
loawa.com,ygosu.com,inven.co.kr,ppss.kr##+js(set, innerHeight, undefined)
```

The above filter will make calculation error on their ad rendering code without being detected.
However, their update is fast enough to beat the ad filters for common users (who doesn't update manually). This is why I am adding this to quick fix.

Also, here is last script that I investigated.

- https://pastebin.mozilla.org/jFXjRahG