### PR TITLE
addresses https://github.com/AdguardTeam/AdguardFilters/issues/130310

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -4607,3 +4607,6 @@ castmax.live##.overlay
 ! https://github.com/uBlockOrigin/uAssets/issues/14965
 dropmms.com##+js(aeld, load, undefined)
 dropmms.com##+js(acs, document.onkeydown)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/130310
+bloground.ro##+js(nostif, show)


### PR DESCRIPTION
@mapx- I thought it was a Romanian site, but there is content in a different language, should the filter be removed from `road-block lite`?

`https://www.reddit.com/r/uBlockOrigin/comments/x9qoen/adblock_detected_on_httpsblogroundro/`