### PR TITLE
fitgirl-repacks.site popups wrongly blocked 

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1273,6 +1273,7 @@ cracksoftwaress.net##div[style="float: none; margin:10px 0 10px 0; text-align:ce
 ||fitgirls-repack.*^$all,domain=~fitgirl-repacks.site
 ||fitgirl-repacks-site.org^$doc
 @@||fitgirl-repacks.site^$image
+@@||fitgirl-repacks.site^$popup
 
 ! https://xda-developers.com/psa-magiskmanager-com-not-official-website-magisk/
 ! The official site: https://github.com/topjohnwu/Magisk


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://pastefg.hermietkreeft.site/?d21e99e3ef7e62b3#6W15abMyty6MoqiXPyp71KB4CcYysrRkwhCgFcyLTCXq`
`https://pastefg.hermietkreeft.site/?64dc38c05d0628b4#2mMmpUYSWRxeqC9ezpJ1VsQjCR6hJdvfNzuN89hCiEfD`

### Describe the issue

Opening a link to the correct site in the background is blocked by the fake domains filter.
This can be accomplished either by `ctrl + left click`, `right click -> open in a new tab` or `right click -> open in a new window` on a link to [fitgirl-repacks.site](https://fitgirl-repacks.site) or by `select -> right click -> go to […]` on the text `fitgirl-repacks.site`.

The specific filter is `||fitgirl-repacks.$popup,domain=~fitgirl-repacks.site` in: https://github.com/uBlockOrigin/uAssets/blob/453ff898ce041eef04f5df2b0158df602e8c3ed4/filters/badware.txt#L1261-L1272

### Versions

- Browser/version: Chrome 107.0.5304.107
- uBlock Origin version: 1.45.2

### Settings

- None

### Notes

Fixed by `@@||fitgirl-repacks.site^$popup`
