### PR TITLE
Added id.group-ib.com

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -411,3 +411,6 @@ salsaposten.no,steinkjer-avisa.no,hamar-dagblad.no,lofot-tidende.no,avisa-valdre
 ||hktvmall.com/_ui/shared/common/js/analytics/with-intersection-track.js
 ||hktvmall.com/_ui/shared/common/js/util/jquery.analytics-utils.js
 ||hktvmall.com/yuicombo|$script,1p
+
+! group-ib.com tracking
+||id.group-ib.com^


### PR DESCRIPTION
Some Group-IB customers integrates cross-site tracking in their websites, it works by creating invisible iframe with URL like `https://ru.id.group-ib.com/id.html`, which executes following:

```js
a();setInterval(a,500);function a(){try{window.parent.postMessage(JSON.stringify({action:"gcfids",data:{id:"IAYEOzT+eHm1f3gfPkOkuxSYI1jkVJvUMF6G7cIdW45wy8tKv8c49o3musEilBcxE2epx1B4rUSNhb7GM83dXjRUW7I4QTqzk8SVLIxB6yEtgEKhOh3cKs+WPbLm"}}),"*")}catch(b){}};
```

This rule prevents such cross-site tracking without breaking websites itself (it may affect "fraud" scope for user, but website mostly resolve that with harder captcha or other verification methods).