### PR TITLE
Fix ad popup on discussingfilm.net

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -3337,6 +3337,11 @@ yugen.to##+js(acis, parseInt, break;case $.)
 angelfire.com##+js(acis, document.write, lycos_ad)
 angelfire.com##^script[type]:has-text(lycos_ad)
 
+! Paramount ad popup overlay
+discussingfilm.net##.mfp-wrap
+discussingfilm.net##.mfp-bg
+discussingfilm.net##html:style(overflow: auto !important;)
+
 ! https://www.reddit.com/r/uBlockOrigin/comments/v1s4c4/please_fix_antiadblocker_detection/
 madshiba.fun##+js(nostif, show)
 *$script,domain=tieutietkiem.com,redirect-rule=noopjs


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`[At least one URL for a web page where the clearly described issue occurs is **mandatory**. The backticks surrounding the URLs is important, it prevents the URL from being clickable. Warn with "NSFW" where applicable.]`

### Describe the issue

Opening `discussingfilm.net` (and clearing cookies) and restore scroll.

### Screenshot(s)
![discus](https://user-images.githubusercontent.com/1659004/171304634-14490aeb-dee1-45ec-b624-638b2c110459.png)


### Versions

- Browser/version: Brave
- uBlock Origin version: 1.42.4

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
