### PR TITLE
outlook.live.com (attachment thumbnails blocked in the list view)

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -2470,6 +2470,7 @@ freebitcoin.top##+js(acis, eval, decodeURIComponent)
 ! https://github.com/uBlockOrigin/uAssets/pull/12517
 ! https://github.com/easylist/easylist/issues/11847
 ! https://github.com/uBlockOrigin/uAssets/issues/13206
+! https://github.com/uBlockOrigin/uAssets/pull/14632/
 outlook.live.com##.customScrollBar > div[class] > div[class]:empty
 outlook.live.com##.customScrollBar > div div.full:not([aria-label]):not([data-convid]):not([role="option"]):not(.disableTextSelection):not([title])
 

--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -2471,8 +2471,7 @@ freebitcoin.top##+js(acis, eval, decodeURIComponent)
 ! https://github.com/easylist/easylist/issues/11847
 ! https://github.com/uBlockOrigin/uAssets/issues/13206
 outlook.live.com##.customScrollBar > div[class] > div[class]:empty
-outlook.live.com##.customScrollBar > div div.full:not([aria-label]):not([data-convid]):not([role="option"])
-outlook.live.com##.customScrollBar > div > div[class^="_"] > div > div.full:not([aria-label]):not([data-convid]):not([role="option"]):upward(2)
+outlook.live.com##.customScrollBar > div div.full:not([aria-label]):not([data-convid]):not([role="option"]):not(.disableTextSelection):not([title])
 
 ! amazon sponsored items .it, .in
 ! https://github.com/uBlockOrigin/uAssets/issues/13799


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://outlook.live.com/`

### Describe the issue

Attachment thumbnails blocked in the list view)

### Screenshot(s)

![kuva](https://user-images.githubusercontent.com/17256841/188011676-bc284caa-c828-44b4-834f-b5b2901b3ef6.png)

Elements having a class "full" are targeted:

![kuva](https://user-images.githubusercontent.com/17256841/188012924-79b80d79-13e0-424e-bd9f-6ffb4ec49336.png)

### Versions

- Browser/version: FF 104.0.1
- uBlock Origin version: 1.44.1b4

### Settings

Only using "uBlock filters"

### Notes

Can be fixed by changing:

`outlook.live.com##.customScrollBar > div div.full:not([aria-label]):not([data-convid]):not([role="option"])`

->

`outlook.live.com##.customScrollBar > div div.full:not([aria-label]):not([data-convid]):not([role="option"]):not(.disableTextSelection):not([title])`

Also removed
`outlook.live.com##.customScrollBar > div > div[class^="_"] > div > div.full:not([aria-label]):not([data-convid]):not([role="option"]):upward(2)` as obsolete.