### PR TITLE
Add another Minecraft phishing site

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1444,3 +1444,6 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||block-ads-now.com^$all
 ||ezadblocker.com^$all
 ||watchadsfree.com^$all
+
+! https://github.com/uBlockOrigin/uAssets/issues/16156
+||discordoauthverification.onrender.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`discordoauthverification.onrender.com`

### Describe the issue

Redirects to a Microsoft OAuth site requesting access to the user's Xbox Live account. Once permission is granted it allows them to login to the victim's Minecraft account

### Screenshot(s)

![image](https://user-images.githubusercontent.com/101084582/209866693-7c4faa23-25c5-4c60-9aae-e3f005c8db7c.png)
