### PR TITLE
Quick fixes: adjust expires grammar

### DIFF
--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -1,6 +1,6 @@
 ! Title: Quick fixes list
 ! Description: experimental filters
-! Expires: 1 days
+! Expires: 1 day
 ! Last modified: %timestamp%
 ! License: https://creativecommons.org/licenses/by/3.0/
 ! Homepage: https://github.com/uBlockOrigin/uAssets


### PR DESCRIPTION
### Describe the issue

Fixes `Expires:` grammar: "1 days" → "1 day"