### PR TITLE
address 2embed.ru ads

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -4482,9 +4482,9 @@ mediapemersatubangsa.com##+js(aopw, _pop)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/90217
 2embed.ru##^script:has-text(break;case $.)
-2embed.ru##+js(acis, Promise, break;case $.)
+2embed.ru##+js(aeld, , break;case $.)
 *$script,3p,denyallow=gstatic.com,domain=la123movies.com
-*$script,3p,denyallow=cloudflare.net|google.com|gstatic.com|jsdelivr.net,domain=2embed.ru
+*$script,frame,xhr,css,image,3p,denyallow=cloudflare.net|dood.watch|embed2.megaxfer.ru|google.com|googleapis.com|gstatic.com|jsdelivr.net|rabbitstream.net|upstream.to|voe-unblock.com|voe.sx,domain=2embed.ru
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/89900
 ! https://github.com/MajkiIT/polish-ads-filter/pull/20116


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

<details>
  <summary>Click to expand!</summary>

```
https://newprimewire.space/movie/the-lost-city-76072
https://primewire-movies.com/movie/fantastic-beasts-the-secrets-of-dumbledore-76075
https://theprimewire.site/movie/the-getaway-king-80047
https://ww.thesoap2day.com/movies/nobody-1/
https://soap2day.digital/movie/the-northman-78847
https://wwv.la123movies.com/movie/salmon-fishing-in-the-yemen/
https://vw2.ffmovies.sc/film/salesmen-2022/
https://www.2embed.ru/embed/tmdb/movie?id=752623
```
</details>


### Describe the issue

unblocked ads on `2embed.ru` in above domains

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera/firefox
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes

Updated denyallow rule for `2embed.ru` ,it might be useful when propeller changes the code
