### PR TITLE
Fingerprint script

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -400,3 +400,6 @@ tarnkappe.info##+js(aopr, Matomo)
 
 ! https://assets.acdn.no/pkg/@amedia/browserid/1.1.6/index.js trackers
 salsaposten.no,steinkjer-avisa.no,hamar-dagblad.no,lofot-tidende.no,avisa-valdres.no,amta.no,firdaposten.no,ringblad.no##+js(nostif, waiting) 
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/119788
+||customfingerprints.bablosoft.com/clientsafe.js

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -402,4 +402,4 @@ tarnkappe.info##+js(aopr, Matomo)
 salsaposten.no,steinkjer-avisa.no,hamar-dagblad.no,lofot-tidende.no,avisa-valdres.no,amta.no,firdaposten.no,ringblad.no##+js(nostif, waiting) 
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/119788
-||customfingerprints.bablosoft.com/clientsafe.js
+||customfingerprints.bablosoft.com^


### PR DESCRIPTION
`customfingerprints.bablosoft.com/clientsafe.js`

Could be found when visiting `https://yun.ir/hj6nr6`.
Other sites which use this script:
https://github.com/AdguardTeam/AdguardFilters/issues/119788

It hasn't been addressed in EasyPrivacy yet.
