### PR TITLE
address topflix. fm ads

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -10922,8 +10922,8 @@ elespanol.com##+js(set, tieneAdblock, 0)
 
 ! https://github.com/NanoAdblocker/NanoFilters/issues/263
 ! https://github.com/NanoMeow/QuickReports/issues/1642
-topflix.*##+js(acis, Math, XMLHttpRequest)
-topflix.*##+js(acis, String.fromCharCode, XMLHttpRequest)
+topflix.*##+js(acis, parseInt, break;case $.)
+masterplayer.xyz##+js(aeld, click, popundr)
 onifile.com,topflix.*##+js(nano-sib)
 topflix.*##+js(nowoif)
 @@||topflix.*^$ghide
@@ -10931,6 +10931,7 @@ topflix.*##+js(nowoif)
 onifile.com##+js(aopw, _pop)
 onifile.com##+js(aost, Math.random, /\st\.[a-zA-Z]*\s/)
 topflix.*##+js(aopr, console.clear)
+||resumeconcurrence.com^
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=42541
 atlasserverlist.com##+js(aopr, adBlockDetected)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://topflix.fm/filmes/assistir-online-panico/`

### Describe the issue

popup ads on main site as well as video embeds

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera browser
- uBlock Origin version: 1.42.4

### Settings

- uBO's default settings

### Notes
