### PR TITLE
Remove Dutch sites. because they're also in @EasyDutch-uBO/EasyDutch

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -896,9 +896,6 @@ archive.org#@#.oasad
 ! fix nfl.com fantasy.nfl.com site and video breakage
 @@||static.parsely.com/p.js$script,domain=nfl.com
 
-! https://twitter.com/tommasobarbugli/status/1040601984624152577
-@@||coolblue.nl^*/ard.png$script,1p
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/9gn4is
 @@||a.4cdn.org/*.json$xhr,domain=4chan.org
 ! https://github.com/uBlockOrigin/uAssets/issues/4740
@@ -1627,9 +1624,6 @@ indoxx1.center#@#.lazy
 ! https://forums.lanik.us/viewtopic.php?f=64&t=43426&p=149429#p149426
 @@||myreadingmanga.info/wp-content/uploads/*.jpg$image,1p
 ||myreadingmanga.info/wp-content/uploads/*.gif$image
-
-! https://github.com/uBlockOrigin/uAssets/issues/6198
-@@||2mdn.net/instream/html5/ima3.js$script,domain=geenstijl.nl
 
 ! https://github.com/easylist/easylist/issues/3942
 ||pmdstatic.net^$3p,badfilter
@@ -2658,9 +2652,6 @@ saltspringexchange.com#@#.single-ad
 ! https://github.com/uBlockOrigin/uAssets/issues/7623
 @@||pxys.ezoic.net^$domain=lanaciondigital.es
 
-! https://github.com/uBlockOrigin/uAssets/issues/7629
-@@||laredoute.com^$image,domain=laredoute.nl|laredoute.lu
-
 ! https://github.com/NanoMeow/QuickReports/issues/4261
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=mypodboxx.com
 
@@ -3627,12 +3618,6 @@ coolmathgames.com##+js(set, network_user_id, '')
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/ovy8cg/why_is_the_image_on_this_page_blocked_no_matter/
 @@||b-cdn.net^*-adap.jpg$image,domain=techxplore.com
-
-! https://github.com/uBlockOrigin/uAssets/issues/9687
-@@||prtawe.com/embed/tbplyr/?$script,domain=camsexbabe.nl
-@@||awemwh.com/$image,domain=camsexbabe.nl
-@@||potwm.com/tube-player/?$frame,domain=camsexbabe.nl
-@@||potwm.com/api/video-promotion/v1/get-$xhr,domain=camsexbabe.nl|potwm.com
 
 ! https://github.com/uBlockOrigin/uAssets/issues/9692
 ||hb.afl.rakuten.co.jp^$badfilter


### PR DESCRIPTION
### URL(s) where the issue occurs
`https://github.com/uBlockOrigin/uAssets/blob/master/filters/unbreak.txt`

### Describe the issue
In the `unbreak-list` are some Dutch domains.
They are also included in the @EasyDutch-uBO/EasyDutch list.
Therefore they could be removed from ubo's list if you agree with it.

[Warning! Some websites to be removed are NSFW.]

### Screenshot(s)

### Versions

- Browser/version: FireFox 108.0.1
- uBlock Origin version: [1.46.0

### Settings

- In this case not needed

### Notes
