### PR TITLE
Add jewishhomelife-pdf.gq - Phishing against Adobe

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1461,5 +1461,5 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ! https://github.com/uBlockOrigin/uAssets/issues/15368
 ||zenlytrade.com^$all
 
-! https://github.com/uBlockOrigin/uAssets/pull/PULL_ID
+! https://github.com/uBlockOrigin/uAssets/pull/15376
 ||jewishhomelife-pdf.gq^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1460,3 +1460,6 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/15368
 ||zenlytrade.com^$all
+
+! https://github.com/uBlockOrigin/uAssets/pull/PULL_ID
+||jewishhomelife-pdf.gq^$all


### PR DESCRIPTION
### URLs
```
http://jewishhomelife-pdf.gq/adobe/secure/document/
```

### Domains
```
jewishhomelife-pdf.gq
```

### Description

The domain _jewishhomelife-pdf.gq_ is running a phishing attack against **Adobe**.

![Screenshot](https://user-images.githubusercontent.com/38866219/197351034-163372a1-8793-46e1-b150-4cd3fc501925.png)