### PR TITLE
Seemingly obsolete filters

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -5682,11 +5682,6 @@ ladbible.com##+js(set, pbjs, [])
 xxxhardcoretube.com##+js(acis, document.querySelectorAll, popMagic)
 xxxhardcoretube.com##+js(ra, onclick, .player > div[onclick])
 
-! windowmatters.com anti-adb
-windowsmatters.com##+js(aeld, load, isBlanketFound)
-*$script,redirect-rule=noopjs,domain=windowsmatters.com
-windowsmatters.com##div[class$="-quick-adsense"]
-
 ! masbrooo.com/2ndrun.tv anti-adb
 masbrooo.com,2ndrun.tv##+js(aeld, load, showModal)
 *$script,redirect-rule=noopjs,domain=masbrooo.com|2ndrun.tv


### PR DESCRIPTION
`windowmatters.com` => `https://gcd.com/protected/`