### PR TITLE
chess.com ads

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -6927,3 +6927,9 @@ ddys.*##+js(no-fetch-if, analytics)
 
 ! kangkimin. com anti select
 kangkimin.com##*:style(-webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
+
+! https://www.chess.com hide ads
+www.chess.com##.main-banner-wrapper
+www.chess.com##.short-sidebar-ad-top.short-sidebar-ad-component
+www.chess.com##.content-ad-content
+www.chess.com##.short-sidebar-ad-bottom.short-sidebar-ad-component


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URLs in question
`https://www.chess.com/home`

### Describe the issue
Ads are blocked with default lists but the containers still take up empty space
