### PR TITLE
Updated adshield block script (from #12853)

### DIFF
--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -81,6 +81,7 @@ ppss.kr##a[href*="president.go.kr"] > img:style(height: 600px !important; width:
 ppss.kr##a[href*="cartax.biz"] > img:style(height: 87px !important; width: 630px !important;)
 ppss.kr##a[href*="president.go.kr"]:style(pointer-events: none !important;)
 ppss.kr##a[href*="cartax.biz"]:style(pointer-events: none !important;)
+loawa.com,ygosu.com,inven.co.kr,ppss.kr,tgd.kr##+js(set, outerHeight, 0)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11152
 *$script,redirect-rule=noopjs,domain=rjno1.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

AdShield ad installed:

```
loawa.com,ygosu.com,inven.co.kr,ppss.kr,tgd.kr
```

AdShield tracker installed (not addressed in this PR):

```
loawa.com,ygosu.com,inven.co.kr,ppss.kr,tgd.kr,joongang.co.kr,donga.com,dailymagazine.co.kr,dailian.co.kr,socialvalue.kr,hobbyen.co.kr,usjournal.kr,ujnews.co.kr,siminilbo.co.kr,mdtoday.co.kr,thespike.co.kr,basketkorea.com,jumpball.co.kr,inews24.com
```

### Describe the issue

Ad provided by AdShield recovered from last update.

### Screenshot(s)

Please check out the previous PR.

### Versions

- uBlock Origin: 1.42.4
- Chromium: 100

### Settings

Tested on clean setup of uBO with Chromium v100.

### Notes

This is continuous PR from #12853 .

- https://github.com/List-KR/List-KR/pull/298
