### PR TITLE
Add badware url

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1598,5 +1598,5 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ! https://twitter.com/AP_Zenmashi/status/1538071140035608577
 /^https:\/\/www\.aeon\.[a-z]{7,8}\.com\/login\.php\?user_token=\d+/$doc
 
-! https://github.com/uBlockOrigin/uAssets/pull/
+! https://github.com/uBlockOrigin/uAssets/pull/13858
 ||skyblockqolhub.com^$all


### PR DESCRIPTION
`skyblockqolhub.com` is distributing malware in the form of Minecraft mods. It steals saved browser passwords, Minecraft authentication tokens, ip addresses, and Discord authentication tokens. It also downloads an executable file and sets it to run when windows starts up.

Proof:

Jar files on the website are obfuscated, so I used https://github.com/java-deobfuscator/deobfuscator to deobfuscate. The result can be put into [recaf](https://github.com/Col-E/Recaf):

![image](https://user-images.githubusercontent.com/58223632/175988955-d615b34d-c91a-4695-90eb-04888347d304.png)
![image](https://user-images.githubusercontent.com/58223632/175989278-6085d025-bf81-47c0-9d6c-e7be50633b3a.png)
![image](https://user-images.githubusercontent.com/58223632/175989332-c4c3f5d4-23f6-4458-ac01-3948f5fa5b81.png)
![image](https://user-images.githubusercontent.com/58223632/175989532-4d479c74-3d1b-4f4a-9bfa-1f6678fa8d62.png)