### PR TITLE
Remove redundant chartbeat.com filters

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -517,9 +517,6 @@ publicdomainq.net##ins.adsbygoogle
 ! http://forums.mozillazine.org/viewtopic.php?f=47&t=3037666
 @@||bom.gov.au/*/analytics.js$script,1p
 
-! https://github.com/uBlockOrigin/uAssets/issues/1367
-@@||static.chartbeat.com/js/chartbeat_video.js$script,domain=nbcwashington.com
-
 ! https://forums.lanik.us/viewtopic.php?f=64&p=131656
 ||gcmgames.com.br/*/google.analytics.trackingcode.js$script,1p,redirect=noopjs
 
@@ -611,7 +608,6 @@ arduino.cc#@#.addthis_toolbox
 
 ! https://github.com/uBlockOrigin/uAssets/issues/1704#issuecomment-372543282
 ! https://forums.lanik.us/viewtopic.php?f=64&t=43860&p=151105#p151105
-@@||bostonglobe.com/js/*/chartbeat.js,dist/*$script,1p
 @@||pages.bostonglobe.com/login/js/lib/AppMeasurement.js$script,1p
 
 ! https://forums.lanik.us/viewtopic.php?p=133754#p133754
@@ -622,9 +618,6 @@ arduino.cc#@#.addthis_toolbox
 ! https://forums.lanik.us/viewtopic.php?f=64&t=40233&p=133912#p133911
 ! https://github.com/NanoMeow/QuickReports/issues/4254
 ||player.ooyala.com/*/analytics-plugin/$script,redirect=noopjs
-
-! https://github.com/uBlockOrigin/uAssets/issues/1736
-@@||cbsnews4.cbsistatic.com/fly/bundles/cbsnewscore/js-build/libs/chartbeat.js$script,domain=cbsnews.com
 
 ! https://forums.lanik.us/viewtopic.php?p=133969#p133969
 @@||code.adsales.snidigital.com/conf/ads-config.js$script,domain=foodnetwork.com
@@ -858,9 +851,6 @@ techadvisor.co.uk#@#.adsbygoogle
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3057
 @@||addthis.com/js/*/addthis_widget.js$script,domain=sainsburys.jobs
-
-! https://github.com/uBlockOrigin/uAssets/issues/3082
-@@||api.chartbeat.com/live/$xhr,domain=mystatesman.com
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/93feu6/unblock_a_major_portuguese_isp_domain/
 ||nostv.pt/Scripts/fingerprint2.min.js$script,redirect=noopjs,1p
@@ -1122,12 +1112,6 @@ mirror.co.uk##+js(set, pbjs_reachChunk, noopFunc)
 ! https://forums.lanik.us/viewtopic.php?f=64&t=42216
 @@||litix.io/core/$script,domain=velocity.com|motortrend.com
 @@||fusion.ddmcdn.com/app/*/comscore.streaming.$script,domain=velocity.com|motortrend.com
-
-! https://forums.lanik.us/viewtopic.php?f=64&t=42233
-@@||playstationlifestyle.net/wp-content/plugins/pb-bwp-minify/*chartbeat$script,1p
-
-! https://github.com/uBlockOrigin/uAssets/issues/4209
-@@||static.chartbeat.com/js/chartbeat_mab.js$script,domain=ny1.com
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4226
 @@||computerworld.com/*/jquery$script,1p
@@ -3332,9 +3316,6 @@ druckerchannel.de###DCGA
 
 ! verhentai.top broken images
 @@||a.realsrv.com/video-slider.js$script,domain=verhentai.top
-
-! https://github.com/uBlockOrigin/uAssets/issues/8340#issuecomment-778277969
-@@||chartbeat.com^$script,domain=hindustantimes.com
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/74505
 @@||cdn.permutive.com/*-web.js$domain=independent.co.uk


### PR DESCRIPTION
Cleanup of chartbeat filters. Any chartbeat exceptions/fixes needed we could just land Easyprivacy, but from my testing these seem fine to remove.

- nbcwashington.com  (Not needed, video plays) also tested other pages.
- bostonglobe.com  (Filter exception not used, since we're blocking the main chartbeat.com domain, videos still play)
- cbsnews.com (Filter exception not used, since we're blocking the main chartbeat.com domain, videos still play)
- mystatesman.com (Filter exception not used)
- playstationlifestyle.net (Filter exception not used)
- ny1.com (Video plays without any exceptions needed: https://www.ny1.com/nyc/all-boroughs/news/2022/09/11/fire-museum-commemorates-343-fdny-members-who-died-on-9-11) 
- hindustantimes.com (Video plays without any exceptions needed (https://www.hindustantimes.com/videos/world-news/china-dumps-hydropower-project-in-pak-as-sharif-govt-copes-with-floods-losses-101662903899713.html)

