### PR TITLE
Remove generic filter

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -804,7 +804,6 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||adultonlineplay.com^$all
 ||fastandslut.com^$all
 &click_price=0.*&click_id=$doc
-?brand=*&model=$doc
 ||familialsimulation.com^$all
 /\/(?:[0-9a-z]{7,25}-){9,13}[0-9a-z]{10,15}\/(?:[0-9a-z]+\/)+index\.php/$doc
 ||imilroshoors.com^$all


### PR DESCRIPTION
### URL(s) where the issue occurs

Any website that contains brand and model params, example:

`https://www.example.com?brand=a&model=b`
`https://www.google.com/?brand=a&model=a`

### Describe the issue

The filter `?brand=*&model=$doc` is too generic to be present in the filter list. It will flag every URL for just containing the `brand` and `model` params which shouldn't be a reason to flag them.

### Screenshot(s)

![example_1](https://user-images.githubusercontent.com/22588915/214812164-2a4135b2-97ef-4df6-85f9-20a4e7053e41.png)
![example_2](https://user-images.githubusercontent.com/22588915/214810740-e4a8987b-fa9b-4dbd-8c65-111f0702eb76.png)

### Versions

- Browser/version: Firefox 109.0 
- uBlock Origin version: 1.46.0

### Settings

No changes

### Notes
