### PR TITLE
GitHub Linguist support for adblock rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-language=AdBlock linguist-detectable


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlighting since September 5th. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401

**Please note that the following rules will be displayed as invalid:**

```adblock
! Skipped arguments
example.com##+js(scriptlet, , arg2, arg3)
example.com##+js(scriptlet, arg2, , arg3)
```

This is a known issue and will be fixed in the next Linguist release (in about ~2 months). Related highlight PR: https://github.com/ameshkov/VscodeAdblockSyntax/pull/50
