### PR TITLE
unbreak hexupload. net

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -17392,7 +17392,6 @@ hexupload.net##+js(acis, JSON.parse, break;case $.)
 hexupload.net##+js(aopw, _pop)
 hexupload.net##+js(aopw, Fingerprint2)
 hexupload.net##+js(nowoif)
-*$script,3p,denyallow=bootstrapcdn.com|cloudflare.com|cloudflare.net|google.com|gstatic.com|hwcdn.net|jsdelivr.net|tawk.to|zencdn.net,domain=hexupload.net
 
 ! popups https://animetak .net/
 animetak.*##+js(acis, JSON.parse, break;case $.)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://hexupload.net/oqswss84yrbr`

### Describe the issue

video player controls appears broken

### Screenshot(s)

**ublock origin enabled=**
https://user-images.githubusercontent.com/20338483/164343001-eba727b2-9c00-4730-9550-f424e7e334d9.png

**ublock origin disabled**=
https://user-images.githubusercontent.com/20338483/164343074-391f9fc0-657d-4b61-a323-a295ff8e1eb1.png


### Versions

- Browser/version: firefox a
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes
