### PR TITLE
Block ConnectTeam ReportHit analytics

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -427,3 +427,5 @@ ericdraken.com##^script[async]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/81856
 /s/s/js/m/om.js?v=
 
+! ConnectTeam ReportHit analytics
+||bi.connecteam.com/bi/api/ReportHit^


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL i'm blocking:
```
||bi.connecteam.com/bi/api/ReportHit^
```

some urls that make use of this endpoint:
- https://app.connecteam.com/index.html#/directory/directory
- https://app.connecteam.com/index.html#/chat/chat
- https://app.connecteam.com/index.html#/feed
- basically everything thats https://app.connecteam.com/index.html/

### Describe the endpoint
It collects analytics, half the buttons on ConnectTeam's web app literally POST to this endpoint, with your UserID, what you clicked, SessionID, and some other things.

### Screenshot(s)
[I wouldn't like to leak my ConnectTeam userID and other personal info]

### Versions
- Browser/version: Brave Chrome Version 1.44.112 Chromium: 106.0.5249.119 (Official Build) (64-bit)


### Settings
- No changes

### Notes
This isn't in any lists such as easyprivacy or uAssets. This should be added ASAP.