### PR TITLE
Remove unneeded comments (very minor)

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -139,10 +139,6 @@
 ! https://blog.sucuri.net/2018/10/malicious-redirects-from-newsharecounts-com-tweet-counter.html
 ||newsharecounts.s3-us-west-2.amazonaws.com/nsc.js$script
 
-! https://github.com/uBlockOrigin/uAssets/issues/4014
-! https://www.virustotal.com/#/url/ac1fe407af0592489e7ef1ff2a62e381f05be08311e010fc4a5736b94b08d070/detection
-! https://www.scumware.org/report/104.27.174.25.html
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4137
 ||governiamo.com^$doc
 
@@ -1008,7 +1004,7 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/92466
 /^https:\/\/serch\d{2}\.biz\/\?p=/$doc,domain=biz
 
-! https://github.com/uBlockOrigin/uAssets/issues/9840
+! https://github.com/uBlockOrigin/uAssets/issues/4014 and https://github.com/uBlockOrigin/uAssets/issues/9840
 ! ||driverfix.com^$doc
 
 ! https://github.com/uBlockOrigin/uAssets/issues/9848


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

N/A

### Describe the issue

Unneeded comments relating to DriverFix. I have deleted the VT url (as the scanned URL is 404) and the scumware link (as the reports are old and it is linked from the issue), and moved the old issue link to where the entry is.

### Screenshot(s)

N/A

### Versions

- Browser/version: N/A
- uBlock Origin version: N/A

### Settings

N/A

### Notes

Given [that AdGuard appears to have added it](https://github.com/AdguardTeam/AdguardFilters/issues/139616) (although their website says otherwise?) and the file on VT has a very bad community rating (although given that people love downvoting even 0 byte files, that's probably not the most reliable indicator, it might (in my opinion) be worth considering uncommenting the entry. (Malwarebytes doesn't seem to detect it though) I know my opinion has little weight, but just my two cents.
