### PR TITLE
Yahoo Finance

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -536,3 +536,8 @@ sportbar.live##+js(nostif, sadbl)
 onionstream.live,sportbar.live##+js(aopw, _pop)
 ||jkfdnofnz.com^
 ||znyiaxnaf.com^
+
+! Yahoo Finance: Premium ad, disable adblock popup
+||s.yimg.com/bx/adb/$image
+finance.yahoo.com##.wafer-beacon
+finance.yahoo.com###finance-desktop-web-homepage-ablock-overlay


### PR DESCRIPTION
New anti-adblock popup and removing premium ads.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://finance.yahoo.com/

### Describe the issue

There was some images promoting premium and a popup asking to disable adblock.
Top right, right side and when you scroll down a banner at the bottom.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/6486343/215836393-59d5925b-3c1f-4386-b879-28e1e533b605.png)
![image](https://user-images.githubusercontent.com/6486343/215836434-367de1dd-506d-4750-b65f-72da0f9c15d2.png)
After changes:
![image](https://user-images.githubusercontent.com/6486343/215836795-5d622f63-2ac7-436a-b142-c07fb65327ef.png)



### Versions

- Browser/version: Edge/Version 109.0.1518.70 (Official build) (64-bit)
- uBlock Origin version: 1.46.0

### Settings

- enabled every list

### Notes

