### PR TITLE
remove digitalvast.com

### DIFF
--- a/thirdparties/urlhaus-filter/urlhaus-filter-online.txt
+++ b/thirdparties/urlhaus-filter/urlhaus-filter-online.txt
@@ -4514,7 +4514,6 @@ digisync.com.au
 digitalaura.us
 digitalbokra.com
 digitalcelulares.com.br
-digitalvast.com
 digitalwaypk.com
 digitown.co.in
 digittech.co.ug


### PR DESCRIPTION
Hi,

The digitalvast . com is needs to be removed. The site was hacked and infected with malware. We've cleaned up the site, now the site is under development.

Please merge the pull request to keep our site unblocked.

Thanks!