### PR TITLE
seemingly obsolete filter

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -1264,9 +1264,6 @@ cube365.net##+js(set, mixpanel.get_distinct_id, true)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/56352
 zipi.com##.ad
 
-! https://github.com/uBlockOrigin/uAssets/issues/7475
-toolforge.org##+js(aopr, noAdBlockers)
-
 ! brstej .com ads + popups
 brstej.com##+js(aeld, , _0x)
 


### PR DESCRIPTION
`toolforge.org` => `https://wikitech.wikimedia.org/wiki/Portal:Toolforge`