### PR TITLE
Fixes @amedia/browserid/ tracker

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -397,3 +397,6 @@ webtoons.com##+js(set, lcs_SerName, '')
 
 ! tarnkappe. info tracking
 tarnkappe.info##+js(aopr, Matomo)
+
+! https://assets.acdn.no/pkg/@amedia/browserid/1.1.6/index.js trackers
+salsaposten.no,steinkjer-avisa.no,hamar-dagblad.no,lofot-tidende.no,avisa-valdres.no,amta.no,firdaposten.no,ringblad.no##+js(nostif, waiting) 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Fixes `https://assets.acdn.no/pkg/@amedia/browserid/1.1.6/index.js` trackers used by various .no sites


### Versions

- Browser/version: Brave
- uBlock Origin version: 1.42.4


