### PR TITLE
feat(privacy.txt): add Fabricators analyics

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -401,3 +401,6 @@ webtoons.com##+js(set, lcs_SerName, '')
 
 ! https://vostanimez.com/Episode/shokei-shoujo-no-ikiru-michi-the-executioner-and-her-way-of-life-vostfr-saison-1-episode-6-streaming-hd/
 ||imsdb.pw/player/ip.php
+
+! Fabricators analytics
+||analytics.fabricators.ltd/sdk/web/countly.min.js


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://usebottles.com` (probably more...)

### Describe the issue
This is fabricators analytics that from what I can see is used in usebottles.com.
there probably isn't many websites that use this at least not yet anyway.

### Versions

- Browser/version: Firefox 100.0 (64-bit)
- uBlock Origin version: 1.42.4

### Settings
(the default was a bit unclear guessing my customization's)
filterset (summary): 
  network: 119530
  cosmetic: 141775
  scriptlet: 34469
  html: 657
listset (total-discarded, last updated): 
  added: 
    adguard-generic: 63576-4885, 10m
    adguard-mobile: 7703-155, 9m
    adguard-spyware: 26160-954, 7m
    adguard-spyware-url: 597-15, 5m
    block-lan: 43-0, 24d.21h.5m
    adguard-annoyance: 52849-1672, 4m
    adguard-social: 17015-28, 3d.23h.53m
    ublock-annoyances: 4399-4, 3d.23h.54m
filterset (user): [array of 39 redacted]
modifiedUserSettings: [none]
modifiedHiddenSettings: [none]