### PR TITLE
Not needed in uAssets

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -5999,29 +5999,16 @@ adfoc.us,bitfly.io,ouo.*,pelisplus.*,pelisplus2.*##+js(aost, Math.random, /\st\.
 taxielcima.live##+js(noeval)
 
 ! pp server
-||abjrtwawbfw.com^
-||acxoxbosblv.com^
-||aimpooft.com^
-||bdfxakyhhiq.com^
 ||biglittleday.com^
 ||boakauso.com^
 ||buksaiss.net^$all
-||ceeleeca.com^
-||chatheez.net^
-||dqupwlanxmjhtx.com^
-||eephaush.comhttps^
-||feefouga.com^
 ||glaichid.net^
-||hnyjqhxmd.com^
 ||intorterraon.com^
 ||jftqnpxewixqrf.com^
 ||moksoxos.com^
-||oaksafta.com^
 ||qhsihvjmut.com^
 ||rvbsugxblak.com^
-||sqsiddqvq.com^
 ||uuknlfqi.com^
-||xjgdxfro.com^
 ||zegrumse.net^
 
 !!! other filters for pp


### PR DESCRIPTION
most of the filters which were removed in this PR's commit were present in EasyList

I think `||eephaush.comhttps^` has a typo and `||eephaush.com` is included in EasyList