### PR TITLE
animefrenzy.net ads

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -14188,7 +14188,8 @@ watchgameofthrones.*##+js(nobab)
 watchgameofthrones.*###keeper2
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/cfnizw/
-@@||animefrenzy.net^$ghide
+animefrenzy.net##+js(acis, parseInt, break;case $.)
+animefrenzy.net##^script:has-text(break;case $.)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5987
 mad4wheels.com##+js(aopr, adblock)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://animefrenzy.net/stream/tsubasa-to-hotaru-2015-episode-4`

### Describe the issue

popups

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera/firefox
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes

i just removed `@@||animefrenzy.net^$ghide` as i can't see any antiadblock there,if anyone reproduce please review

