### PR TITLE
deepl.com: prevent link injection into the clipboard

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -6646,3 +6646,6 @@ box-manga.com##+js(aeld, contextmenu)
 
 ! https://go.rocklinks.net/ivrYmh anti right click
 disheye.com##+js(aopr, alert)
+
+! deepl.com: prevent link injection into the clipboard
+deepl.com##+js(aeld, copy)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.deepl.com/translator`

### Describe the issue

Often enough (though not every time), copying the translated text from the output panel on the right results in an advertising link being injected at the end of the clipboard, like "Translated with `www.DeepL.com/Translator` (free version)". This filter disables it.

### Versions

- Browser/version: Firefox ESR 91.11.0 
- uBlock Origin version: 1.43.0
