### PR TITLE
update https://github.com/NanoMeow/QuickReports/issues/3529

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -34,6 +34,8 @@ mysflink.blogspot.com##+js(nano-sib)
 
 ! https://github.com/NanoMeow/QuickReports/issues/3529
 neonlink.net##+js(aopr, app_vars.force_disable_adblock)
+neonlink.net##+js(set, blurred, false)
+neonlink.net##+js(nowoif)
 
 ! https://github.com/NanoMeow/QuickReports/issues/3531
 sofwaremania.blogspot.com##+js(nano-stb)


### PR DESCRIPTION
I would rather not share a URL publicly, so could a `uAssets` maintainer please try to create a URL on `https://neonlink.net/`?