### PR TITLE
address slmaxed. com popunders

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -3139,3 +3139,8 @@ imdbembed.xyz###addiv
 apkmody.io##+js(acis, parseInt, break;case $.)
 apkmody.io##+js(nano-stb, download_loading, *)
 ||tiwhaiph.net^
+
+! slmaxed. com{streamlare alias} ads
+slmaxed.com##+js(nostif, 0x)
+slmaxed.com##+js(set, console.clear, noopFunc)
+


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`streamlare.com` mirror

`https://slmaxed.com/v/4j57gDmQKaeD26Xb`

### Describe the issue

popunders when clicked play

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.4

### Settings

- uBO's default settings

### Notes

