### PR TITLE
fix(urlhaus-filter): host migrated to malware-filter.gitlab.io

### DIFF
--- a/tools/update-3rdparties.sh
+++ b/tools/update-3rdparties.sh
@@ -12,7 +12,7 @@ assets=(
     ['thirdparties/easylist-downloads.adblockplus.org/easyprivacy.txt']='https://easylist.to/easylist/easyprivacy.txt'
     ['thirdparties/pgl.yoyo.org/as/serverlist']='https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=1&startdate%5Bday%5D=&startdate%5Bmonth%5D=&startdate%5Byear%5D=&mimetype=plaintext'
     ['thirdparties/publicsuffix.org/list/effective_tld_names.dat']='https://publicsuffix.org/list/public_suffix_list.dat'
-    ['thirdparties/urlhaus-filter/urlhaus-filter-online.txt']='https://curben.gitlab.io/urlhaus-filter/urlhaus-filter-online.txt'
+    ['thirdparties/urlhaus-filter/urlhaus-filter-online.txt']='https://malware-filter.gitlab.io/urlhaus-filter/urlhaus-filter-online.txt'
 )
 
 for i in "${!assets[@]}"; do


### PR DESCRIPTION
### Describe the issue

curben.gitlab.io has been migrated to malware-filter.gitlab.io to avoid [gitlab quota](https://about.gitlab.com/blog/2021/11/11/public-project-minute-limits).
