### PR TITLE
badware: Add galeden.cn

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1461,3 +1461,5 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 
 ! https://twitter.com/harugasumi/status/1612249590023192576
 ||paypay.srbxjd.com^$all
+
+||galeden.cn^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1462,4 +1462,5 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ! https://twitter.com/harugasumi/status/1612249590023192576
 ||paypay.srbxjd.com^$all
 
+! https://github.com/uBlockOrigin/uAssets/pull/16283
 ||galeden.cn^$all


### PR DESCRIPTION
### URL(s) where the issue occurs

`galeden.cn`

### Describe the issue

This domain was used to be the official website of [MisakaTranslator](https://github.com/hanmin0822/MisakaTranslator) and it has some traffic.

However the owner spent his time on work and didn't hold the ownership of that domain. Later someone registered it and put some ADware or maybe NSFW content on it.

In order to prevent people from accessing the wrong *official* website, I suggest to block it.

### Notes

I am the maintainer of MisakaTranslator. You can see me at releases.

For the usage of that domain in the past, see `https://github.com/hanmin0822/MisakaTranslator/commit/08293b6dbafa3b7cec18be8fff58564641c7a64c` and `https://github.com/hanmin0822/MisakaTranslator/issues/232`
