### PR TITLE
movie123. in ads

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -2840,3 +2840,12 @@ faucetcrypto.net##+js(acis, eval, decodeURIComponent)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/118042
 freepreset.net##+js(no-fetch-if, googlesyndication)
+
+! movie123. in ads
+movie123.in##+js(acis, Math, XMLHttpRequest)
+movie123.in##+js(aopw, Fingerprint2)
+||d2qnx6y010m4rt.cloudfront.net^
+||effections.xyz^
+||fnyfiexpectth.xyz^
+||win-bidding.com^
+movie123.in##[href*="rebrand.ly/"]


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://movie123.in/guilty-minds-2022/`

### Describe the issue

unblocked ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.4

### Settings

- uBO's default settings

### Notes
