### PR TITLE
Embedded Tiktok videos won't play

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -1,2 +1,2 @@
-!
+! https://github.com/uBlockOrigin/uAssets/pull/16191
 @@||mcs-va.tiktok.com/v1/user/webid$xhr

--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -1,0 +1,2 @@
+!
+@@||mcs-va.tiktok.com/v1/user/webid$xhr


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.verkkouutiset.fi/a/hirvi-pudottaa-sarvensa-harvinaisella-videolla/#96a4177e`

### Describe the issue

Embedded TikTok videos won't play, the issue is caused by Lowe's list.

### Screenshot(s)

![kuva](https://user-images.githubusercontent.com/17256841/210169554-80b8c501-7250-410f-a3ad-6b783e4711b2.png)

After whitelisting:

![kuva](https://user-images.githubusercontent.com/17256841/210169566-0fd59ec1-d859-431b-b17d-405256f34517.png)


### Versions

- Browser/version: FF 108
- uBlock Origin version: 1.46.1b3

### Settings

Use Lowe's list

### Notes

When testing, always load the page in a new incognito window to make sure it can reproduced correctly.
