### PR TITLE
programs.sbs.co.kr - conflict

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -3613,10 +3613,6 @@ serialeonlinesubtitrate.ro###text-6
 ! https://github.com/uBlockOrigin/uAssets/issues/9443
 @@/wp-content/plugins/dh-new-anti-adblocker$script,1p
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/86335
-||smartmediarep.com^$media,redirect=noop-0.1s.mp3,domain=sbs.co.kr
-sbs.co.kr##.ad_skip_area_w
-
 ! https://github.com/AdguardTeam/AdguardFilters/issues/86270
 javhd.icu##+js(acis, decodeURI, decodeURIComponent)
 javhdfree.icu##+js(nowoif)


### PR DESCRIPTION
### URL(s) where the issue occurs

 - https://github.com/AdguardTeam/AdguardFilters/issues/132176
 - https://github.com/AdguardTeam/AdguardFilters/issues/86335

### Describe the issue

`||smartmediarep.com^$media,redirect=noop-0.1s.mp3,domain=sbs.co.kr` can be covered by https://github.com/List-KR/List-KR/commit/eb29cca97821deb7a86e160ca62dafd4627dde42 and https://github.com/List-KR/List-KR/commit/3b9a4cf66e6c180833b4058a3f681857eed12f9f.

### Screenshot(s)

_None._

### Versions

- Browser/version: Mozilla Firefox Developer Edition 106.0b9
- uBlock Origin version: 1.44.4

### Settings

```
uBlock Origin: 1.44.4
Firefox: 106
filterset (summary): 
  network: 87107
  cosmetic: 41069
  scriptlet: 18202
  html: 786
listset (total-discarded, last updated): 
  added: 
    KOR-1: 3510-31, now
  default: 
    user-filters: 0-0, never
    ublock-filters: 33826-51, now
    ublock-badware: 4373-0, now
    ublock-privacy: 281-0, now
    ublock-abuse: 76-0, now
    ublock-unbreak: 1885-1, now
    ublock-quick-fixes: 366-0, now
    easylist: 61968-631, now
    easyprivacy: 30725-1715, now
    urlhaus-1: 9070-0, now
    plowe-0: 3675-3, now
filterset (user): [empty]
modifiedUserSettings: [none]
modifiedHiddenSettings: [none]
supportStats: 
  allReadyAfter: 467 ms
  maxAssetCacheWait: 167 ms
```

### Notes

- https://github.com/easylist/easylist/pull/13774
