### PR TITLE
Remove filters for Persian websites (from uBlock Unbreak and Annoyances)

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -6154,11 +6154,6 @@ koszalincity.pl##+js(acis, document.onkeydown)
 ! https://github.com/uBlockOrigin/uAssets/issues/12297
 theghostinmymachine.com##+js(acis, document.oncontextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/issues/12279
-jobinja.ir##.c-forceToLogin__overlay
-jobinja.ir##.c-forceToLogin__message.o-box
-jobinja.ir##[class*="forceToLogin"] [class*="forceToLogin"]:style(filter: none !important)
-
 ! codehelppro.com anti-adblock
 @@||codehelppro.com^$ghide
 codehelppro.com##.adsbygoogle

--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -6076,11 +6076,6 @@ gamingsinners.com##+js(acis, $, test)
 ! https://github.com/uBlockOrigin/uAssets/issues/11785
 allhorror.com##.ad-placeholder-wrapper
 
-! https://github.com/uBlockOrigin/uAssets/issues/11786
-coffeeapps.ir##+js(aopr, nocontext)
-coffeeapps.ir##+js(acis, disableSelection, reEnable)
-coffeeapps.ir##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/11788
 bike-parts-sym.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 

--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -1013,9 +1013,6 @@ cine.to##+js(aeld, , /open.*_blank/)
 ! https://github.com/uBlockOrigin/uAssets/issues/11779
 thebharatexpressnews.com##+js(aopr, b2a)
 
-! https://github.com/uBlockOrigin/uAssets/issues/11786
-coffeeapps.ir##+js(nowoif)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/11790
 world4ufree1.*##+js(acis, parseInt, break;case $.)
 

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4543,9 +4543,6 @@ duckduckgo.com#@#.js-sidebar-ads
 @@||bayanbox.ir/view/$image
 @@||cdn.asriran.com^$image
 
-! https://github.com/uBlockOrigin/uAssets/discussions/13259#discussioncomment-2784865
-tebyan.net#@#.theiaStickySidebar
-
 ! https://github.com/uBlockOrigin/uAssets/issues/13290
 @@||app.detrack.com/api/v2/tracking$xhr
 

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4576,32 +4576,6 @@ tebyan.net#@#.theiaStickySidebar
 ! https://github.com/uBlockOrigin/uAssets/pull/13443
 tamin.ir#@#.ads2
 @@||tamin.ir/content/ads/
-@@||zoomit.ir/assets/img/advertise-$image,1p
-@@||zoomg.ir/banners/demo/advertise-zoomg.jpg
-webii.ir#@#.ads-sidebar
-webii.ir#@#.ads-box
-@@||webii.ir/upload/ads/$image,1p
-@@||1000site.ir/asset/images/images/adpage/$image,1p
-@@||1000site.ir/home/ads/asset/favicon.ico
-sakhtafzar.com#@#.ads-title
-sakhtafzar.com#@#.ads-content
-sakhtafzar.com#@#.ads_box
-sakhtafzar.com#@#.tz_ad300_widget
-forum.p30world.com#@##ad_global_above_footer
-@@||persianv.com/wp-content/uploads/*/adv-$image,1p
-@@||parsiblog.com/Adv/imgs/
-@@||niksalehi.com/wp-content/uploads/*/adv
-nicmusic.net#@#.boxads
-@@||images.kojaro.com/assets/ad/advertise-$image,1p
-gooyait.com#@#.page-ads
-gooyait.com#@#.banner-ads
-gamesib.ir#@#.ads_2
-farsroid.com#@#.place-ads
-@@||beytoote.com/ads/images_$image,1p
-@@||beytoote.com/ads/js/$script,1p
-@@||ads.beytoote.com/live_chat
-@@||blogfa.com/static/ads/
-@@||asandl.com/ads/img/$image,1p
 
 ! voeunblock2.com break by EL regex filter
 @@||voeunblock2.com^$frame,3p


### PR DESCRIPTION
Addressed in [PersianBlocker](https://github.com/MasterKia/PersianBlocker)
https://github.com/gorhill/uBlock/commit/33b839fdd03f74689df3ee2b5c25a06435b350e0

Since `tamin.ir` is an important government website, it should stay in uBlock Unbreak in case someone doesn't enable the regional list.