### PR TITLE
fix: skk.moe fetch method param

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -332,7 +332,7 @@ reddit.com##+js(no-xhr-if, method:POST url:/^https:\/\/www\.reddit\.com$/)
 ||zhihu.com^$removeparam=hybrid_search_extra
 
 ! https://github.com/easylist/easylist/issues/6724#issuecomment-1003172754
-skk.moe##+js(no-fetch-if, method:POST)
+skk.moe##+js(no-fetch-if, method:post)
 /cfga/jquery.js?$image
 /npm/sks@0.*/lazyload.js$script,3p
 


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://blog.skk.moe/`

### Describe the issue

The params in the fetch is lower case while the filter is upper case.

### Notes

I believe the root cause is because `no-fetch-if` does not support case insensitive (require extra params if build regex from string), while in `fetch()` you could pass `PoSt` as method while still have correct behavior but bypass the filter. A separate issue for uBlock may be required.

Related https://github.com/gorhill/uBlock/blob/b6ed83bc5c840431ed03cddaed1daeb395db3b0e/assets/resources/scriptlets.js#L609
