### PR TITLE
update https://github.com/uBlockOrigin/uAssets/issues/6057

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -14508,7 +14508,6 @@ prad.de##+js(nostif, Delay)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6057
 letsupload.io##+js(acis, JSON.parse, break;case $.)
-*$script,3p,domain=letsupload.*
 ||umbemonop.info^
 ||etoads.net^$3p
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://letsupload.io/1QLry/`

### Describe the issue

With ` *$script,3p,domain=letsupload.*` in place (default ubo settings) on firefox; page is blank whenever try to download.
it seems it blocks cname request `dotblocking.dummy` which results in blank page at last

### Screenshot(s)

https://user-images.githubusercontent.com/20338483/169232496-27aec5d9-79a7-469d-836e-bc7c7138103d.png

https://user-images.githubusercontent.com/20338483/169232504-8e348bab-ef61-4949-bdb4-5a03afdf2489.png


### Versions

- Browser/version: firefox stable browser
- uBlock Origin version: 1.42.4

### Settings

- uBO's default settings + vpn on

### Notes

