### PR TITLE
update filter moviewatchonline. com.pk

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -1213,7 +1213,7 @@ moviewatchonline.com.pk##+js(acis, JSON.parse, break;case $.)
 moviewatchonline.com.pk##+js(aeld, , break;case $.)
 moviewatchonline.com.pk##^script:has-text(break;case $.)
 moviewatchonline.com.pk##+js(aopw, atOptions)
-*$3p,frame,denyallow=adblockstreamtape.art|dood.so|dood.ws|jetpack.wordpress.com|mixdrop.ch|mixdrop.sx|ok.ru|pkspeed.net|playersb.com|streamtape.com|streamtapeadblock.art|widgets.wp.com,domain=moviewatchonline.com.pk
+*$3p,frame,denyallow=adblockstreamtape.art|dood.pm|dood.so|dood.ws|jetpack.wordpress.com|mixdrop.to|mixdrop.ch|mixdrop.sx|ok.ru|pkspeed.net|playersb.com|streamtape.com|streamtapeadblock.art|widgets.wp.com,domain=moviewatchonline.com.pk
 moviewatchonline.com.pk##[href^="https://angularconstitution.com/"]
 moviewatchonline.com.pk##[href*="?key="]
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://moviewatchonline.com.pk/kalavu-thozhirchalai-2017-hindi-dubbed-full-movie-watch-online-hd-print-free-download/`

### Describe the issue

`dood.pm`/`mixdrop.to` embed is prevented due to denyallow rule ,due to fact that those embed domains are changing domains frequently

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes

If its too frequent domain change ,consider removing denyallow filter
