### PR TITLE
Remove Persian websites from uBlock Unbreak

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4538,11 +4538,6 @@ duckduckgo.com#@#.js-sidebar-ads
 ! https://github.com/uBlockOrigin/uAssets/issues/13222
 @@||postclickmarketing.com^$domain=adtspecials.com|befinanciallyfit.com|cursodemedicina.com.br|demandmetric.com|hootsuite.com|semipresencial.com.br|systemsprotect.com
 
-! https://github.com/uBlockOrigin/uAssets/discussions/13259#discussion-4078224
-@@||ashoora.ir/images/banners/$image
-@@||bayanbox.ir/view/$image
-@@||cdn.asriran.com^$image
-
 ! https://github.com/uBlockOrigin/uAssets/issues/13290
 @@||app.detrack.com/api/v2/tracking$xhr
 


### PR DESCRIPTION
No longer needed, because Adblock-Iran is replaced with PersianBlocker

I forgot those in the last pull request.