### PR TITLE
Redundant entries

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -196,9 +196,6 @@
 ! https://github.com/uBlockOrigin/uAssets/issues/34
 @@||premium.soundcloud.com/*/js/tracking.js$script,1p
 
-! https://github.com/uBlockOrigin/uAssets/issues/46
-@@||snoobi.com^$script,domain=kartta.hel.fi
-
 ! https://github.com/gorhill/uBlock/issues/1737
 @@||googletagmanager.com/gtm.js?$domain=willyweather.com.au
 


### PR DESCRIPTION
These entries are not needed. The site doesn't use `snoobi.com` anymore (I didn't see that entry in the logger).

Checkboxes under "Layers" section work fine.