### PR TITLE
chore: add dailian.co.kr to adcrap list

### DIFF
--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -77,7 +77,7 @@ aternos.org##ins[id^="gpt_unit_"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/12163
 ppss.kr##+js(no-fetch-if, adsbygoogle)
-ppss.kr,ygosu.com,tgd.kr,loawa.com,inven.co.kr,feedclick.net##+js(nostif, , 10)
+ppss.kr,ygosu.com,tgd.kr,loawa.com,inven.co.kr,feedclick.net,dailian.co.kr##+js(nostif, , 10)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11152
 *$script,redirect-rule=noopjs,domain=rjno1.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

- https://dailian.co.kr/news/view/1100127

### Describe the issue

Yet another AdShield website.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/30369714/169655228-7efdb0ce-9066-4362-90e1-6ff68527cb30.png)

![image](https://user-images.githubusercontent.com/30369714/169655134-f0adfeae-8d56-4a63-a13b-0c5ff6f5d5e7.png)

### Versions

- Browser/version: Waterfox (FF 91)
- uBlock Origin version: 1.42.4

### Settings

### Notes

- https://forum.adguard.com/index.php?threads/adshield-ads-cannot-be-blocked.48434/#post-221577
- https://listauthorschat.slack.com/archives/C010N14G4TF/p1653141468155389?thread_ts=1652992922.980719&cid=C010N14G4TF
