### PR TITLE
Block login tooltip annoyance on behance.net

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -1501,6 +1501,7 @@ kqed.org##[class*="modal"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5136
 ! https://github.com/uBlockOrigin/uAssets/issues/14337
+behance.net##[class*="PrimaryNav-loggedOutOptions-"] [class*="PrimaryNav-tooltipWrapper-"]
 behance.net##[class*="ImageElement-blockPointerEvents-"]:style(pointer-events: auto !important)
 behance.net##[class*="Module-blockGridPointerEvents-"] .grid__item-image:style(pointer-events: auto !important)
 behance.net##[class*="Search-contentBlocker-"]


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.behance.net/gallery/73079593/Cats`

### Describe the issue

Block annoying login tooltip that appears on page load

### Screenshot(s)

<img width="904" alt="image" src="https://user-images.githubusercontent.com/110956608/187597158-01163f7b-72a7-4d11-be00-e57398a72257.png">

### Versions

- Browser/version: ff 104
- uBlock Origin version: ubo 1.44
