### PR TITLE
Blocks the onClick popup on torlock2.com

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -6613,3 +6613,6 @@ sneakernews.com##+js(aopr, sneakerGoogleTag)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16545
 socialcounts.org##+js(no-fetch-if, googlesyndication)
+
+! blocks the onClick popup on torlock2.com
+ecorph.com/script/bootstrap.js


### PR DESCRIPTION
This addition blocks the onClick popup on torlock2.com. As far as I can tell, the file blocked is responsible for setting up the "click" EventListener that opens up ad pages the first time a user clicks anywhere on the website. The file is pretty long and obfuscated, but I haven't been able to find any side effects.

### URL(s) where the issue occurs

Ads may be NSFW.
`https://www.torlock2.com/torrent/63489835/ubuntu-22-04-desktop-amd64.html`

### Describe the issue
In each page under torlock2.com, when the user clicks anywhere for the first time, a pop-up page will come up. Most pop-up pages are immediately killed by uBlock, but through this file block they don't even show up.

### Screenshot(s)
Not applicable.

### Versions
Not necessarily applicable, but in case anyone finds conflicting behavior:
- Browser/version: Microsoft Edge v.111.0.1646.0 (canary branch)
- uBlock Origin version: uBlock Origin 1.46.0

### Settings
Not applicable.

### Notes
[META] It's weird that the bug report and the pull request templates are the same.