### PR TITLE
unbreak streamtape frame

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4507,3 +4507,6 @@ cadenadial.com##+js(aost, History, /(^(?!.*(Function|HTMLDocument).*))/)
 ! fix slide images
 @@||laptopoutlet.co.uk/wysiwyg/asus/rise-up/popunder-$image,1p
 @@||laptopoutlet.co.uk/wysiwyg/lenovo/*_popunder_$image,1p
+
+! unbreak streamtape frame
+@@||streamadblockplus.com^$frame,domain=streamtape.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://vw1.ffmovies.sc/film/salesmen-2022/`

the streamtape frame

### Describe the issue

streamadblockplus.com is blocked by regex rule

<details>
  <summary>Click here to expand</summary>

`/^https?:\/\/[0-9a-z]{8,}\.com\/.*/$3p,~media,domain=1cloudfile.com|2embed.ru|9xmovies.app|9xupload.asia|adblockstreamtape.art|adblockstreamtape.fr|adblockstreamtape.site|allsports.icu|aotonline.co|bowfile.com|cast4u.xyz|cloudvideo.tv|coloredmanga.com|daddylive.click|daddylive.fun|deltabit.co|dood.la|dood.pm|dood.sh|dood.so|dood.to|dood.watch|dood.ws|drivebuzz.icu|dslayeronline.com|dulu.to|dum.to|embedsb.com|embedsito.com|embedstream.me|eplayvid.net|evoload.io|fembed-hd.com|fileclub.cyou|filmy4wap.ink|flashx.net|fmovies.ps|gamovideo.com|gaybeeg.info|givemenbastreams.com|gogoanimes.org|gogoplay.io|gogoplay4.com|gomo.to|goodstream.org|hdfilme.cx|hexupload.net|hurawatch.at|kickasstorrents.to|linkhub.icu|linksafe.cc|mangareader.cc|mangovideo.pw|maxsport.one|mixdrop.bz|mixdrop.ch|mixdrop.club|mixdrop.co|mixdrop.sx|mixdrop.to|mixdrops.xyz|mp4upload.com|mystream.to|nelion.me|nocensor.biz|ovagames.com|pcgamestorrents.com|playtube.ws|pouvideo.cc|projectfreetv2.com|proxyer.org|putlockers.gs|rojadirecta.watch|scloud.online|send.cm|shortlinkto.icu|skidrowcodex.net|soccerstreamslive.co|stape.fun|stayonline.pro|strcloud.in|streamlare.com|streamsport.icu|streamta.pe|streamta.site|streamtape.com|streamtapeadblock.art|streamz.ws|streamzz.to|strtape.cloud|strtape.tech|strtapeadblock.club|superstream123.net|supervideo.tv|theproxy.ws|upbam.org|uplinkto.one|uproxy.to|upstream.to|uptobhai.com|userload.co|userload.xyz|vidembed.me|videovard.sx|vidlox.me|vidsrc.me|vidsrc.stream|vipleague.tv|vivo.sx|voe.sx|vudeo.io|vupload.com|wowlive.info|yodbox.com`
</details>

so can't see the video

### STR
click server backup> servers > streamtape

### Screenshot(s)

<details>
  <summary>Click here to expand</summary>

![image](https://user-images.githubusercontent.com/20338483/165825992-401b94bc-a46a-42ef-8d5d-0e7051c64449.png)
![Opera Snapshot_2022-04-29_000745_chrome-extension](https://user-images.githubusercontent.com/20338483/165826082-05d5bcc3-0c4a-43ed-a0c1-f8c938102d51.png)
</details>

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes

Hard to reproduce sometimes
reported to EL maintainer but doesn't get any feedback from them ,so a PR here
