### PR TITLE
Add verify.fragbot.online

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1451,5 +1451,5 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ! https://github.com/uBlockOrigin/uAssets/pull/15381
 ||verifyhypixel.net^$all
 
-! https://github.com/uBlockOrigin/uAssets/pull/
-||verify.fragbot.online^$all
+! https://github.com/uBlockOrigin/uAssets/pull/15391
+||fragbot.online^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1450,3 +1450,6 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 
 ! https://github.com/uBlockOrigin/uAssets/pull/15381
 ||verifyhypixel.net^$all
+
+! https://github.com/uBlockOrigin/uAssets/pull/
+||verify.fragbot.online^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
`https://verify.fragbot.online/` hosts a button that requests access to user's Microsoft account. Once the OAuth token is aquired data is sent to a Heroku endpoint.

### Describe the issue

Phishing

### Screenshot(s)

![image](https://user-images.githubusercontent.com/101084582/197405729-0687c711-3474-4f96-ae85-2621723d66cf.png)
![image](https://user-images.githubusercontent.com/101084582/197405759-c2ad0b4e-155a-449b-b648-86131e56c5b6.png)


Similar to #15197
#15381
and other "verify" oauth sites.