### PR TITLE
update speedostream filter

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -1520,6 +1520,8 @@ speedostream.com##+js(acis, Math, break;case $.)
 speedostream.com##+js(aost, Object.getOwnPropertyDescriptor, /^/)
 speedostream.com##+js(aost, JSON.parse, computed)
 speedostream.com##^script:has-text(break;case $.)
+speedostream.com##+js(aeld, , break;case $.)
+||s.speedostream.com^$script,1p
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/76791
 @@||nnaa66.xyz^$ghide


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

embed over here **NSFW** `https://flizmovies.cc/best-bhabhi-2022-season-1-hotx-originals-uncut-Watch-online-on-flizmovies/`

### Describe the issue

when downloading from speedostream ,popups arises

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera 
- uBlock Origin version: 1.42.4

### Settings

- uBO's default settings

### Notes
