### PR TITLE
Add badware url

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1460,3 +1460,6 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/15368
 ||zenlytrade.com^$all
+
+! <to be replaced
+||verifyhypixel.net^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1461,5 +1461,5 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ! https://github.com/uBlockOrigin/uAssets/issues/15368
 ||zenlytrade.com^$all
 
-! <to be replaced
+! https://github.com/uBlockOrigin/uAssets/pull/15381
 ||verifyhypixel.net^$all


### PR DESCRIPTION
verifyhypixel.net : _Another_ 'verify' phishing page that maliciously takes advantage of Microsoft's oauth system to steal Minecraft accounts (at least for enough time to steal in-game items). Identical to #15197. The owners of this page seem to have switched TLDs from com (#15364) to net.


(There's a constant stream of new websites like this, that's why I don't condense everything into a single pr)