### PR TITLE
address ads at 111.90.151.26

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -3374,3 +3374,8 @@ mathportal.org##.googleOglasVrhCalculatorResp
 
 ! https://github.com/uBlockOrigin/uAssets/issues/13516
 course9x.com##+js(aeld, , show)
+
+! 111.90.151.26 ads
+111.90.151.26##+js(aopr, preroll_helper.advs)
+111.90.151.26##+js(acis, jQuery, magnificPopup)
+111.90.151.26##[href^="http://buaksib.in/"]


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://111.90.151.26/krodh/`

### Describe the issue

preroll /banner ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox android
- uBlock Origin version: 1.42.4

### Settings

- uBO's default settings

### Notes

