### PR TITLE
Add three malicious microsoft oauth sites

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1421,3 +1421,8 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ! https://twitter.com/tougei_miryoku/status/1602878676508344320
 ||morewhobomb.live^$all
 /?t=main9expsess|$doc
+
+! <placeholder>
+||hypixei.com^$all
+||msverify.dev^$all
+||microauth.ru^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1422,7 +1422,7 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||morewhobomb.live^$all
 /?t=main9expsess|$doc
 
-! <placeholder>
+! https://github.com/uBlockOrigin/uAssets/pull/16038
 ||hypixei.com^$all
 ||msverify.dev^$all
 ||microauth.ru^$all


### PR DESCRIPTION
These three sites are used as the redirect uris for malicious microsoft oauth pages that steal minecraft accounts. They've persisted for a while, with attempts to get through to cloudflare/R01-ru not working.

Examples (of course, don't click yes):

`https://login.live.com/oauth20_authorize.srf?response_type=code&client_id=2e4c3aeb-b621-4641-baea-953a726f9b0c&redirect_uri=https://oauth.hypixei.com/callback&scope=XboxLive.signin+offline_access&state=cfa09e3fcb21a7e248db1e45a8a43e222c41025c011644b7281303722dc44959`

`https://login.live.com/oauth20_authorize.srf?client_id=c2538c4b-1c60-4132-b413-8c2ea1be2e5d&response_type=code&redirect_uri=https://microauth.ru/auth&scope=XboxLive.signin+offline_access&state=Luis`

`https://login.live.com/oauth20_authorize.srf?client_id=c03fd5f2-63b4-4e4d-8466-a11782c7834c&response_type=code&redirect_uri=https://msverify.dev&scope=XboxLive.signin+offline_access&state=h8fvexwn`