### PR TITLE
fix: exclude loawa.com (breakage)

### DIFF
--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -107,7 +107,7 @@ ppss.kr##a[href*="cartax.biz"]:style(pointer-events: none !important;)
 ||ppss.kr/wp-content/uploads/2022/02/cartax-*.jpg$image,domain=ppss.kr
 loawa.com##div[id^="ad_"]:style(z-index: -10000 !important; position: absolute !important;)
 loawa.com##div[class="p-0 m-0 mb-2 d-none d-md-block text-center "]:style(z-index: -10000 !important; position: absolute !important;)
-ppss.kr,ygosu.com,tgd.kr,inven.co.kr,loawa.com,feedclick.net##+js(aopr, document.querySelectorAll)
+ppss.kr,ygosu.com,tgd.kr,inven.co.kr,feedclick.net##+js(aopr, document.querySelectorAll)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11152
 *$script,redirect-rule=noopjs,domain=rjno1.com

--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -1,5 +1,5 @@
 ! Title: Quick fixes list
-! Description: experimental filters 
+! Description: experimental filters
 ! Expires: 1 days
 ! Last modified: %timestamp%
 ! License: https://creativecommons.org/licenses/by/3.0/
@@ -107,6 +107,7 @@ ppss.kr##a[href*="cartax.biz"]:style(pointer-events: none !important;)
 ||ppss.kr/wp-content/uploads/2022/02/cartax-*.jpg$image,domain=ppss.kr
 loawa.com##div[id^="ad_"]:style(z-index: -10000 !important; position: absolute !important;)
 loawa.com##div[class="p-0 m-0 mb-2 d-none d-md-block text-center "]:style(z-index: -10000 !important; position: absolute !important;)
+ppss.kr,ygosu.com,tgd.kr,inven.co.kr,loawa.com,feedclick.net##+js(aopr, document.querySelectorAll)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11152
 *$script,redirect-rule=noopjs,domain=rjno1.com


### PR DESCRIPTION
From #13312 , `loawa.com` is causing breakage on sub-pages as I checked again and should be excluded for now.
