### PR TITLE
address moviesjoy popups

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -2586,3 +2586,9 @@ apkmagic.com.ar##+js(no-xhr-if, ads)
 ! https://forums.lanik.us/viewtopic.php?t=47501-gamaniak-com
 @@||gamaniak.com^$script,1p
 @@||gamaniak.com^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/issues/13035
+! moviesjoy. pw/.best/.plus popunders
+moviesjoy.*##+js(acis, parseInt, break;case $.)
+moviesjoy.*##+js(aopr, mm)
+||meteorclashbailey.com^


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`moviesjoy(.pw/.best/.plus)`

### Describe the issue

everything under https://github.com/uBlockOrigin/uAssets/issues/13035
and popunders at above domains