### PR TITLE
Fix mail.com anti-adblock

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -2677,6 +2677,7 @@ japannews.yomiuri.co.jp##div[class^="ad_background"]
 ! https://github.com/uBlockOrigin/uAssets/issues/13211
 mail.com##+js(nostif, offsetHeight)
 mail.com##.mod-container:has-text(/sponsor/i)
+mail.com##+js(set, AdService.info.abd, noopFunc)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/13213
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xhr,domain=tiodonghua.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.mail.com`

### Describe the issue

After logging in to mail.com, anti-adblock splash screen - redirects to `https://www.mail.com/fairplay/?section=fairplay`

### Screenshot(s)

![image](https://user-images.githubusercontent.com/16567977/208358101-2267c432-bdc8-4324-b376-23d661c69a35.png)

### Versions

- Browser/version: Firefox Stable
- uBlock Origin version: uBo 1.45.2

### Settings

n/a

### Notes

Don't need an account to test, just type in made-up credentials and verify that in the request to `https://login.mail.com/login`, the `ibaInfo` parameter is empty
