### PR TITLE
address ads ytix. xyz for firefox

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -2466,3 +2466,6 @@ hotabis.com##[href^="https://axiadata.co.id"]
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/116108
 66ccff.work##+js(alert-buster)
+
+! ads ytix.xyz
+ytix.xyz##^script:has-text(break;case $.)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://ytix.xyz/convert/43299/OGey74KvjIw`

### Describe the issue

popup ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox stable
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes
