### PR TITLE
Update filters.txt

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -10204,8 +10204,16 @@ soft98.ir##+js(nosiif, remove)
 soft98.ir##article.card > div[class]:nth-child(5):style(pointer-events:none !important)
 soft98.ir##[class$="-link"] > .text-danger:upward(2)
 soft98.ir,~forum.soft98.ir##img[src*="forum.soft98.ir/"]:upward(1):style(pointer-events:none !important)
-soft98.ir##img[src*="hostdl"]:upward(1):style(pointer-events:none !important)
+soft98.ir##img[src*="hostdl"]:upward(3):remove()
+soft98.ir##div[id] img[src*="file.soft98.ir"]:remove()
+soft98.ir##.b8d12y:remove()
+soft98.ir###sidebar > section.card > .card-header:has-text(آ):upward(1):remove()
+soft98.ir###sidebar > section.card > .card-header:not(:has-text(لیست)):upward(1):remove()
+soft98.ir###sideb9r-sticky:remove()
+soft98.ir##[id*="r-sticky"]:remove()
 *$image,strict3p,denyallow=cdn.soft98.ir,domain=soft98.ir|~forum.soft98.ir
+||file.soft98.ir^$all
+||cdn.hostdl.com^$all,domain=soft98.ir
 @@||soft98.ir^$ghide
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4368#issuecomment-450665976

--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -196,3 +196,23 @@ buzz#@#.ads1
 apkcombo.com##+js(aeld, DOMContentLoaded, clientHeight)
 apkcombo.com##div[class*=-ad]
 apkcombo.com##p:has-text(Advertisement)
+
+! https://github.com/uBlockOrigin/uAssets/pull/14178
+forum.soft98.ir##.shad
+soft98.ir##+js(nostif, hasAttributes)
+soft98.ir##+js(nostif, {e()})
+soft98.ir##+js(nosiif, remove)
+soft98.ir##article.card > div[class]:nth-child(5):style(pointer-events:none !important)
+soft98.ir##[class$="-link"] > .text-danger:upward(2)
+soft98.ir,~forum.soft98.ir##img[src*="forum.soft98.ir/"]:upward(1):style(pointer-events:none !important)
+soft98.ir##img[src*="hostdl"]:upward(3):remove()
+soft98.ir##div[id] img[src*="file.soft98.ir"]:remove()
+soft98.ir##.b8d12y:remove()
+soft98.ir###sidebar > section.card > .card-header:has-text(آ):upward(1):remove()
+soft98.ir###sidebar > section.card > .card-header:not(:has-text(لیست)):upward(1):remove()
+soft98.ir###sideb9r-sticky:remove()
+soft98.ir##[id*="r-sticky"]:remove()
+*$image,strict3p,denyallow=cdn.soft98.ir,domain=soft98.ir|~forum.soft98.ir
+||file.soft98.ir^$all
+||cdn.hostdl.com^$all,domain=soft98.ir
+@@||soft98.ir^$ghide


### PR DESCRIPTION
This site has ad-reinsertion and heavy anti-adblock so _regular_ cosmetic filters don't work (They either trigger the anti-adb or the ads is just re-inserted).

The site admin has a long history of changing CSS names and hardening the anti-adb on a _**daily**_ basis so I believe it's beneficial to have these filters in uAssets.
`https://github.com/uBlockOrigin/uAssets/issues/10883`

Edit: The site is high-traffic in Iran.

This is happening **_everyday_** to make filters useless: 
b7d9x => b8d9x => b8d10x => b8d11x => ..
sideb5r => sideb6r => sideb7r => ...
آسیاتک آسـیـاتـک آســیــاتــک  ...

I'll keep the filters updated daily.