### PR TITLE
Update #9542 / #7897

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -15091,6 +15091,7 @@ shon.xyz##+js(popads-dummy)
 ||shon.xyz^$csp=script-src 'self' 'unsafe-inline' *.gstatic.com *.google.com *.googletagmanager.com *.googleapis.com;frame-src 'self' *.google.com;connect-src 'self'
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=43658
+daftsex.com##+js(aopr, TextDecoder)
 daftsex.com##+js(aopr, AaDetector)
 daftsex.com##+js(set, extEnabled, 0)
 daxab.com##+js(nowebrtc)

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -14561,8 +14561,8 @@ vidia.tv##+js(nostif, pop)
 multiup.*##+js(acis, decodeURI, decodeURIComponent)
 multiup.*##+js(nosiif, .submit)
 multiup.*##.text-center.bg-info
-multiup.*##div.col-md-4:nth-of-type(1):has-text(Usemet)
-multiup.*##.panel-featured-success.panel-featured-bottom.panel-featured-top.panel.text-center:has([alt="Usemet.nl"]):upward(1)
+multiup.*##div.col-md-4:nth-of-type(1):has-text(Usennet)
+multiup.*##.panel-featured-success.panel-featured-bottom.panel-featured-top.panel.text-center:has([alt="Usennet.nl"]):upward(1)
 multiup.*##.mfp-ready
 multiup.*##div.text-center:has(a[class="btn btn-success"][href^="abp:subscribe"])
 *$popunder,3p,domain=multiup.*
@@ -15091,7 +15091,6 @@ shon.xyz##+js(popads-dummy)
 ||shon.xyz^$csp=script-src 'self' 'unsafe-inline' *.gstatic.com *.google.com *.googletagmanager.com *.googleapis.com;frame-src 'self' *.google.com;connect-src 'self'
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=43658
-daftsex.com##+js(aopr, TextDecoder)
 daftsex.com##+js(aopr, AaDetector)
 daftsex.com##+js(set, extEnabled, 0)
 daxab.com##+js(nowebrtc)


### PR DESCRIPTION
Badware section again changed name

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

like in https://github.com/uBlockOrigin/uAssets/issues/7897

### Describe the issue

Domain shifting names between Usennet and Usemet

### Screenshot(s)


![obraz](https://user-images.githubusercontent.com/35370833/199101511-95d79574-a904-4d6d-8b56-f619bfeee27c.png) | ![obraz](https://user-images.githubusercontent.com/35370833/199101567-9b553a8d-3429-40e9-ac77-60ba346b38fd.png)
--- | ---


### Versions

- Browser/version: Firefox 107
- uBlock Origin version: 1.44.5rc0

### Settings

- added to stock: uBo Annoyances, POL-0, POL-2

### Notes

Regex are not recommended: https://github.com/uBlockOrigin/uAssets/pull/10173
