### PR TITLE
Add qolhub.info

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1438,3 +1438,6 @@ cracksoftwaress.net##div[style="float: none; margin:10px 0 10px 0; text-align:ce
 ||slugmefilehos.xyz^$all
 ||tinyurl.com/setup-full-version$doc
 torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
+
+! <insert pr link here>
+||qolhub.info^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1439,5 +1439,5 @@ cracksoftwaress.net##div[style="float: none; margin:10px 0 10px 0; text-align:ce
 ||tinyurl.com/setup-full-version$doc
 torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 
-! <insert pr link here>
+! https://github.com/uBlockOrigin/uAssets/pull/15197
 ||qolhub.info^$all


### PR DESCRIPTION
At verify.qolhub.info, clicking `I'm not a robot` opens this popup:
![image](https://user-images.githubusercontent.com/58223632/194717424-bd7df260-5de3-4fb7-8716-87a85daa3d3e.png)
This gives the site's owner access to your minecraft account, where they then go on to steal your in-game items. People are convinced to click the link with this discord message:
![image](https://user-images.githubusercontent.com/58223632/194717489-07bc0b57-bd8e-4c2a-b516-7ab61bfafc36.png)

(I blocked the whole domain just in case they change to a different subdomain)