### PR TITLE
Add skymods.net

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1401,3 +1401,6 @@ cracksoftwaress.net##div[style="float: none; margin:10px 0 10px 0; text-align:ce
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/129493
 ||ucetnictvi-liberec.eu^$all
+
+! https://github.com/uBlockOrigin/uAssets/pulls/<placeholder, will edit when pr is actually made so I know the ID)>
+||skymods.net^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1402,5 +1402,5 @@ cracksoftwaress.net##div[style="float: none; margin:10px 0 10px 0; text-align:ce
 ! https://github.com/AdguardTeam/AdguardFilters/issues/129493
 ||ucetnictvi-liberec.eu^$all
 
-! https://github.com/uBlockOrigin/uAssets/pulls/<placeholder, will edit when pr is actually made so I know the ID)>
+! https://github.com/uBlockOrigin/uAssets/pull/14985
 ||skymods.net^$all


### PR DESCRIPTION
This url is used to distribute a minecraft mod that has malware injected in it:
![image](https://user-images.githubusercontent.com/58223632/191654685-f107d2a1-2fa7-4cbe-a46c-d84e5f34f268.png)
It steals the discord token, minecraft session id, and ip address from anyone who runs it as a 1.8.9 forge mod.