### PR TITLE
Redundant entry

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -9061,10 +9061,6 @@ peeplink.in##+js(popads-dummy)
 ! https://github.com/uBlockOrigin/uAssets/issues/4104
 jagran.com##+js(set, canRun, true)
 
-! https://forums.lanik.us/viewtopic.php?f=62&t=42143
-@@||fwmrm.net/ad/$script,domain=dplay.fi
-||dniadops-a.akamaihd.net/video-assets/$media,domain=dplay.fi
-
 ! https://github.com/NanoMeow/QuickReports/issues/314
 @@||megaleech.us^$ghide
 megaleech.us##.ad_code2:style(height: 1px !important;)

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -9085,9 +9085,6 @@ ehikioya.com##[id*="affspot"]
 ! https://github.com/NanoMeow/QuickReports/issues/318
 menantisenja.com##+js(set, adblock, 1)
 
-! https://forums.lanik.us/viewtopic.php?f=62&t=42156
-||damoh.katsomo.fi/*$media,redirect=noopmp3-0.1s,domain=mtv.fi
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4098
 ! https://github.com/uBlockOrigin/uAssets/issues/7122
 temp-mail.org##+js(set, checkadBlock, noopFunc)


### PR DESCRIPTION
`dplay.fi` not in use anymore, redirects elsewhere.

`damoh.katsomo.fi` not in use anymore either. Removed it today from the Finnish list as well.