### PR TITLE
Two malicious microsoft oauth servers

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1433,3 +1433,7 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16209
 ||barlear.ru^$all
+
+! <will replace>
+||breadcat.cc^$all
+||mc-hypixel.store^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1434,6 +1434,6 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ! https://github.com/uBlockOrigin/uAssets/issues/16209
 ||barlear.ru^$all
 
-! <will replace>
+! https://github.com/uBlockOrigin/uAssets/pull/16214
 ||breadcat.cc^$all
 ||mc-hypixel.store^$all


### PR DESCRIPTION
1- 
`mc-hypixel.store` is a newer domain being used by the same person that ran `msverify.dev`. It's registered under publicdomainregistry.com (takedown failed) and hosted on a server provided by `des.capital` (according to whois).
Example: `https://login.live.com/oauth20_authorize.srf?client_id=c03fd5f2-63b4-4e4d-8466-a11782c7834c&response_type=code&redirect_uri=https://mc-hypixel.store&scope=XboxLive.signin+offline_access&state=de7q4ccq`

2-
`breadcat.cc` is operated by the same person as `hypixei.com`, and is used as an alternative callback domain for oauth prompts. Everything is behind cloudflare, takedown failed.
Example: `https://login.live.com/oauth20_authorize.srf?response_type=code&client_id=2e4c3aeb-b621-4641-baea-953a726f9b0c&redirect_uri=https://breadcat.cc/api/v1/auth/callback&scope=XboxLive.signin+offline_access&state=84b164f686300177673b8c6ee53b6f4e190c1b957ae59b025cb077f3186715a8`