### PR TITLE
maxgaming.fi (enable contextmenu for product images)

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -5188,5 +5188,5 @@ picyield.com##+js(aost, document.body.appendChild)
 picyield.com##.adbwarning
 ||agatarainpro.com^
 
-!
+! https://github.com/uBlockOrigin/uAssets/pull/15515
 maxgaming.fi##+js(aeld, contextmenu)

--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -5187,3 +5187,6 @@ picgiraffe.com##+js(nostif, showModal)
 picyield.com##+js(aost, document.body.appendChild)
 picyield.com##.adbwarning
 ||agatarainpro.com^
+
+!
+maxgaming.fi##+js(aeld, contextmenu)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.maxgaming.fi/fi/sisainen-kaapelit/sata-3-6gb-s-30cm-musta`

### Describe the issue

Contextmenu is disabled in product images.

### Screenshot(s)

### Versions

- Browser/version: FF 106.0.3
- uBlock Origin version: 1.44.5rc0

### Settings

- Defaults

### Notes

This filter seems to fix it properly:
`maxgaming.fi##+js(aeld, contextmenu)`