### PR TITLE
Remove unnecessary lines

### DIFF
--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -204,7 +204,3 @@ next-episode.net##+js(aost, document.createElement, inlineScript)
 
 ! https://github.com/easylist/easylist/commit/c4e35a0a60dc4a5a2a822f9c425afc358db19971#commitcomment-84395694
 bing.com#@##bepfo
-
-! hotfix https://github.com/uBlockOrigin/uAssets/issues/14999
-||fwmrm.net^$important,domain=vtm.be,badfilter
-vtm.be##+js(no-fetch-if, csai)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
None / `vtm.be`

### Describe the issue
These lines can be removed, because they are already applied in the regional list. (see: https://github.com/EasyDutch-uBO/EasyDutch/commit/4f365269ca81d6e6e88376b19a78ab1adad2dc77 and https://github.com/EasyDutch-uBO/EasyDutch/commit/d2794926688f49a8bde74a1875d5c1948b36ce79)
Because `||fwmrm.net^$important,domain=vtm.be ` is also removed from uBO List (see https://github.com/uBlockOrigin/uAssets/commit/d49ff440a4e187dcde31de9f2fa69e076e330919), there is no need for those rules to stay in `quick-fixes.txt`

### Screenshot(s)

### Versions

- Browser/version: FireFox 105.0.1
- uBlock Origin version: 1.44.4

### Settings

### Notes
See also https://github.com/uBlockOrigin/uAssets/issues/14999