### PR TITLE
address gdtot.re ads

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -14050,7 +14050,7 @@ tusfiles.com##+js(nowoif)
 tusfiles.com##+js(acis, JSON, break;case)
 tusfiles.com##^script:has-text(break;case $.)
 ||tusfiles.com/sw.js$script,1p
-gdtot.*##+js(acis, JSON.parse, break;case $.)
+gdtot.*##+js(acis, parseInt, break;case $.)
 gdtot.*,tusfiles.com##+js(acis, document.createElement, 'script')
 ||bhrbbwup.xyz^
 ||opositeass.com^


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://new.gdtot.re/file/431833580`

### Describe the issue

unblocked ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes
