### PR TITLE
https://github.com/easylist/easylist/issues/12147#issue-1251695641

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4589,7 +4589,7 @@ webii.ir#@#.ads-sidebar
 webii.ir#@#.ads-box
 `@@||webii.ir/upload/ads/$image`
 @@||1000site.ir/asset/images/images/adpage/$image
-@@1000site.ir/home/ads/asset/favicon.ico
+@@||1000site.ir/home/ads/asset/favicon.ico
 sakhtafzar.com#@#.ads-title
 sakhtafzar.com#@#.ads-content
 sakhtafzar.com#@#.ads_box

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4605,5 +4605,6 @@ gooyait.com#@#.banner-ads
 gamesib.ir#@#.ads_2
 farsroid.com#@#.place-ads
 @@||beytoote.com/ads/images_$image,1p
+@@||ads.beytoote.com/live_chat
 @@||blogfa.com/static/ads/
 @@||asandl.com/ads/img/$image

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4605,6 +4605,7 @@ gooyait.com#@#.banner-ads
 gamesib.ir#@#.ads_2
 farsroid.com#@#.place-ads
 @@||beytoote.com/ads/images_$image,1p
+@@||beytoote.com/ads/js/$script,1p
 @@||ads.beytoote.com/live_chat
 @@||blogfa.com/static/ads/
 @@||asandl.com/ads/img/$image

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4578,3 +4578,36 @@ thelincolnite.co.uk#@#.inline-ad
 
 ! https://github.com/uBlockOrigin/uAssets/issues/13284
 @@||googletagmanager.com/gtm.js$script,domain=mumzworld.com
+
+! https://github.com/easylist/easylist/issues/12147#issue-1251695641
+tamin.ir#@#.ads2
+@@||tamin.ir/content/ads/
+
+@@||cdn01.zoomit.ir/assets/img/advertise-*.jpg$image
+@@||cdn.zoomg.ir/banners/demo/advertise-zoomg.jpg$image
+webii.ir#@#.ads-sidebar
+webii.ir#@#.ads-box
+`@@||webii.ir/upload/ads/$image`
+@@||1000site.ir/asset/images/images/adpage/$image
+@@1000site.ir/home/ads/asset/favicon.ico
+sakhtafzar.com#@#.ads-title
+sakhtafzar.com#@#.ads-content
+sakhtafzar.com#@#.ads_box
+sakhtafzar.com#@#.tz_ad300_widget
+@@||sourceiran.com/wp-content/uploads/*.jpg
+forum.p30world.com#@##ad_global_above_footer
+@@||persianv.com/wp-content/uploads/*/adv-*.jpg
+@@||parsiblog.com/Adv/imgs/
+@@||niksalehi.com/wp-content/uploads/*/adv
+nicmusic.net#@#.boxads
+@@||images.kojaro.com/assets/ad/advertise-*.jpg
+gooyait.com#@#.page-ads
+gooyait.com#@#.banner-ads
+gamesib.ir#@#.ads_2
+farsroid.com#@#.place-ads
+cooldl.net#@#.ads-box
+cooldl.net#@#.ads-content
+@@||beytoote.com/ads/images_pc/$image
+@@||beytoote.com/ads/images_mob/$image
+@@||blogfa.com/static/ads/
+@@||asandl.com/ads/img/$image

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4594,7 +4594,6 @@ sakhtafzar.com#@#.ads-title
 sakhtafzar.com#@#.ads-content
 sakhtafzar.com#@#.ads_box
 sakhtafzar.com#@#.tz_ad300_widget
-@@||sourceiran.com/wp-content/uploads/*.jpg
 forum.p30world.com#@##ad_global_above_footer
 @@||persianv.com/wp-content/uploads/*/adv-*.jpg
 @@||parsiblog.com/Adv/imgs/

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4604,9 +4604,6 @@ gooyait.com#@#.page-ads
 gooyait.com#@#.banner-ads
 gamesib.ir#@#.ads_2
 farsroid.com#@#.place-ads
-cooldl.net#@#.ads-box
-cooldl.net#@#.ads-content
-@@||beytoote.com/ads/images_pc/$image
-@@||beytoote.com/ads/images_mob/$image
+@@||beytoote.com/ads/images_$image,1p
 @@||blogfa.com/static/ads/
 @@||asandl.com/ads/img/$image


### PR DESCRIPTION
https://github.com/easylist/easylist/issues/12147#issue-1251695641
Since EasyList maintainer @Khrin didn't like cooperating with the downstream.

All rules should be kept *until* PersianBlocker is added as default (hopefully).
The only rules which are too important and can't be removed are (until EasyList decides to add them):
```
tamin.ir#@#.ads2
@@||tamin.ir/content/ads/
```