### PR TITLE
update https://github.com/uBlockOrigin/uAssets/issues/2233

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -3197,7 +3197,8 @@ flashx.*##+js(nowoif)
 flashx.*##+js(acis, Math, zfgloaded)
 flashx.*##+js(acis, String.fromCharCode, 'shift')
 flashx.net##+js(set, $.adblock, 0)
-@@||fastcontentdelivery.com^$media,domain=flashx.net
+||fastcontentdelivery.com^$badfilter
+flashx.*##+js(acis, Math, XMLHttpRequest)
 flashx.*##^script:has-text(FingerprintJS)
 @@||flashx.*/counter.cgi$script
 flashx.*##A[href$=".html"][rel="nofollow norefferer noopener"]


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.flashx.tv/b9jmey1c7fcv.html`

### Describe the issue

download blocked due to  `||fastcontentdelivery.com^` in EL

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera
- uBlock Origin version: 1.42.4

### Settings

-  uBO's default settings

### Notes

