### PR TITLE
address wigistream .to ads

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -5888,12 +5888,15 @@ arkadiumhosted.com##+js(set, Adv_ab, false)
 xpicse.com##+js(acis, document.querySelectorAll, popMagic)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/kicmhf/adblock_detected/
-live-eventsport.com##+js(acis, document.getElementById, alert)
 streamsport.*##+js(aopw, _pop)
-wigistream.to##+js(aopw, adcashMacros)
-wigistream.to##+js(nowoif)
 streamsport.*##+js(aeld, , _0x)
 streamsport.*##+js(nowoif)
+wigistream.to##+js(aopw, adcashMacros)
+wigistream.to##+js(nowoif)
+*$script,3p,denyallow=jsdelivr.net|fastly.net|swarm.video,domain=wigistream.to
+||addeby.com^
+||caeory.com^
+||wzcdn264.net^$badfilter
 wigistream.to##div[style="position:absolute;top:0;left:0;width: 100%;height: 100%;z-index:2147483647"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8396


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://wigistream.to/embed/8tafh22njcm8i1`
over here
`https://starlive.xyz/embed.php?id=live10m`

### Describe the issue

video doesn't play and address changing adservers

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox stable
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes

