### PR TITLE
Update

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -2431,8 +2431,10 @@ androidapks.biz,androidsite.net,animeonlinefree.org,animesite.net,computercrack.
 ! https://github.com/uBlockOrigin/uAssets/issues/12880
 mat6tube.com##+js(set, ads, undefined)
 
-! multiup. is popups
-multiup.us##+js(nowoif)
+! multiup. us popups
+!multiup.us##+js(nowoif)
+multiup.us##+js(aopr, BetterJsPop)
+||multiup.us/cdn-cgi/trace$xhr,1p
 
 ! https://github.com/uBlockOrigin/uAssets/issues/12884
 techydino.net##+js(nostif, displayMessage)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
https://multiup.us/files/?id=04252022104149

https://1.multiup.us/watch_video.php?v=MXhtdVpVbTRPalpTaVVyeThYTDFQV2pxc2tNN3YwQllyZ3duWFozeVNjYXhSbDJINjl6TkpCbStzUUZwU20zeA%3D%3D#iss=MTAzLjE1My4xNjcuMTM5
```

### Describe the issue

update as per https://github.com/webcompat/web-bugs/issues/103479

previous fix was added for `https://1.multiup.us/watch_video.php?v=MXhtdVpVbTRPalpTaVVyeThYTDFQV2pxc2tNN3YwQllyZ3duWFozeVNjYXhSbDJINjl6TkpCbStzUUZwU20zeA%3D%3D#iss=MTAzLjE1My4xNjcuMTM5`

but breaks opening links here

`https://multiup.us/files/?id=04252022104149`

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox
- uBlock Origin version: 1.42.4

### Settings

- uBO's default settings

### Notes
