### PR TITLE
knowyourmeme.com CPU drain

### DIFF
--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -137,3 +137,6 @@ bilibili.com,dandanzan.top,nunuyy.*,v.qq.com##+js(nowebrtc)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/tznsj6/help_creating_a_block_filter_for_background/
 app.koinly.io##.login-page:style(-webkit-animation: none !important)
+
+! knowyourmeme.com CPU drain when ads fail to load
+knowyourmeme.com##+js(nosiif, blogherads)


### PR DESCRIPTION
### URL(s) where the issue occurs

`knowyourmeme.com`, `news.knowyourmeme.com`

### Describe the issue

knowyourmeme.com has some pretty nasty busy-polling scripts to enable ads that drain CPU time and spam the developer console if ads fail to load. This filter disables them.

### Versions

- Browser/version: Firefox ESR 91
- uBlock Origin version: 1.42.4

### Settings

Not applicable

### Notes

Unobfuscated <https://s.kym-cdn.com/assets/desktop-3803bd870954a11d320339e610cb6b14.js>:

```js
  this.SheMedia = {
    init: function () {
      var t,
      e,
      n,
      i,
      o,
      r,
      s;
      return n = document.getElementById('shemedia-data'),
      null != n ? (r = n.getAttribute('data-script'), i = document.createElement('script'), i.type = 'text/javascript', i.src = r, i.async = 'async', i.data - (e = 'false'), document.body.appendChild(i), s = n.getAttribute('data-headerscript'), o = document.createElement('script'), o.type = 'text/javascript', o.src = s, o.async = 'async', o.data - (e = 'false'), document.body.appendChild(o), t = setInterval(function () {
        return blogherads ? (Ad.load(), Ad.track(), clearInterval(t), void 0) : void 0
      }, 300)) : void 0
    },
```

```js
return n = setInterval(function () {
        return blogherads ? (blogherads.adq.push(function () {
          var n;
          return n = blogherads.defineSlot(t, e),
          n.display()
        }), clearInterval(n), void 0) : void 0
      }, 300)
```

Honestly, the site abuses `setInterval` to such an extent that disabling it entirely looks attractive.