### PR TITLE
Allow kebhana.com and hometax.go.kr to access 127.0.0.1

### DIFF
--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -34,7 +34,7 @@
 ! ——— localhost
 ! https://en.wikipedia.org/wiki/Localhost
 !
-/^\w+://127\.(?:(?:[1-9]?\d|1\d\d|2(?:[0-4]\d|5[0-5]))\.){2}(?:[1-9]?\d|1\d\d|2(?:[0-4]\d|5[0-5]))[:/]/$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
+/^\w+://127\.(?:(?:[1-9]?\d|1\d\d|2(?:[0-4]\d|5[0-5]))\.){2}(?:[1-9]?\d|1\d\d|2(?:[0-4]\d|5[0-5]))[:/]/$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local|~kebhana.com|~hometax.go.kr
 ||[::1]^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||localhost^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 !


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
```
kebhana.com/common/login.do
hometax.go.kr/websquare/websquare.wq?w2xPath=/ui/pp/index_pp.xml
```

### Describe the issue

It can't detect the software required to login to these websites.

### Screenshot(s)

https://user-images.githubusercontent.com/96731476/209783644-ad173562-be1e-4e86-b121-403f43fed9b9.png

https://user-images.githubusercontent.com/96731476/209804706-99a45000-7c5d-4f2f-84d0-e66542312bf2.png


### Versions

- Browser/version: Firefox 110
- uBlock Origin version: 1.46.1b3
- Browser/version: Chrome 108
- uBlock Origin version: 1.45.2

### Settings

My backup file: `https://raw.githubusercontent.com/bestplayerbot/filterlists/main/my-ublock-backup.txt`

### Notes

I found that blocking `127.0.0.1` in `kebhana.com` and `hometax.go.kr` prevents it from accesing the required softwares for me to login to the website