### PR TITLE
world4ufree. plus antiadb(firefox)

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -2987,8 +2987,10 @@ gurl.pw##+js(nosiif, visibility, 1000)
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=pozirk.com
 
 ! https://github.com/NanoMeow/QuickReports/issues/4536
+! world4ufree. plus antiadblock
 world4ufree.*##+js(aeld, , _0x)
 world4ufree.*##+js(acis, parseInt, break;case $.)
+world4ufree.*##+js(acis, eval, replace)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7796
 krankheiten-simulieren.de##+js(nostif, exitTimer)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`world4ufree.plus`

### Describe the issue

antiadblock preventing the site access in firefox

### Screenshot(s)

![firefox_IiVv3BHsoN](https://user-images.githubusercontent.com/20338483/165891808-6d480f6f-0d3c-4cb0-a7a3-279466de0f29.png)

### Versions

- Browser/version: firefox stable
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes
