### PR TITLE
Update quick-fixes.txt

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -1016,9 +1016,6 @@ wholehk.com##+js(acis, document.onkeydown, keypress)
 ! https://github.com/NanoMeow/QuickReports/issues/446
 howjsay.com##+js(nostif, (), 1500)
 
-! https://github.com/NanoMeow/QuickReports/issues/437
-soft98.ir##+js(aeld, contextmenu)
-
 ! https://github.com/NanoMeow/QuickReports/issues/450
 overlordfree.web.id##+js(acis, disableselect, reEnable)
 overlordfree.web.id##body:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -10201,39 +10201,6 @@ gazetedamga.com.tr##+js(aopw, importFAB)
 ! https://github.com/NanoMeow/QuickReports/issues/498
 sledujfilmy.to##+js(acis, $, hide)
 
-! https://github.com/uBlockOrigin/uAssets/pull/14178
-soft98.ir##+js(nostif, hasAttributes)
-soft98.ir##+js(nostif, {e()})
-soft98.ir##+js(nosiif, remove)
-soft98.ir##article.card > div[class]:nth-child(5):style(pointer-events:none !important)
-soft98.ir##[class$="-link"] > .text-danger:upward(2)
-soft98.ir,~forum.soft98.ir##img[src*="forum.soft98.ir/"]:upward(1):style(pointer-events:none !important)
-! ! soft98.ir##div[id] img[src*="file.soft98.ir"]:remove()
-soft98.ir##[class^=b][class*=d][class$="-link"]:upward(2):remove()
-soft98.ir##.b8d4y3:remove()
-soft98.ir###logo__wrap > .row:remove()
-soft98.ir##[src*="file.soft98.ir"]:upward(3):remove()
-soft98.ir##[title*="خرید"]:upward(2):remove()
-soft98.ir##div[id] a[title*="azon"]:upward(2):remove()
-soft98.ir###header img[src*="file.soft98.ir"]:upward(2):remove()
-soft98.ir###linkdo1oni:remove()
-soft98.ir##[id*="linkd"]:remove()
-soft98.ir###content2top > .row > div.col-l2g:nth-of-type(2)
-soft98.ir##.row > div.col-l2g:nth-of-type(2):remove()
-soft98.ir##img[src*="hostdl"]:upward(3):remove()
-soft98.ir##.bg-light.container:remove()
-soft98.ir###sidebar:remove()
-soft98.ir###main:style(max-width: 100% !important; flex-grow: 1 !important;)
-*$image,strict3p,denyallow=cdn.soft98.ir,domain=soft98.ir|~forum.soft98.ir,badfilter
-||linkdoni.soft98.ir^$all
-||file.soft98.ir^$all
-||cdn.hostdl.com^$all,domain=soft98.ir
-||iranicard.ir^$all,domain=soft98.ir
-||asiatech.ir^$all,domain=soft98.ir
-||webzi.ir^$all,domain=soft98.ir
-||hostdl.com^$all,domain=soft98.ir
-@@||soft98.ir^$ghide
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4368#issuecomment-450665976
 bitlk.com##+js(aopr, app_vars.force_disable_adblock)
 

--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -177,36 +177,22 @@ apkcombo.com##div[class*=-ad]
 apkcombo.com##p:has-text(Advertisement)
 
 ! https://github.com/uBlockOrigin/uAssets/pull/14178
-soft98.ir##+js(nostif, hasAttributes)
-soft98.ir##+js(nostif, {e()})
-soft98.ir##+js(nosiif, remove)
-soft98.ir##article.card > div[class]:nth-child(5):style(pointer-events:none !important)
-soft98.ir##[class$="-link"] > .text-danger:upward(2)
-soft98.ir,~forum.soft98.ir##img[src*="forum.soft98.ir/"]:upward(1):style(pointer-events:none !important)
-! ! soft98.ir##div[id] img[src*="file.soft98.ir"]:remove()
-soft98.ir##[class^=b][class*=d][class$="-link"]:upward(2):remove()
-soft98.ir##.b8d4y3:remove()
-soft98.ir###logo__wrap > .row:remove()
-soft98.ir##[src*="file.soft98.ir"]:upward(3):remove()
-soft98.ir##[title*="خرید"]:upward(2):remove()
-soft98.ir##div[id] a[title*="azon"]:upward(2):remove()
-soft98.ir###header img[src*="file.soft98.ir"]:upward(2):remove()
-soft98.ir###linkdo1oni:remove()
-soft98.ir##[id*="linkd"]:remove()
-soft98.ir###content2top > .row > div.col-l2g:nth-of-type(2)
-soft98.ir##.row > div.col-l2g:nth-of-type(2):remove()
-soft98.ir##img[src*="hostdl"]:upward(3):remove()
-soft98.ir##.bg-light.container:remove()
-soft98.ir###sidebar:remove()
-soft98.ir###main:style(max-width: 100% !important; flex-grow: 1 !important;)
-*$image,strict3p,denyallow=cdn.soft98.ir,domain=soft98.ir|~forum.soft98.ir,badfilter
+soft98.ir##[src*="file.soft98.ir"]:upward(5):remove()
+soft98.ir##[href*="linkdoni.soft98.ir"]:upward(3):remove()
+soft98.ir##[href*="instagram.com"]:upward(5):remove()
+soft98.ir##[src*="cdn.hostdl.com"]:upward(6):remove()
+soft98.ir##.text-center.card-body:not(:has([src*="cdn.soft98.ir"])):upward(2):remove()
+||file.soft98.ir^$all,redirect=click2load.html
+||cdn.hostdl.com^$all,redirect=click2load.html
 ||linkdoni.soft98.ir^$all
-||file.soft98.ir^$all
-||cdn.hostdl.com^$all,domain=soft98.ir
 ||iranicard.ir^$all,domain=soft98.ir
 ||asiatech.ir^$all,domain=soft98.ir
-||webzi.ir^$all,domain=soft98.ir
-||hostdl.com^$all,domain=soft98.ir
+!#if ext_ublock
+soft98.ir##.show.t2oast:before:style(content: "برای خلاص شدن از شر این پیغام مزخرف کافیست به تنظیمات افزونه مسدودسازتان بروید و لیست PersianBlocker و Quick-Fixes را بروز کنید." !important; color: #E6000D !important; visibility: visible; font-size: xx-large !important;)
+!#endif
+!#if adguard
+soft98.ir##.show.t2oast:before:style(content: "برای خلاص شدن از شر این پیغام مزخرف کافیست به تنظیمات افزونه مسدودسازتان بروید و لیست PersianBlocker را بروز کنید." !important; color: #E6000D !important; visibility: visible; font-size: xx-large !important;)
+!#endif
 @@||soft98.ir^$ghide
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/weu5ra/


### PR DESCRIPTION
Removed from uBlock Filters because Brave doesn't support ":upward()" for now.
The annoyance filter should be deprecated by now.