### PR TITLE
refactor: remove alexbcberio.eus nooptext rule

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -1714,9 +1714,6 @@ insidertracking.com##+js(acis, jQuery, length)
 *$popunder,3p,domain=mp4porn.space
 mp4-porn.space##.href_
 
-! https://www.reddit.com/r/uBlockOrigin/comments/m8kqch/antiadblock_on_httpswwwalexbcberioeus/
-||matomo.alexbcberio.eus^$xhr,redirect-rule=nooptext,domain=alexbcberio.eus
-
 ! https://github.com/AdguardTeam/AdguardFilters/issues/77993
 @@||smartparaphrasingtool.com^$ghide
 smartparaphrasingtool.com##.adsbygoogle
@@ -4264,7 +4261,7 @@ manganelo.tv##+js(aopr, JSON.parse)
 ! 1piecemanga. com popups
 1piecemanga.com##+js(acis, document.querySelectorAll, popMagic)
 
-! movizland. top + players => popups 
+! movizland. top + players => popups
 movizland.*##+js(aopr, open)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/90816
@@ -5447,7 +5444,7 @@ kshow123.net###ads-top-player
 kshow123.net###closeads
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10249
-designtagebuch.de##+js(set, SteadyWidgetSettings.adblockActive, false) 
+designtagebuch.de##+js(set, SteadyWidgetSettings.adblockActive, false)
 @@*$xhr,domain=designtagebuch.de
 designtagebuch.de##[id^="desig-"]:has-text(ANZEIGE)
 designtagebuch.de##.zwischen-posts-wrapper
@@ -5661,7 +5658,7 @@ watchtheofficetv.com###custom_html-4
 pelis-online.net##+js(aopw, absda)
 pelis-online.net##.adv
 
-! cinevision. online popups + anti adb 
+! cinevision. online popups + anti adb
 @@||receitasone.com^$ghide
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/98203
@@ -6339,7 +6336,7 @@ xenvn.com##+js(nostif, ads)
 tvhai.org##+js(aeld, , open)
 plhqtvhay.xyz##+js(nosiif, 0x)
 
-! glotorrents.* ads, popups 
+! glotorrents.* ads, popups
 glotorrents.fr-proxy.com##+js(aopw, decodeURI)
 glotorrents.fr-proxy.com##+js(aopw, adcashMacros)
 glotorrents.fr-proxy.com,glotorrents.theproxy.ws##+js(nowoif)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

alexbcberio.eus

### Describe the issue

The domain alexbcberio.eus is no longer active

### Screenshot(s)

*N/A*

### Versions

- Browser/version: *any*
- uBlock Origin version: *any*

### Settings

- filter-2021.txt: remove `alexbcberio.eus` domain's nooptext rule

### Notes

I was the previous owner of the domain ([keybase proof](https://keybase.io/alexbcberio/sigchain#9f1b7d8105e4a89a6749e46a2529502e1c90dd84562e4b0f2dd266162af8e61c0f)) and I have moved it to a new tld (.com). I also no longer detect any adblock, so I have not added any rule for this new domain.
I do still track users on the new domain unless they have DNT (do not track) enabled on their browser. I don't have any issues adding a block to it, feel free to tell me if so and I'll add it to this PR.

PS, [here](https://keybase.io/alexbcberio/sigchain#9f1b7d8105e4a89a6749e46a2529502e1c90dd84562e4b0f2dd266162af8e61c0f) is the proof of the relation between this github account and the keybase account.