### PR TITLE
Update badware.txt for balena Etcher

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1567,3 +1567,7 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ! https://twitter.com/rarara18181818/status/1530214731608313856
 /rtbfeed.php?$image,3p
 ||mepiloxa.com^$all
+
+! https://forums.balena.io/t/counterfeit-etcher-websites/274606/5
+||etcher.net
+||etcher.download

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1569,5 +1569,5 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||mepiloxa.com^$all
 
 ! https://forums.balena.io/t/counterfeit-etcher-websites/274606/5
-||etcher.net
-||etcher.download
+||etcher.net^$all
+||etcher.download^$all


### PR DESCRIPTION
```
||etcher.net
||etcher.download
```

Confirmed by the balena team: `forums.balena.io/t/counterfeit-etcher-websites/274606/5`
The real website is: `balena.io/etcher/`

[Credit](https://github.com/DRSDavidSoft/additional-hosts/blob/master/domains/blacklist/fake-domains.txt#L43-L45): @DRSDavidSoft