### PR TITLE
address goload.pro popups

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -2190,6 +2190,8 @@ freemoviesfull.com,paidnaija.com##+js(acis, parseInt, break;case $.)
 hindilinks4u.*##^script:has-text(break;case $.)
 /ajax/banner/list?page=$xhr,1p
 ovamusic.com##+js(aopw, _pop)
+goload.pro##+js(aeld, click, 0x)
+||goload.click^$3p
 
 ! uploader. trade,uploadingsite. com,uploadraja. com intermediate ad
 uploader.*,uploadingsite.com,uploadraja.com##+js(acis, onload)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://goload.pro/download?id=MTg1NDk1&title=One+Piece%3A+Luffy+Senpai+Ouen+Kikaku%21+Barto+no+Himitsu+no+Heya%21+Episode+2&mip=0.0.0.0&refer=https://ww2.gogoanime2.org/&ch=d41d8cd98f00b204e9800998ecf8427e&token2=a_S8BpAiJl1LsSW8obsjxA&expires2=1651386915&op=1`

### Describe the issue

popups

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox
- uBlock Origin version: 1.42.4

### Settings

- uBO's default settings

### Notes
