### PR TITLE
Removed addthis.com, included in Easyprivacy

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -66,7 +66,6 @@
 ! https://www.eff.org/deeplinks/2014/07/white-house-website-includes-unique-non-cookie-tracker-despite-privacy-policy
 ! https://github.com/uBlockOrigin/uAssets/issues/1713
 ! https://github.com/uBlockOrigin/uAssets/issues/6319
-||addthis.com^$important,3p,domain=~amd.com|~missingkids.com|~missingkids.org|~sainsburys.jobs|~schonmagazine.com|~sitecore.com|~plotaroute.com
 ! https://github.com/gorhill/uBlock/issues/1384
 ! https://github.com/uBlockOrigin/uAssets/issues/11003
 ||addthis.com/*/addthis_widget.js$script,redirect=addthis.com/addthis_widget.js
@@ -75,11 +74,7 @@
 ! https://github.com/uBlockOrigin/uAssets/issues/6608
 free18.net,gadgetlove.com,nrc.gov,onbeing.org,rapgenius.com,schonmagazine.com,tech.co,tmz.com#@#.addthis_toolbox
 ! https://github.com/uBlockOrigin/uAssets/issues/6557
-@@||addthis.com/js/*/addthis_widget.js$script,domain=amd.com
-@@||addthisedge.com/live/$script,domain=amd.com
 ! https://www.reddit.com/r/uBlockOrigin/comments/oifywi/
-@@||addthis.com^$script,domain=schonmagazine.com
-@@||addthis.com/js/*/addthis_widget.js$script,domain=plotaroute.com
 
 ! Examples of what is fixed by even an unfilled dummy API:
 ! https://twitter.com/kenn_butler/status/709163241021317120


### PR DESCRIPTION
Cleaned up unused filters, since its now included in Easyprivacy. any fixes can land in Easyprivacy