### PR TITLE
limetorrents. cyou popunders

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -7617,6 +7617,7 @@ elixx.*##^script:has-text(0x3)
 limetorrents.*##+js(aeld, , _0x)
 limetorrents.*##+js(aeld, load, onload)
 limetorrents.*##+js(acis, Object.assign, popunder)
+limetorrents.*##+js(acis, Math, XMLHttpRequest)
 limetorrents.*##[href^="/fast.php"]
 limetorrents.*##tr:has-text(VPN)
 ||limetorrents.*/sw.js


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`limetorrents.cyou`

### Describe the issue

popunders

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.4

### Settings

- uBO's default settings

### Notes
