### PR TITLE
fix bing ads

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -13433,7 +13433,7 @@ oranhightech.com##+js(aopw, cancelAdBlocker)
 ! https://github.com/uBlockOrigin/uAssets/issues/12505
 bing.com##[onclick^="ad_choice"]:upward(3)
 bing.com###b_results > li[style]:not([class])
-bing.com#?#.b_algo:has(p:matches-css-before(display:inline-block))
+bing.com#?#.b_algo:has(.b_caption>*:matches-css-before(display:inline-block))
 bing.com##.b_ad:remove()
 bing.com##.b_algo:has(.b_textAdTitleLink)
 bing.com##.ins_exp.tds

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -13433,10 +13433,7 @@ oranhightech.com##+js(aopw, cancelAdBlocker)
 ! https://github.com/uBlockOrigin/uAssets/issues/12505
 bing.com##[onclick^="ad_choice"]:upward(3)
 bing.com###b_results > li[style]:not([class])
-bing.com#?#.b_algo:has(p:matches-css-before(content: "Ad"))
-bing.com##+js(set, AdBlockerTracking.AdBlockMonitor, noopFunc)
-bing.com##+js(set, AdBTrack.AdbMon.isBlocked, noopFunc)
-bing.com##+js(set, SVGForeignObjectElement, undefined)
+bing.com#?#.b_algo:has(p:matches-css-before(display:inline-block))
 bing.com##.b_ad:remove()
 bing.com##.b_algo:has(.b_textAdTitleLink)
 bing.com##.ins_exp.tds


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
https://www.bing.com/search?q=skinny+jeans+for+petite+women&lvl=5&FORM=PMETIS&filters=ans%3a%22cvns%22+level%3a%222%22+mcid%3a%227ec7e468f3f848b497291427f20ab314%22&idx=0,0,0
https://www.bing.com/search?q=life+insurance+quotes+comparison&FORM=QSRE2
https://www.bing.com/search?q=warmest+winter+coats+for+men&FORM=QSRE6
```


### Describe the issue

unblocked bing ads. i guess they updated their circumvention.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/16567977/201585901-2f2c2c1a-6f4f-4535-8c47-ce71c7c2822a.png)
![image](https://user-images.githubusercontent.com/16567977/201586071-91588928-f9d3-4415-a13d-46c314fafaae.png)


### Versions

- Browser/version: Firefox stable
- uBlock Origin version: uBlock Origin 1.45.0

### Settings

n/a

### Notes

Relevant part of the (unobfuscated!) adblock-circumvention script used by bing: https://gist.github.com/liamengland1/f73b79050932b65a255414b36e95c34d#file-bing-anti-adb-nov22-js-L706

see also https://github.com/uBlockOrigin/uAssets/pulls?q=bing+author%3Aliamengland1
