### PR TITLE
Delete outdated filters related to kakao tv

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -16714,15 +16714,6 @@ sonyliv.com##+js(json-prune, adProvider)
 ! https://github.com/uBlockOrigin/uAssets/issues/6662
 @@||realmofdarkness.net^$ghide
 
-! https://github.com/NanoMeow/QuickReports/issues/2462
-! https://github.com/uBlockOrigin/uAssets/issues/12081
-@@||kakao.com^$ghide
-*$image,redirect-rule=32x32.png,domain=tv.kakao.com
-@@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=tv.kakao.com
-@@||play-tv.kakao.com/embed/player/image/$image
-@@||adserver.rockwell.kakao.com/adserver/api/v2^$xhr
-@@||videoads.kakao.com/adserver/api/*$xhr,1p
-
 ! https://github.com/NanoMeow/QuickReports/issues/2465
 @@||magyarhang.org^$shide
 ||magyarhang.org/*.gif$image


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://tv.kakao.com/channel/3990670/cliplink/430913247

### Describe the issue

An anti-adblock script in tv.kakao.com is resolved by List-KR uBO.

### Versions

- Browser/version: Mozilla Firefox Dev 104.0b6
- uBlock Origin version: 1.43.0

### Settings

```
uBlock Origin: 1.43.0
Firefox: 104
filterset (summary): 
  network: 13151
  cosmetic: 11110
  scriptlet: 17636
  html: 716
listset (total-discarded, last updated): 
  removed: 
    easylist: null
    easyprivacy: null
    urlhaus-1: null
    plowe-0: null
  added: 
    KOR-1: 2889-12, now
  default: 
    user-filters: 0-0, never
    ublock-filters: 33070-41, now
    ublock-badware: 4175-0, now
    ublock-privacy: 247-0, now
    ublock-abuse: 76-0, now
    ublock-unbreak: 1865-0, now
    ublock-quick-fixes: 353-1, now
filterset (user): [empty]
modifiedUserSettings: 
  advancedUserEnabled: true
modifiedHiddenSettings: [none]
supportStats: 
  allReadyAfter: 239 ms
  maxAssetCacheWait: 38 ms

```

### Notes

 - https://github.com/uBlockOrigin/uAssets/issues/12081
 - https://github.com/List-KR/List-KR/commit/8cd39cd2ffa49e453b01f279ee676b7a2efbabad
 - https://github.com/List-KR/List-KR/commit/77ac5471dcd89cc1933d85dbc3935c3b0bf52e59
 - https://github.com/List-KR/List-KR/commit/0bd7f2012bc01002c95c512a00c17e2a941eea30