### PR TITLE
Addressed in PersianBlocker and dead links

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -18759,14 +18759,6 @@ femalefirst.co.uk##+js(aopr, ppload)
 @@||shana.pe.kr^$ghide
 shana.pe.kr##.adsbygoogle
 
-! fardasub .pw popups
-fardasub.pw##+js(aopr, open)
-||adsima.net^$3p
-
-! subtak .ir popups
-subtak.ir##+js(aopr, open)
-||zarpop.com^$3p
-
 ! perfectmomsporn .com ads + popunder
 perfectmomsporn.com##+js(aopr, Aloader)
 perfectmomsporn.com##+js(noeval)


### PR DESCRIPTION
`zarpop.com` (Persian popup site) and `adsima.net` (Persian ads site) are addressed in PersianBlocker.
`subtak.ir` and `fardasub.pw` seem to be dead Persian sites.