### PR TITLE
shopify.com: ads 

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -4130,6 +4130,12 @@ pornhubed.com##+js(aopr, __Y)
 stream4free.live##+js(aopw, adcashMacros)
 stream4free.live##.closeButton
 
+! Upsell advertisements embedded into Shopify pages
+||launcher.disconetwork.com/
+||widget.disconetwork.com/
+||widget2.disconetwork.com/
+||consumer.discornetwork.com/
+
 ! https://github.com/AdguardTeam/AdguardFilters/issues/126628
 softcobra.*##+js(set, canRunAds, true)
 ! https://www.reddit.com/r/uBlockOrigin/comments/ya0wyc/

--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -4134,7 +4134,7 @@ stream4free.live##.closeButton
 ||launcher.disconetwork.com/
 ||widget.disconetwork.com/
 ||widget2.disconetwork.com/
-||consumer.discornetwork.com/
+||consumer.disconetwork.com/
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/126628
 softcobra.*##+js(set, canRunAds, true)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://thescribes.co/XXXXX/orders/XXXXX`

### Describe the issue

Up-sell advertisements and trackers from appears on checkout pages for Shopify.  

### Screenshot(s)

![chrome](https://user-images.githubusercontent.com/15152269/201764903-370e6a4e-ee7a-4d44-8799-0d68bcfafb7c.png)

### Versions

- Browser/version: Chrome 107.0.5304.110
- uBlock Origin version: 1.45.2

### Settings

- Added filters for Shopify up-sells advertisements and trackers.

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
