### PR TITLE
Add malware

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1464,3 +1464,8 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||ka4cv7yh4w.com^$all
 ||raedieshi.com^$all
 ||webuzz.me^$doc
+
+! https://twitter.com/1ZRR4H/status/1623067548781539339
+||best-exp.org^$all
+||soft-pro.site^$all
+||exp-pc.com^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1469,3 +1469,4 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||best-exp.org^$all
 ||soft-pro.site^$all
 ||exp-pc.com^$all
+||download2348.mediafire.com/ewjzz8pmn7rg/4n5bc37ank892fh/Expert-PC_2023.rar^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.youtube.com/watch?v=5ggPo6r4M2s`

### Describe the issue

A popular YouTube channel has been hacked and is promoting malware (RecordStealer)

### Screenshot(s)

![image](https://user-images.githubusercontent.com/84232764/217532158-3225c41e-2722-48e0-ac90-32deb3fcf4ff.png)
![image](https://user-images.githubusercontent.com/84232764/217532422-c64c6184-c3b6-4650-aa83-9b3c9767dad1.png)

### Versions

- Browser/version: Firefox 109.0.1
- uBlock Origin version: 1.46.1b18

### Settings

- N/A

### Notes

https://twitter.com/1ZRR4H/status/1623067548781539339
I have added `https://download2348.mediafire.com/ewjzz8pmn7rg/4n5bc37ank892fh/Expert-PC_2023.rar`, which is now in use on some of the videos. I can remove it if needed, but it currently isn't blocked by URLHaus (although I have reported it, so it should be once the URLHaus version in ubo updates)
As is normal for malware like this, the file is bloated & too big to upload to VT. Unbloated, it is detected by several AVs: https://www.virustotal.com/gui/file/a9018c918732d4687ad72aae2993b378f0ff2f39fe51d128dca2ea5be06aba61