### PR TITLE
viprow. nu ads

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -9035,7 +9035,7 @@ oncehelp.com##[href*="?token"]
 tionghoa.info##.adsbygoogle
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4059
-viprow.*##+js(aeld, , break;case $.)
+viprow.*##+js(acis, parseInt, break;case $.)
 viprow.*##+js(nowoif, |)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4060


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.viprow.nu/sky-sports-news-ssn-breaking-sports-news-online-stream-1`

### Describe the issue

popups

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes

