### PR TITLE
Updated trakt.tv filters

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -16239,9 +16239,10 @@ sonyliv.com##+js(json-prune, adProvider)
 @@||magyarhang.org^$shide
 ||magyarhang.org/*.gif$image
 
-! https://www.reddit.com/r/uBlockOrigin/comments/e8xapo/hide_ads_on_trakt/
-trakt.tv##:xpath('//*[(text()='Advertisement')]/..')
-trakt.tv##:xpath(//*[(text()='Advertisement')]/..)
+trakt.tv##div:matches-attr(class="/[\da-f]{6}-[\w]+-[\w]+/"):has-text(Advertisement)
+trakt.tv##div:matches-attr(id="/[\da-f]{6}-[\w]+-[\w]+/"):has-text(Advertisement)
+trakt.tv##section:matches-attr(id="/[\da-f]{6}-[\w]+-[\w]+/"):has-text(Advertisement)
+trakt.tv##div.fanarts>div.grid-item:has-text(Hide ads)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/e93zy9/adblock_blocker_on_vsttorrents/
 @@||vsttorrents.net^$ghide


### PR DESCRIPTION
The original filters were no longer working

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
https://trakt.tv
https://trakt.tv/movies/trending
https://trakt.tv/calendars
https://trakt.tv/dashboard
```

+ other user-specific pages

### Describe the issue

Advertisement banners can be seen, in the form of:

* Full-row ad sections (in many places)
* Sidebar panels on the bottom-right, showing advertisements
* VIP feature ads in-line with the image grid in the movies listing

### Versions

- Browser/version: tested on Chromium 107.0.5304.110
- uBlock Origin version: 1.46.0

### Settings

Attached my settings json

### Notes

The previously existing filters were no longer effective, very obvious ads were displayed all over just about every page. The updated filters take advantage of the website's randomization system being not random enough (seemingly).