### PR TITLE
Replace many `:upward(selector)` rules with `selector:has()`

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -875,7 +875,7 @@ talkceltic.net##+js(set, samDetected, false)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7365
 @@||splitshire.com^$ghide
-splitshire.com##.adsbygoogle:upward(.row-container)
+splitshire.com##.adtester-container
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7366
 @@||kwamkidhen.com^$ghide
@@ -2522,7 +2522,7 @@ real-sky.com##+js(aopr, app_vars.force_disable_adblock)
 healthline.com##aside:has(div:matches-css-before(content:/ADVERTISEMENT/))
 healthline.com##div[data-empty^="true"]:matches-css-before(content:/ADVERTISEMENT/)
 healthline.com##[class*="css"]:matches-css-before(content:/ADVERTISEMENT/)
-healthline.com##[href*="redirect"]:upward(section)
+healthline.com##section:has([href*="redirect"])
 healthline.com##hl-adsense
 
 ! https://community.brave.com/t/website-kept-asking-leave-site-if-i-click-cancel-it-opened-new-window-i-couldnt-even-close-brave-without-end-process/
@@ -2921,10 +2921,9 @@ duplichecker.com##[href^="https://www.duplichecker.com/link"]
 duplichecker.com##.home_bg > .container > style + style + div
 duplichecker.com##.clearfix + div > style + style + div
 duplichecker.com##.clearfix + div:has(> style:has-text(min-height:302px))
-duplichecker.com###home_after_title > .adsbygoogle:upward(.main-content > div > *)
-duplichecker.com###home_before_buton > .adsbygoogle:upward(.data_inbox > div)
-duplichecker.com##div[style] > [class^="avds"]:upward(div[style])
-duplichecker.com##div > span[id^="side_bar"] > .adsbygoogle:upward(div)
+duplichecker.com##[class^="avds"]
+duplichecker.com##div[style]:has(> [class^="avds"])
+duplichecker.com##div:has(> span[id^="side_bar"] > .adsbygoogle)
 duplichecker.com##a[style="display: inline-block;"][target="_blank"][rel="nofollow"]
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/63002
@@ -2998,18 +2997,12 @@ ohentai.org##[class^="listleaderboardcontainer"]
 ohentai.org##.videobrick > .videoadintro:upward(1)
 ohentai.org##+js(nowoif)
 
-! youngpornvideos.com popup ads
-youngpornvideos.com##+js(acis, url)
-youngpornvideos.com##.ads
-youngpornvideos.com##.ads-mobile
-youngpornvideos.com##.ads-thumb-list:upward(.outer-item)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/8988
 hentaicloud.com##+js(set, decodeURI, noopFunc)
 hentaicloud.com##+js(aopr, TotemToolsObject)
 hentaicloud.com##+js(aopr, AaDetector)
 hentaicloud.com##.vertical-ads-content
-hentaicloud.com##.ad:upward(.horizontal-ads-content)
+hentaicloud.com##.horizontal-ads-content:has(.ad)
 hentaicloud.com##section.videos-content:has(.thumbnail > a[href^="https://www.nutaku.net/signup/landing/"])
 
 ! javdoe.to/javsun.cc/javtc.fun popup ads
@@ -3867,11 +3860,6 @@ humannootropicsindex.com##.widget_custom_html
 forums.asianbookie.com##.topics > table > tbody > tr > td > table > tbody > tr > .topicrowdate
 ||asianbookie.com/displaytable.cfm?tablename=cslodds$frame
 asianbookie.com##a[href^="/cgi-bin/to.cgi"]
-
-! justfullporn.com popup
-justfullporn.com##.video-block-happy:upward(.order-1)
-*$script,3p,denyallow=fastly.net|google.com|gstatic.com|twitter.com,domain=justfullporn.com
-vidxhot.net##+js(nowoif)
 
 ! elitetorrent.com popup
 elitetorrent.*##+js(aopw, adcashMacros)
@@ -4841,7 +4829,7 @@ forexforum.co##+js(acis, $, .test)
 21porno.com##+js(nostif, window.location.href, 50)
 
 ! rule34.paheal.net PH
-rule34.paheal.net##script[src$="ads.js"]:upward(section[id])
+rule34.paheal.net##section[id]:has(script[src$="ads.js"])
 
 ! palcomix.com ads
 palcomix.com##center > font[size="3"][face="ARIAL"]:has-text(ADVERTISING):upward(td)
@@ -4867,7 +4855,7 @@ freemagazines.top##+js(acis, eval, replace)
 *$xhr,redirect-rule=nooptext,domain=freemagazines.top
 ! https://github.com/uBlockOrigin/uAssets/issues/15522
 freemagazines.top###fixedbanner
-freemagazines.top##.adsbygoogle:upward(.code-block)
+freemagazines.top##.code-block:has(.adsbygoogle)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/k6opvk/aggressive_ad_popup_locks_out_site_for_45seconds/
 namebio.com##.modal.bootbox[aria-hidden="false"]:has(#nudge-link[href^="https://bit.ly"])
@@ -5035,9 +5023,6 @@ cashearn.cc##div[style="display: flex;justify-content: center;"]
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/69563
 *$script,redirect-rule=noopjs,domain=konnoznet.xyz
-
-! nypost.com PH
-nypost.com##img[src$="/knewz_300x250.png"]:upward(.widget_text)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/69639
 fappee.com##+js(acis, doMyStuff)
@@ -5268,7 +5253,7 @@ miklpro.com##.banner
 *$script,3p,denyallow=google.com|gstatic.com|recaptcha.net,domain=miklpro.com
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/70442
-jerkoffer.com##iframe[src^="//a.o333o.com"]:upward(li.thumb)
+jerkoffer.com##li.banner:has(iframe[src^="//a.labadena.com"])
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/70460
 sshconect.com.br##+js(acis, addEventListener, nextFunction)
@@ -5277,7 +5262,7 @@ sshconect.com.br##+js(acis, addEventListener, nextFunction)
 ||zusepe.xyz^
 ! hd21.com/net
 hd21.*##+js(nowoif)
-hd21.com###spot_livecams_menu:upward(.holder)
+hd21.com##.holder:has(#spot_livecams_menu)
 hd21.com##.ID-bottom-banner
 hd21.com##.adv_middle
 hd21.*##.aside_video
@@ -5495,20 +5480,14 @@ sexflashgame.org##+js(acis, ishop_codes)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/70849
 ||porngames.com/*.gif$image,1p
-porngames.com##a[href="javascript:void(0);"]:upward(.contentbox)
+porngames.com##.contentbox:has(a[href="javascript:void(0);"])
 porngames.com##div[style^="display: block; position: fixed; z-index:"]
-porngames.com##iframe[src^="//"]:upward(.contentbox)
+porngames.com##.contentbox:has(iframe[src^="//"])
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/kkg3sw/
 f2movies.to##+js(nostif, /0x|devtools/)
 f2movies.to##+js(nosiif, _0x)
 f2movies.to###gift-top > [href="/android-movies-apk"]
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/70843
-//images\/(?:Banner\d{1,2}\.|[a-z]{3}\/)/$image,1p,domain=thesquarshers.com
-thesquarshers.com##img[src*="/Banner"]:upward(a)
-thesquarshers.com##.table
-thesquarshers.com##.video-holder
 
 ! cutesexyteengirls.com exit prevention
 cutesexyteengirls.com##+js(aeld, beforeunload)
@@ -5602,7 +5581,7 @@ javnow.net##div[style$="width:300px;height:250px;"]
 ||highwebmedia.com/ri/$domain=clubsarajay.com
 clubsarajay.com###mgb
 clubsarajay.com###mpc-container
-clubsarajay.com##iframe[src^="https://ads2."]:upward(.widget)
+clubsarajay.com##.widget:has(> small)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/71300
 gatcha.org##+js(nostif, css_class.show)

--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -110,7 +110,7 @@ e-sushi.fr##+js(ra, onclick, body)
 
 ! elquintobeatle .com anti adb
 elquintobeatle.com##+js(nostif, show)
-elquintobeatle.com##iframe[width="970"]:upward([id^=tdi_].tdc-row)
+elquintobeatle.com##[id^=tdi_].tdc-row:has(iframe[width="970"])
 
 ! encodinghub. com anti adb
 encodinghub.com##+js(aeld, load, nextFunction)
@@ -250,7 +250,7 @@ tubsxxx.com##.videoAd
 536sdms.com###text-5
 pornez.net###cb00
 pornez.net###cb01
-cnnamador.com##.cards__item--videos span.flag--banner:upward(.cards__item--videos)
+cnnamador.com##.cards__item--videos:has(span.flag--banner)
 cutscenes.net##.item > div[id^="ts_ad_native"]:upward(1)
 cutscenes.net##.item > iframe[src^="https://go."]:upward(1)
 pornxday.com,twinkybf.com##.happy-sidebar
@@ -357,7 +357,7 @@ jetpunk.com##.box-ad-outer
 imgur.com##+js(set, ADBLOCKED, false)
 ! https://www.reddit.com/r/uBlockOrigin/comments/m1iib6/imgur_ads_still_making_it_through/
 imgur.com##.Post-item--interactions:upward(1)
-imgur.com##.Post-item-external-ad:upward(div[style])
+imgur.com##div[style]:has(.Post-item-external-ad)
 
 ! thodkyaat.com ad-reinsertion
 thodkyaat.com##pp
@@ -403,7 +403,7 @@ kisahdunia.com##[href^="https://www.samsung.com/"]
 hentai-party.com,hentaibaka.one,hentaicomics.pro,xxx-comics.pro##+js(set, adb, 0)
 hentaicomics.pro##+js(nowoif)
 hentai-party.com,xxx-comics.pro##figure.mix > .tac
-hentaibaka.one,hentaicomics.pro##.single-portfolio .xxx-banner:upward(.single-portfolio)
+hentaibaka.one,hentaicomics.pro##.single-portfolio:has(.xxx-banner)
 ||hentai-party.com/*?view=$doc,other,removeparam=view
 ||hentaibaka.one/*?code=$doc,other,removeparam=code
 ||hentaicomics.pro/*?code=$doc,other,removeparam=code
@@ -684,7 +684,7 @@ getsexgames.com##.menuAff
 getsexgames.com##.menuPointPic
 
 ! https://github.com/easylist/easylist/issues/6983
-adultgamestop.bigtopsites.com##img[width="558"][height="149"]:upward(td[style])
+adultgamestop.bigtopsites.com##td[style]:has(img[width="558"][height="149"])
 
 ! https://github.com/easylist/easylist/issues/6985
 pornachi.com,rule34.art##+js(acis, document.querySelectorAll, popMagic)
@@ -727,7 +727,7 @@ pornojenny.com##.vjs-overlay
 pornojenny.com##div[id="wrapper_content"] > aside
 pornojenny.com###wa_10
 @@||pornojenny.com^$ghide
-pornojenny.com##[href^="https://www.handy-sextreffen.info/"]:upward(.grid_box)
+pornojenny.com##.grid_box:has([href^="https://www.handy-sextreffen.info/"])
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/72868
 mundowuxia.com##+js(aopw, _pop)
@@ -795,7 +795,7 @@ winaero.com##[href^="/idx.php"]
 taxidrivermovie.com###scroll-div
 taxidrivermovie.com##.adboard-top
 taxidrivermovie.com##.thumb-holder[style="height:250px;"]:upward(1)
-taxidrivermovie.com##[href="/category/taxi-fares/"]:upward(.thumb)
+taxidrivermovie.com##.thumb:has([href="/category/taxi-fares/"])
 
 ! https://github.com/uBlockOrigin/uAssets/issues/15622
 embedstream.me,nolive.me##+js(aopw, _pop)
@@ -1302,7 +1302,7 @@ cine-calidad.*##+js(ra, href, #opfk)
 cine-calidad.*##.links
 
 ! https://github.com/easylist/easylist/pull/6896#pullrequestreview-599945327
-cambb.xxx##.thumb div.ad:upward(.thumb)
+cambb.xxx##.thumb:has(div.ad)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8628
 embed.indavideo.hu##+js(set, AdHandler.adblocked, 0)
@@ -1409,7 +1409,7 @@ nexusmods.com##.areplacer
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8674
 discovermagazine.com##.adunitContainer:upward(1)
-discovermagazine.com##a > img + div[class]:last-of-type:has-text(Sponsored):upward(div[sizes])
+discovermagazine.com##div[sizes]:has(a > img + div[class]:last-of-type:has-text(Sponsored):upward(div[sizes])
 discovermagazine.com##div[sizes] > span[class]:has-text(Sponsored):upward(div[sizes])
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/76858
@@ -1595,8 +1595,8 @@ renault-club.cz##.adsbygoogle
 ||bohubrihi.com^$3p
 
 ! https://github.com/easylist/easylist/issues/7400
-bhaskar.com##[id^="Ad"]:upward([style])
-divyabhaskar.co.in##[id^="Ad"]:upward([style])
+bhaskar.com##[style]:has(> [id^="Ad"])
+divyabhaskar.co.in##[style]:has(> [id^="Ad"])
 
 ! propeller crap/ads
 livesport24.net##+js(acis, setTimeout, admc)
@@ -2393,7 +2393,7 @@ german-porno-deutsch.info##[href="/acamateure.html"]
 @@||trafficfabrik.com/mine.js$script,domain=movie.momo-net.com
 momo-net.com##+js(aeld, contextmenu)
 momo-net.com##+js(aopr, document.body.appendChild)
-movie.momo-net.com##iframe:upward([style*="visibility"])
+movie.momo-net.com##[style*="visibility"]:has(iframe)
 deutschsex.mobi,1milf.com##+js(aost, Math.floor, randStr)
 1milf.com##.desktop.aside_media.aside
 1milf.com##.desctop.spot
@@ -2432,7 +2432,7 @@ bollyholic.*##+js(aopr, disableDeveloperTools)
 
 ! influencersgonewild.com popunder
 influencersgonewild.com##+js(aost, Math.round, onload)
-influencersgonewild.com##.g1-advertisement-inside-grid:upward(li)
+influencersgonewild.com##li:has(.g1-advertisement-inside-grid)
 
 ! xxxwebdlxxx.top anti-adb, popup
 xxxwebdlxxx.top##+js(aopw, _pop)
@@ -2551,7 +2551,7 @@ icttipsandtricks.nl##+js(aost, String.prototype.charCodeAt, ai_)
 *$script,redirect-rule=noopjs,domain=ver-television.online
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/n1cats/ads_on_qwant_lite/
-lite.qwant.com##.ad:upward(article.result.web)
+lite.qwant.com##article.result.web:has(.ad)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/81856
 gay4porn.com##+js(set, flashvars.adv_start_html, '')
@@ -2626,7 +2626,7 @@ dubzstreams.com###id-custom_banner
 #@#.display_ad
 
 ! https://github.com/uBlockOrigin/uAssets/issues/9017
-bleepingcomputer.com###bc-home-news-main-wrap > li a[href$="/deals/"]:upward(li)
+bleepingcomputer.com###bc-home-news-main-wrap > li:has(a[href$="/deals/"])
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/82339
 ! https://github.com/uBlockOrigin/uAssets/issues/15501
@@ -3686,7 +3686,7 @@ download.sharenulled.net##+js(aopr, app_vars.force_disable_adblock)
 download.sharenulled.net##+js(set, blurred, false)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/of8b31/golinuxcloudcom_has_big_rectangles_where_ads/
-golinuxcloud.com##.golin-adlabel:upward([class^="golin-content"])
+golinuxcloud.com##[class^="golin-content"]:has(.golin-adlabel)
 golinuxcloud.com##.adtag_250
 golinuxcloud.com##.adtag_600
 
@@ -4504,7 +4504,7 @@ animet.tv##.adsbygoogle
 owlzo.com##+js(nostif,  adblockEnabled)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/pifkxt/kumparancom/
-kumparan.com##.adunitContainer:upward([data-qa-id])
+kumparan.com##[data-qa-id]:has(.adunitContainer)
 
 ! DeBlocker sites
 doffeecafe.me,nulljungle.com,oyuncusoruyor.com,pbarecap.ph,sourds.net,teknobalta.com,tinyppt.com,tvinternetowa.info##+js(aeld, DOMContentLoaded, adsBlocked)
@@ -4775,7 +4775,7 @@ readytechflip.com##.widget_custom_html
 ! https://github.com/uBlockOrigin/uAssets/issues/10043
 ! https://github.com/uBlockOrigin/uAssets/issues/10044
 ! https://github.com/uBlockOrigin/uAssets/issues/10045
-onlylesbiantube.com##iframe:upward(.thumb)
+onlylesbiantube.com##.thumb:has(iframe)
 onlylesbiantube.com##.hor_bs
 onlylesbiantube.com##.video_av_bl
 ||ag.palmtube.net^
@@ -4885,7 +4885,7 @@ embedsb.com,streamlare.com##+js(nosiif, 0x)
 everyeye.it##+js(nostif, adb)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/px06je/ad_was_not_blocked/
-nodejs.libhunt.com##[data-ref="saashub"]:upward(div.feed-item)
+nodejs.libhunt.com##div.feed-item:has([data-ref="saashub"])
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/px0zwg/antiadblock_detected_instaanimecom/
 instaanime.com##+js(nostif, length)
@@ -4916,7 +4916,7 @@ pobre.*##.generalModal
 ! https://github.com/uBlockOrigin/uAssets/issues/15588
 coinsparty.com##+js(nowoif)
 coinsparty.com##+js(no-xhr-if, wpadmngr)
-coinsparty.com###captchaShortlink:upward(form#coinsparty > div):style(display: block !important;)
+coinsparty.com##form#coinsparty > div:has(#captchaShortlink):style(display: block !important;)
 coinsparty.com##form[action$="/links/popad"]:remove()
 coinsparty.com##div[style="position: fixed; display: block; width: 100%; height: 100%; inset: 0px; background-color: rgba(0, 0, 0, 0); z-index: 300000;"]
 ||ad4point.nyc3.digitaloceanspaces.com^
@@ -4950,7 +4950,7 @@ mikl4forex.com##+js(nano-sib, counter, 2000)
 michaelemad.com##+js(nano-sib, timer)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10102
-reddit.com##.adLinkBar:upward(article[style="z-index: 1;"])
+reddit.com##article[style="z-index: 1;"]:has(.adLinkBar)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10104
 @@||xtremestream.co^$ghide
@@ -5192,7 +5192,7 @@ pirate4all.com##.e3lan-top.e3lan
 pirate4all.com##.pirat-before-content
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/97286
-animenhentai.com##.post.has-post-thumbnail video#gump:upward(.post):remove()
+animenhentai.com##.post.has-post-thumbnail:has(video#gump):remove()
 animenhentai.com###custom_html-3
 
 ! https://github.com/uBlockOrigin/uAssets/issues/1905#issuecomment-394129540
@@ -5779,7 +5779,7 @@ coinsearns.com###promo3
 coinsearns.com,mcrypto.club,blog-forall.com,luckydice.net,adarima.org###wpsafe-generate, #wpsafe-link:style(display: block !important;)
 coinsearns.com,mcrypto.club##.safelink-recatpcha:upward(div):style(display: block !important;)
 mcrypto.club##div[style="display: none;"]:style(display: block !important;)
-shinchu.*##.g-recaptcha:upward(form > div):style(display: block !important;)
+shinchu.*##form > div:has(.g-recaptcha):style(display: block !important;)
 blog-forall.com##+js(no-fetch-if, googlesyndication)
 blog-forall.com##[id^="wpsafe-wait"]
 blog-forall.com###fixed-bot-ad2
@@ -5894,7 +5894,7 @@ readgraphicnovels.blogspot.com##+js(nobab)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10508
 @@||washingtoninformer.com^$ghide
-washingtoninformer.com##.widget a.gofollow:upward(.widget)
+washingtoninformer.com##.widget:has(a.gofollow)
 washingtoninformer.com##.a-772
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10509
@@ -6413,7 +6413,7 @@ arhplyrics.in##+js(no-fetch-if, googlesyndication)
 ! https://github.com/uBlockOrigin/uAssets/issues/10850
 ! https://github.com/uBlockOrigin/uAssets/issues/10851
 scrolller.com##.ad-block-popup:upward(2)
-scrolller.com##.native-ad-item-panel:upward(.vertical-view__item)
+scrolller.com##.vertical-view__item:has(.native-ad-item-panel)
 ||photon.scrolller.com/categories/$image,media
 ||photon.scrolller.com/scrolller/$media
 

--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -58,7 +58,7 @@ rosefile.net##+js(acis, document.addEventListener, nextFunction)
 ! https://jbbs.shitaraba.net/bbs/read.cgi/internet/25463/1598352715/430
 ac-illust.com,photo-ac.com##+js(set, enable_dl_after_countdown, true)
 ac-illust.com,photo-ac.com##+js(set, isGGSurvey, true)
-ac-illust.com,photo-ac.com###eachDownloadedModal .ac-btn[href^="https://premium."]:upward(#eachDownloadedModal)
+ac-illust.com,photo-ac.com###eachDownloadedModal:has(.ac-btn[href^="https://premium."])
 ac-illust.com,photo-ac.com##.modal-backdrop
 ac-illust.com,photo-ac.com##body.modal-open *:style(filter: none!important;)
 
@@ -459,7 +459,7 @@ piracy.moe##[class^="SupportBanner_banner__"]
 ! https://github.com/uBlockOrigin/uAssets/issues/11449
 digminecraft.com##+js(aopr, pbg)
 ! https://github.com/uBlockOrigin/uAssets/issues/15392
-digminecraft.com##div > [id$="_slot"]:upward(div)
+digminecraft.com##div:has(> [id$="_slot"])
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/sbkktu/popup_ad_and_site_blocks_developer_tools/
 rabbitstream.net##+js(set, console.clear, undefined)
@@ -656,7 +656,7 @@ vizstream.ru##+js(aopr, AaDetector)
 ||vizstream.ru/log/
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11622
-vidstreamz.online##[target="_blank"][style]:upward([style])
+vidstreamz.online##[style]:has([target="_blank"][style])
 vidstreamz.online##.xad-wrapper
 vidstreamz.online##+js(aopr, open)
 
@@ -694,7 +694,7 @@ mp3juices.su##[href^="https://apkpure7.com/"]
 ! https://github.com/uBlockOrigin/uAssets/issues/13928
 ! https://github.com/uBlockOrigin/uAssets/issues/15413
 etsy.com##li.wt-list-unstyled .v2-listing-card__info > div.wt-text-truncate.wt-text-caption > span[class] > span[class]:upward(1):matches-css(display: inline-block):upward(li)
-etsy.com##.listing-link[href*="ref=sc_gallery"]:upward(li)
+etsy.com##li:has(.listing-link[href*="ref=sc_gallery"])
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11648
 techhelpbd.com##+js(nano-sib, counter--)
@@ -830,7 +830,7 @@ megafilmeshdonline.org##+js(aopr, __Y)
 ! https://github.com/uBlockOrigin/uAssets/issues/12476
 beastx.top,playerx.stream###theotherads
 beastx.top,playerx.stream##+js(nowoif, !/d/)
-playerx.stream##[style][href]:upward([style])
+playerx.stream##[style]:has([style][href])
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11730
 supersextube.pro##+js(nowoif)
@@ -1377,7 +1377,7 @@ redirect.dafontvn.com##+js(nano-sib, distance)
 ! https://github.com/uBlockOrigin/uAssets/issues/12250
 @@||gsmware.com^$ghide
 gsmware.com##.adtester-container
-gsmware.com##.HTML.widget .adsbygoogle:upward(.widget)
+gsmware.com##.HTML.widget:has(.adsbygoogle)
 gsmware.com##.kabaradd
 
 ! https://github.com/uBlockOrigin/uAssets/issues/12258
@@ -1972,7 +1972,6 @@ autotrader.co.uk##.search-page__products > [data-is-promoted-listing]
 
 ! tiki.vn search ads
 tiki.vn##[class^="ProductList__Wrapper"] > div
-tiki.vn##.brand-ad:upward(div)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/12713
 ||111.90.150.10/wp-content/uploads/*.gif$image,1p
@@ -2304,7 +2303,7 @@ racedepartment.com##+js(acis, $, adsBlocked)
 ! https://tecmundo.net/verify/?HUuun2= timer
 tecmundo.net###yuidea-btn:style(display: block !important)
 tecmundo.net###yuidea-btn-before
-tecmundo.net##.percent:upward([id^="yuidea-wait"])
+tecmundo.net##[id^="yuidea-wait"]:has(.percent)
 
 ! freeporncomics.me popup
 freeporncomics.me##+js(acis, Date, 'shift')
@@ -2317,11 +2316,11 @@ playdede.tv##+js(acis, eval, window.atob)
 ||theswagsports.com/can/*.htm$script,1p
 theswagsports.com##.colombiaoneinvalid
 theswagsports.com##a[rel*="sponsored"]
-theswagsports.com###btm-widget img[onload]:upward(#btm-widget > .colombiaonesuccess > div)
+theswagsports.com###btm-widget > .colombiaonesuccess > div:has(img[onload])
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/116606
 pkpics.club###countdown
-pkpics.club##img[onclick]:upward(.wait):style(display: block !important)
+pkpics.club##.wait:has(img[onclick]):style(display: block !important)
 
 ! hentaimoe.me popup
 hentaimoe.me##+js(acis, Date, 'shift')
@@ -2440,7 +2439,7 @@ movgotv.net##+js(aopw, _pop)
 droidmirror.com##+js(nano-sib, counter)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/12273
-slidesgo.com##.ssm_adunit_container:upward([id^="list_ads"])
+slidesgo.com##[id^="list_ads"]:has(.ssm_adunit_container)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/117701
 ! https://github.com/uBlockOrigin/uAssets/issues/13856
@@ -2576,7 +2575,7 @@ faucetclub.net##+js(acis, eval, decodeURIComponent)
 faucetclub.net##+js(no-xhr-if, czilladx)
 faucetclub.net##.container > div > center
 faucetclub.net##.ads
-faucetclub.net##.card-body > .row > iframe:upward(.card-body)
+faucetclub.net##.card-body:has(> .row > iframe)
 faucetclub.net##center:has([id^="bantraf"])
 faucetclub.net###adCenter
 faucetclub.net###wcfloatDiv4
@@ -2627,7 +2626,7 @@ onlyhgames.com##+js(nano-stb, CountBack, 990)
 @@||blogupdated.com^$ghide
 blogupdated.com##+js(acis, eval, lazyadsense)
 blogupdated.com##+js(nano-sib, counter)
-blogupdated.com##.adsbygoogle:upward([id^="HTML"])
+blogupdated.com##[id^="HTML"]:has(.adsbygoogle)
 
 ! https://forums.lanik.us/viewtopic.php?t=47536-nsfw-multiple-websites
 amateur8.com,freeporn8.com,maturetubehere.com##+js(aeld, /click|mousedown/, catch)
@@ -2662,7 +2661,7 @@ guidon40hyporadius9.com,449unceremoniousnasoseptal.com,19turanosephantasia.com,3
 ! https://github.com/AdguardTeam/AdguardFilters/issues/118331
 givee.club##+js(acis, document.addEventListener, adjsData)
 givee.club##.definetelynotanad
-givee.club##.definetelynotanad:upward([class^="col-md-"])
+givee.club##[class^="col-md-"]:has(.definetelynotanad)
 
 ! hdmovies4u. mom & cryptoblog24. info ads
 cryptoblog24.info##+js(no-fetch-if, googlesyndication)
@@ -2687,7 +2686,7 @@ watchimpracticaljokers.com##+js(aopr, popns)
 ! https://www.reddit.com/r/uBlockOrigin/comments/uo7w9g/clicking_on_the_play_button_of_the_video/
 ||fucktube4k.com/wp-content/uploads/*porn4k-banner.png$image,1p
 fucktube4k.com##+js(acis, document.querySelectorAll, popMagic)
-fucktube4k.com##.partner-banner:upward(div[style])
+fucktube4k.com##div[style]:has(.partner-banner)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/12772#issuecomment-1125434557
 @@||s0.2mdn.net/instream/html5/ima3.js$script,domain=cadenaser.com
@@ -2969,7 +2968,7 @@ bestcash2020.com#@#.banner-728x90
 bestcash2020.com##.banner-inner
 ||youtube.com/embed/$frame,domain=bestcash2020.com
 edummm.xyz##+js(nano-sib, timeLeft)
-edummm.xyz##.inst > div.text-left iframe[src^="//"]:upward(.inst)
+edummm.xyz##.inst:has(> div.text-left iframe[src^="//"])
 
 ! https://www.elektronikpraxis.vogel.de ad reinsertion
 *$xhr,redirect-rule=nooptext,domain=vogel.de|elektronikpraxis.de
@@ -3096,7 +3095,7 @@ subtitles.cam##+js(aopw, _pop)
 yts-subs.net##+js(nostif, (), 150)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/13557
-distrowatch.com##[href*="utm"]:upward(tbody)
+distrowatch.com##tbody:has(> [href*="utm"])
 
 ! https://github.com/uBlockOrigin/uAssets/issues/13569
 turbo1.co##+js(nostif, getComputedStyle, 250)
@@ -3159,7 +3158,7 @@ drakescans.com##+js(aeld, , ads)
 ! https://github.com/uBlockOrigin/uAssets/issues/10291
 allcryptoz.net##+js(set, blurred, false)
 ! https://www.reddit.com/r/uBlockOrigin/comments/ukz7wr/need_help_with_some_popups/
-topcryptoz.net##[id^="gpt-passback"]:upward(table)
+topcryptoz.net##table:has([id^="gpt-passback"])
 allcryptoz.net,topcryptoz.net##[id^="promol"]
 ! https://github.com/uBlockOrigin/uAssets/issues/10291
 uniqueten.net,ultraten.net##+js(acis, document.querySelectorAll, popMagic)
@@ -4248,7 +4247,7 @@ rtl.de##+js(nostif, null, 10)
 @@||iocnt.net^$script,domain=rtl.de
 @@||googletagmanager.com/gtm.js$script,domain=rtl.de
 ||ais-akamai.rtl.de/autoimg/*$frame,1p
-rtl.de##[class*="superbanner"]:upward(article > div:not(#main))
+rtl.de##article > div:not(#main):has([class*="superbanner"])
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/wzwgpa/how_would_one_go_about_removing_this_countdown_so/
 crdroid.net##+js(no-fetch-if, googlesyndication)
@@ -4636,8 +4635,8 @@ seriesmetro.net##+js(aopr, afStorage)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/xil5y3/
 ||desktopnexus.com/pb-ads/
-desktopnexus.com###rightcolumn > .rbox > .rboxInner img[alt="Advertisement"]:upward(.rbox)
-desktopnexus.com##.wallpaperSidebarAds:upward(div)
+desktopnexus.com###rightcolumn > .rbox:has(> .rboxInner img[alt="Advertisement"])
+desktopnexus.com##div:has(> .wallpaperSidebarAds)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/14953
 weather.com##+js(no-fetch-if, doubleclick)
@@ -4863,7 +4862,7 @@ mdn.lol##+js(acis, onload, adblock)
 mdn.lol##+js(nowoif)
 ||coinzillatag.com^$script,redirect-rule=noopjs
 mdn.lol##input:style(display: block !important)
-mdn.lol##.g-recaptcha:upward(div):style(display: block !important)
+mdn.lol##div:has(> .g-recaptcha):style(display: block !important)
 bitcotasks.com,mdn.lol,techydino.net##[class^="floating-banner"]
 ! https://github.com/uBlockOrigin/uAssets/issues/15428
 *$script,redirect-rule=noopjs,domain=bitcotasks.com
@@ -5013,7 +5012,7 @@ mathway.com##.container:style(width: 100% !important;)
 ! https://github.com/uBlockOrigin/uAssets/issues/16358
 viefaucet.com#@#.ad-description
 viefaucet.com##.ads
-viefaucet.com##.is-guttered > .ads:upward(.is-guttered)
+viefaucet.com##.is-guttered:has(> .ads)
 videolyrics.in##+js(acs, document.createElement, adsBlocked)
 *$script,domain=videolyrics.in,redirect-rule=noopjs
 ||videolyrics.in^$csp=style-src *
@@ -5900,7 +5899,7 @@ spigotunlocked.com##+js(nostif, show)
 ! https://github.com/uBlockOrigin/uAssets/issues/16377
 tagecoin.com##+js(acs, alert)
 tagecoin.com##+js(acs, document.createElement, adsBlocked)
-tagecoin.com##div > ins:upward(div)
+tagecoin.com##div:has(> ins)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16120
 bitzite.com##+js(nostif, show)

--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -14,7 +14,7 @@
 kaguya.live##+js(nowoif)
 ||kaguya.live/sw.js$script,1p
 kaguya.live##[class^="bg-black"]
-kaguya.live##.text-lg:upward(.flex)
+kaguya.live##.flex:has(.text-lg)
 kaguya.live##.my-8.justify-center.items-center.flex
 kaguya.live##.z-\[9999\].inset-0.fixed
 ||i.imgur.com/*.jpg$image,domain=kaguya.live
@@ -58,7 +58,7 @@ infokik.com##+js(set, two_worker_data_js.js, [])
 freepik.com##+js(aeld, click, adobeModalTestABenabled)
 freepik.com##.adobe-coupon-container
 freepik.com##.main-spr
-freepik.com##.spr > .container-fluid:not([data-autopromo-name="freepik"]):upward(.spr)
+freepik.com##.spr:has(> .container-fluid:not([data-autopromo-name="freepik"]))
 ! https://github.com/uBlockOrigin/uAssets/issues/16393
 freepik.com##+js(set, FEATURE_DISABLE_ADOBE_POPUP_BY_COUNTRY, true)
 
@@ -111,9 +111,9 @@ welovemanga.*##+js(nowoif)
 ! https://github.com/uBlockOrigin/uAssets/issues/16281
 techpp.com##.tppAds
 techpp.com##.side-inserter
-techpp.com##.brxe-div > div[class="brxe-container"] .adsbygoogle:upward(.brxe-container)
-techpp.com###customad:upward(.code-block)
-techpp.com##section.brxe-section > div[class="brxe-container"] .adsbygoogle:upward(section)
+techpp.com##.brxe-container:has(.brxe-div > div[class="brxe-container"] .adsbygoogle)
+techpp.com##.code-block:has(#customad)
+techpp.com##section:has(section.brxe-section > div[class="brxe-container"] .adsbygoogle)
 
 ! https://github.com/easylist/easylist/issues/14573
 streamtb.me##+js(nowoif)
@@ -217,13 +217,13 @@ btc25.org,doge25.in##+js(acs, document.getElementById, Swal.fire)
 btc25.org,doge25.in##+js(no-xhr-if, czilladx)
 btc25.org,doge25.in###wcfloatDiv4
 btc25.org##.ads
-btc25.org##center > ins:upward(center)
+btc25.org##center:has(> ins)
 doge25.in##.alert-success.alert .ads
 doge25.in##.row.text-center > .ads
 doge25.in##[id^="hbagency_space"]
 doge25.in##center > .ads
 doge25.in##center > ins
-doge25.in##div[style] > ins:upward(div)
+doge25.in##div:has(div[style] > ins)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16347
 darkwanderer.net,truckingboards.com##+js(nostif, show)
@@ -497,8 +497,8 @@ daddylivehd.*,earthquakecensus.com,footyhunter.lol,poscitech.click,starlive.stre
 bloginguru.xyz##+js(set, blurred, false)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16545
-socialcounts.org##.container > .adsbygoogle:upward(.container)
-socialcounts.org##.container > div > .adsbygoogle:upward(div)
+socialcounts.org##.container:has(> .adsbygoogle)
+socialcounts.org##div:has(.container > div > .adsbygoogle)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16547
 ahmedmode.*##+js(nostif, show)
@@ -564,10 +564,10 @@ shrdsk.me##+js(nostif, ad_listener)
 nilesoft.org##+js(aost, document.createElement, notify)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16633
-tlgrm.eu##.channel-feed__brick .cfeed-card-contents--banner-adsense:upward(.channel-feed__brick)
+tlgrm.eu##.channel-feed__brick:has(.cfeed-card-contents--banner-adsense)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16634
-telegramchannels.me##.is-full .climad-badge:upward(.is-full)
+telegramchannels.me##.is-full:has(.climad-badge)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16637
 nicesss.com##+js(aopw, _pop)
@@ -592,7 +592,7 @@ iwatchtheoffice.com##+js(aopw, _pop)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16664
 nn.de##+js(nostif, .call(null), 10)
-nn.de###ad-Billboard:upward([style])
+nn.de##[style]:has(#ad-Billboard)
 
 ! baits
 .net/ads_$badfilter
@@ -615,7 +615,7 @@ moegirl.org.cn##+js(nostif, offsetHeight)
 nhl66.ir##+js(nowoif)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/10wlagl/
-www.walmart.com##[data-stack-index] > section > div > div [data-item-id] > a[link-identifier][href^="https://wrd.walmart.com"]:upward(section > div > div)
+www.walmart.com##[data-stack-index] > section > div > div:has([data-item-id] > a[link-identifier][href^="https://wrd.walmart.com"])
 www.walmart.com##[data-testid="flex-container"] > div > span:has(a[link-identifier][href^="https://wrd.walmart.com"])
 www.walmart.com##[data-testid="skyline-ad"]
 

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -154,8 +154,8 @@ mathebibel.de###banner-bottom
 echo-online.de##.mainFooter__ccePosition
 echo-online.de##.recommendations__cceWidget
 echo-online.de##.storyElementWrapper__container > [data-testid="storyElementWrapper-cceWidget-element"]:upward(1)
-echo-online.de##.swiper-slide [data-testid="topStories-cardSlider-ad"]:upward(.swiper-slide)
-echo-online.de##.teaserGrid > div .nativeAd:upward(.teaserGrid > div)
+echo-online.de##.swiper-slide:has([data-testid="topStories-cardSlider-ad"])
+echo-online.de##.teaserGrid > div:has(.nativeAd)
 echo-online.de##div.frontpageOverview__child
 allgemeine-zeitung.de,buerstaedter-zeitung.de,echo-online.de,lampertheimer-zeitung.de,lauterbacher-anzeiger.de,main-spitze.de,oberhessische-zeitung.de,wiesbadener-kurier.de,wormser-zeitung.de##.adSlot, .loadingBanner
 berliner-zeitung.de##[class^="ad-slot"]
@@ -475,14 +475,14 @@ facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##div
 facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##div[role="region"] + div[role="main"] div[role="article"] div[style="border-radius: max(0px, min(8px, ((100vw - 4px) - 100%) * 9999)) / 8px;"] > div[class]:not([class*=" "])
 ! https://github.com/uBlockOrigin/uAssets/issues/3367#issuecomment-1416733062
 !#if env_chromium
-facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##html[lang="en"] div[aria-posinset] svg[style$="width: 56.8906px;"] use:upward(div[aria-posinset])
-facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##html[lang="pl"] div[aria-posinset] svg[style$="width: 78.5465px;"] use:upward(div[aria-posinset])
-facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##html[lang="vi"] div[aria-posinset] svg[style$="width: 65.0684px;"] use:upward(div[aria-posinset])
+facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##html[lang="en"] div[aria-posinset]:has(svg[style$="width: 56.8906px;"] use)
+facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##html[lang="pl"] div[aria-posinset]:has(svg[style$="width: 78.5465px;"] use)
+facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##html[lang="vi"] div[aria-posinset]:has(svg[style$="width: 65.0684px;"] use)
 !#endif
 !#if env_firefox
-facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##html[lang="en"] div[aria-posinset] svg[style$="width: 59px;"] use:upward(div[aria-posinset])
-facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##html[lang="pl"] div[aria-posinset] svg[style$="width: 80.8px;"] use:upward(div[aria-posinset])
-facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##html[lang="vi"] div[aria-posinset] svg[style$="width: 65px;"] use:upward(div[aria-posinset])
+facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##html[lang="en"] div[aria-posinset]:has(svg[style$="width: 59px;"] use)
+facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##html[lang="pl"] div[aria-posinset]:has(svg[style$="width: 80.8px;"] use)
+facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##html[lang="vi"] div[aria-posinset]:has(svg[style$="width: 65px;"] use)
 !#endif
 facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##div[aria-posinset]:has(a[aria-label="広告"])
 facebook.com##div[aria-posinset] h4 > span > a[href]:not([href*="section_header_type"]):matches-attr(href="/__cft__\[0\]=[-\w]{270,}/"):upward(div[aria-posinset])
@@ -584,7 +584,7 @@ amazon.*##.a-carousel-card > div > div[cel_widget_id^="adplacements:"]:upward(2)
 ! https://github.com/uBlockOrigin/uAssets/issues/12268
 amazon.*##.AdHolder
 ! https://jbbs.shitaraba.net/bbs/read.cgi/internet/25463/1598352715/851
-amazon.*###similarities_feature_div span[id^="ad-feedback-text"]:upward(#similarities_feature_div)
+amazon.*###similarities_feature_div:has(span[id^="ad-feedback-text"])
 ! https://github.com/easylist/easylist/commit/73701244b11d5d916bef99627dbfb409e7e14e44
 amazon.*##div[cel_widget_id="sims-consolidated-5_csm_instrumentation_wrapper"]
 
@@ -959,7 +959,7 @@ watchcartoononline.bz##.BorderColorChangeElement
 @@||wcoanimedub.tv^$ghide
 @@||wcoanimesub.tv^$ghide
 @@||wco.tv^$ghide
-wco.tv##iframe.hide-ads:upward(div[style])
+wco.tv##div:has(> #reklam_kapat)
 thewatchcartoononline.tv,watchanimesub.net,wco.tv,wcoanimesub.tv,wcoforever.net##+js(set, isAdBlockActive, false)
 wcostream.com,wcoanimedub.tv,wcoforever.net##+js(nostif, google_jobrunner)
 *$script,3p,domain=wcostream.com,denyallow=gstatic.com|bootstrapcdn.com|fastly.net|googleapis.com|hwcdn.net|jquery.com|jwpcdn.com
@@ -1009,8 +1009,7 @@ kissasian.*##.ksAds
 kissasian.*##[id*="ScriptRoot"]
 kissasian.*###videoAd
 kissasian.*###hideAds
-kissasian.*##.adsbyvli:upward(div[style$="width: 610px;"])
-kissasian.*###leftside .adsbyvli:upward(div[style$="height: 90px;"])
+kissasian.*##div:has(> iframe[src^="/Ads/"])
 kissasian.*###overplay
 ||kissasian.*/Ads/$frame
 gaobook.*##+js(aopr, Date.prototype.toUTCString)
@@ -1833,7 +1832,7 @@ mylink.*,my1ink.*,myl1nk.*,myli3k.*##+js(nowoif)
 mylink.*,my1ink.*,myl1nk.*,myli3k.*##a[href^="https://go.nordvpn.net/"], [src^="/nordcode.php"]
 mylink.*,my1ink.*,myl1nk.*,myli3k.*##div[id][style^="width: 970px; height: 250px;"]
 mylink.*,my1ink.*,myl1nk.*,myli3k.*##div[id][style="width: 300px; height: 250px;"]
-mylink.*,my1ink.*,myl1nk.*,myli3k.*##div[id][style="width: 728px; height: 90px;"]:upward(#pub1)
+mylink.*,my1ink.*,myl1nk.*,myli3k.*###pub1:has(div[id][style="width: 728px; height: 90px;"])
 mylink.*,my1ink.*,myl1nk.*,myli3k.*##html > iframe
 @@*$script,1p,domain=mylink.*|my1ink.*|myl1nk.*|myli3k.*
 @@||in-page-push.com^$script,domain=mylink.*|my1ink.*|myl1nk.*|myli3k.*
@@ -2513,7 +2512,6 @@ senzuri.tube##+js(acis, adver)
 txxxporn.tube##div[style="display:flex !important"] > div
 txxxporn.tube##.video-videos-slider + div[class] + div[class]
 txxxporn.tube##div.text:upward(1)
-txxxporn.tube##img[src^="https://tn.txxx.tube/contents/cst/"]:upward(.video-content > div > div)
 txxxporn.tube##.video-content > div:not(:has(.pplayer))
 ! https://github.com/uBlockOrigin/uAssets/issues/4234
 hclips.com##+js(acis, adver)
@@ -3406,7 +3404,7 @@ feet9.com##.pup
 feet9.com##.video:has(span:has-text(Live))
 ! https://github.com/uBlockOrigin/uAssets/issues/1301#issuecomment-1364615843
 feet9.com##+js(acs, __ADX_URL_U)
-feet9.com##[onclick*="banner"]:upward(.video)
+feet9.com##.video:has([onclick*="banner"])
 feet9.com##.hvr-pulse
 feet9.com##[class^="ig"]
 ||feet9.com^$csp=worker-src 'none';
@@ -3791,7 +3789,7 @@ tubemania.org##+js(nowoif)
 ! https://forums.lanik.us/viewtopic.php?p=136688#p136688
 readcomiconline.*##+js(aopr, adblockDetector)
 ||vliplatform.com^$3p
-readcomiconline.*##.adsbyvli:upward(div[style^="width: 300px; height: 250px"])
+readcomiconline.*##div:has(> iframe[src^="/Ads/"])
 readcomiconline.*##.divCloseBut
 *$script,3p,denyallow=cloudfront.net|disqus.com|disquscdn.com|edgecastcdn.net|facebook.net|fastlylb.net|fbcdn.net|twitter.com,domain=readcomiconline.*
 
@@ -4253,7 +4251,7 @@ op.gg##+js(nostif, adblock, 2000)
 op.gg##div[class^="css-"]:has(> div:not([class], [id]) > .vm-placement:not([style]))
 op.gg##div[class^="css-"]:has(> div:not([class], [id]) > .vm-placement[data-display-type="hybrid-banner"])
 ! https://github.com/uBlockOrigin/uAssets/issues/13023
-op.gg##[id^="div-gpt-ad"]:not([class]):upward(div[class])
+op.gg##div[class]:has([id^="div-gpt-ad"]:not([class]))
 @@||doubleclick.net^$xhr,domain=op.gg
 @@||vntsm.com^$xhr,domain=op.gg
 @@||pagead2.googlesyndication.com^$xhr,domain=op.gg
@@ -4458,7 +4456,7 @@ reddit.com##.size-compact.Post:has([class*="promoted"])
 reddit.com##div[id*="sidebar"][data-before-content="advertisement"]:upward(3)
 reddit.com##div[class][data-before-content="advertisement"]:not([id])
 ! https://github.com/uBlockOrigin/uAssets/issues/13072
-reddit.com##[id^="t3"].promotedlink:upward(.rpBJOHq2PR60pnwJlUyP0 > div)
+reddit.com##.rpBJOHq2PR60pnwJlUyP0 > div:has([id^="t3"].promotedlink)
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=40330
 toyoheadquarters.com##+js(aopr, document.dispatchEvent)
@@ -4509,7 +4507,7 @@ gamcore.com,69games.xxx##[href*="/ads/"]
 classic.gamcore.com##.warningbox:upward(1)
 classic.gamcore.com###center > .flashes > .wide:has(> a[href][rel])
 gamcore.com##.item:has([href^="/games/"][class=""])
-gamcore.com##.item > a[href] > img[src*="//cdn.69games.xxx/"]:upward(.item)
+gamcore.com##.item:has(> a[href] > img[src*="//cdn.69games.xxx/"])
 gamcore.com##.menuArea [rel]
 gamcore.com##.row > .d-md-block
 gamcore.com##.row > .d-lg-block.d-none
@@ -4522,8 +4520,8 @@ gamcore.com###ad_unter_spiel
 gamcore.com###tvnotice
 porcore.com##.adscolumn
 porcore.com##[style^="width:728px;height:90px"]
-porcore.com###videoitems.videoitems > .onevideothumb > .clip-link > img[src^="/uploads/"][src$="gif"]:upward(.onevideothumb)
-porcore.com##[src*=".gif"]:upward([target="_blank"])
+porcore.com###videoitems.videoitems > .onevideothumb:has(> .clip-link > img[src^="/uploads/"][src$="gif"])
+porcore.com##[target="_blank"]:has([src*=".gif"])
 porcore.com##li > a[href*="/loader?"]
 69games.xxx###footer
 69games.xxx###right
@@ -4735,7 +4733,6 @@ acortalo.*,acortar.*,megadescarga.net,megadescargas.net##+js(set, sync, true)
 ! https://github.com/uBlockOrigin/uAssets/issues/7348
 hentai2read.com##+js(nowoif)
 hentai2read.com,hentai2w.com##+js(aeld, click, popMagic)
-hentai2read.com##[src^="//"]:upward([target="_blank"])
 ||hentaicdn.com^*/NATORI.$script,3p
 /\.com\/\d+/[0-9a-z]+\.js$/$script,1p,domain=hentai2w.com
 ||hentai2w.com/templates/default/js/ab.functions.js
@@ -5730,7 +5727,7 @@ redtube.*##+js(nowoif)
 redtube.*##+js(set, page_params.holiday_promo, true)
 redtube.*##.abovePlayer
 redtube.*##.adsbytrafficjunky
-redtube.*##.adsbytrafficjunky:upward(li)
+redtube.*##li:has(.adsbytrafficjunky)
 redtube.*##.remove_ads
 ! mirror
 9908ww.com,adelaidepawnbroker.com,bztube.com,hotovs.com,insuredhome.org,nudegista.com,pornluck.com,vidd.se##+js(set, page_params.holiday_promo, true)
@@ -6159,7 +6156,7 @@ filecrypt.*##+js(set, isAdblock, false)
 filecrypt.*##+js(popads-dummy)
 ||filecrypt.*^$popunder
 @@||cutcaptcha.com/captcha/*$script,domain=filecrypt.cc|filecrypt.co
-filecrypt.*##div > [href*=".html"]:upward(div)
+filecrypt.*##div:has(> [href*=".html"])
 filecrypt.*###jvb
 filecrypt.*##li:has-text(100% Anonym)
 filecrypt.*##.bums
@@ -6349,7 +6346,6 @@ xrares.com##+js(acis, decodeURI, decodeURIComponent)
 xrares.com##+js(disable-newtab-links)
 xrares.com###linkedblok
 xrares.com##.absd-body:not(.row + .well)
-xrares.com##[href^="/plugout.php"]:upward([class^="col-sm"])
 ||xrares.com/sw.js$script,1p
 
 ! https://github.com/jspenguin2017/uBlockProtector/issues/958
@@ -6739,7 +6735,7 @@ game-dna.de##+js(acis, document.getElementById, TVGuideUd)
 macplanete.com##.adsbygoogle
 
 ! https://github.com/uBlockOrigin/uAssets/issues/2965
-classicreload.com##.ad-wrapper:upward(div.region-sidebar-first-wrapper)
+classicreload.com##div.region-sidebar-first-wrapper:has(.ad-wrapper)
 classicreload.com##+js(nostif, show())
 classicreload.com###div-gpt-ad
 classicreload.com##.content-top-wrapper
@@ -9472,7 +9468,7 @@ xnxxjapon.com###asg-inplayer-block:upward(4)
 xxmovz.com##+js(aopr, decodeURI)
 xxmovz.com##.ad
 xxxvideos.ink###hidme
-xxxvideos.ink##li.plate iframe[width="300"]:upward(.plate)
+xxxvideos.ink##li.plate:has(iframe[width="300"])
 xxxvideos.ink##.curiosity
 /quwet.js$script,1p
 ||all-usanomination.com^$3p
@@ -10640,7 +10636,6 @@ extramovies.*##[href^="http://adfpoint.com"]
 extramovies.*###theme_back
 ! https://github.com/uBlockOrigin/uAssets/issues/11023
 extralinks.*,extramovies.*##[href^="https://t.me/"]
-extralinks.*,extramovies.*##[class^="ad_btn"]:upward(center)
 ||extralinks.*/ads.js$script,1p
 ||extramovies.*/ads.js$script,1p
 recipesdelite.com##+js(nano-sib, inner)
@@ -11107,7 +11102,7 @@ vbox7.com##.vbox-cap-adw
 ! https://github.com/uBlockOrigin/uAssets/issues/5047
 @@||convallariaslibrary.com^$ghide
 convallariaslibrary.com##.code-block
-convallariaslibrary.com##.widget_custom_html ins:upward(.widget_custom_html)
+convallariaslibrary.com##.widget_custom_html:has(ins)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/744#issuecomment-469062646
 @@||ksta.de^$ghide
@@ -13466,7 +13461,7 @@ adultdvdparadise.com,freeomovie.info,fullxxxmovies.me,mangoparody.com,mangoporn.
 adultdvdparadise.com,freeomovie.info,fullxxxmovies.me,mangoparody.com,mangoporn.co,netflixporno.net,pandamovie.*,pandamovies.me,playpornfree.xyz,pornkino.cc,pornwatch.ws,speedporn.*,watchfreexxx.pw,watchpornfree.*,watchxxxfree.pw,xopenload.pw,xtapes.me,xxxmoviestream.xyz,xxxparodyhd.net,xxxscenes.net,xxxstream.me,youwatchporn.com##+js(nowoif)
 pandamovie.*,pandamovies.me,pornkino.cc,speedporn.*,youwatchporn.com###tracking-url
 pornwatch.ws,xopenload.pw,xxxparodyhd.net,xxxstream.me##.btn-lg.btn-block.btn
-pandamovie.*,pandamovies.me,pornkino.cc,speedporn.*,xxxscenes.net,youwatchporn.com##.video-block-happy-absolute:upward(.order-1)
+pandamovie.*,pandamovies.me,pornkino.cc,speedporn.*,xxxscenes.net,youwatchporn.com##.order-1:has(.video-block-happy-absolute)
 pandamovie.*,pandamovies.me,pornkino.cc,speedporn.*,xxxscenes.net,youwatchporn.com##.happy-player-beside, .happy-section, .widget_execphp:has-text(/Advertisement|ExoLoader/)
 
 ! serialy.bombuj.tv | .si anti adb
@@ -14247,8 +14242,8 @@ pussyspot.net,wildpictures.net##[href^="https://easygamepromo.com/"]
 novojoy.com,novoporn.com##+js(acis, document.querySelectorAll, popMagic)
 babesaround.com,dirtyyoungbitches.com,grabpussy.com,join2babes.com,nightdreambabe.com,novoglam.com,novohot.com,novojoy.com,novoporn.com,novostrong.com,pbabes.com,pussystate.com,redpornblog.com,rossoporn.com,sexynakeds.com,thousandbabes.com##+js(aopr, AaDetector)
 babesinporn.com##.topbanner
-boobgirlz.com##.widget-column > center > [href="https://boobgirlz.com/istripper"]:upward(.widget-column)
-nakedneighbour.com##.banner:upward(.block)
+boobgirlz.com##.widget-column:has(> center > [href="https://boobgirlz.com/istripper"])
+nakedneighbour.com##.block:has(.banner)
 /sex.gif$domain=epikporn.com|erotichdworld.com|guruofporn.com|jesseporn.xyz|jumboporn.xyz|kendralist.com|steezylist.com
 /yep.gif$domain=abellalist.com|doseofporn.com|freyalist.com|lizardporn.com|moozporn.com|zehnporn.com
 /flr.js$domain=8boobs.com|angelgals.com|babesexy.com|babesinporn.com|fooxybabes.com|hotbabeswanted.com|hotstunners.com|mainbabes.com|nakedbabes.club|nakedgirlsroom.com|nudebabes.sexy|pleasuregirl.net|rabbitsfun.com|sexybabes.club|sexybabesart.com|silkengirl.*|wantedbabes.com
@@ -15127,7 +15122,7 @@ hl-live.de##+js(aeld, load, onload)
 hl-live.de##+js(nostif, getComputedStyle, 250)
 
 ! flsaudio.com anti adb
-flsaudio.com##.adsbygoogle:upward(.widget)
+flsaudio.com##.widget:has(.adsbygoogle)
 flsaudio.com##.altumcode-coupon-content
 ||flsaudio.com^$image,redirect-rule=1x1.gif,1p
 
@@ -15224,7 +15219,6 @@ bluemediafiles.*##+js(set, Time_Start, 0)
 ! https://www.reddit.com/r/uBlockOrigin/comments/pywx7p/ad_block_detected_httpssports24stream/
 @@||sports24.*^$ghide
 sports24.*##+js(aopw, _pop)
-sports24.*##iframe[src^="//sports24.site/"]:upward(div)
 sports24.*##div[style*="z-index: 30000"]
 sports24.*##div[style^="width:300px;height:250px"]:upward(1)
 sports24.*##.adrespl
@@ -15299,8 +15293,9 @@ closermag.fr##+js(acis, document.head.appendChild, ='\x)
 @@||closermag.fr^$ghide
 
 ! https://github.com/uBlockOrigin/uAssets/issues/14095
-autotrader.com##svg:has([transform]):upward(span)
-autotrader.com##svg:has([transform]):upward(span) + div
+autotrader.com##[data-cmp="alphaShowcase"]:has(svg [transform])
+autotrader.com##span:has(svg [transform])
+autotrader.com##span:has(svg [transform]) + div
 
 ! https://github.com/NanoMeow/QuickReports/issues/2067
 @@||watchcalifornicationonline.com^$ghide
@@ -15661,7 +15656,7 @@ forocoches.com###vbnotices
 m.forocoches.com##div.title-forum-display-destacado
 m.forocoches.com##.page > div > ul > li[style^="word-wrap:break-word; word-break:break-word; background-color: #"]
 m.forocoches.com##.page > div > ul[style]:has(> li > div[style] > a[style][href^="/foro/"] > strong)
-m.forocoches.com##[id*="adslot"]:upward(ul > li)
+m.forocoches.com##[id^="AutoNumber"]:has([id*="adslot"])
 ||cdn.forocoches.com/lwa/forocoches/*_promo.html$frame,1p
 
 ! https://github.com/NanoMeow/QuickReports/issues/2231
@@ -16108,7 +16103,7 @@ femina.ch##+js(aopr, _sp_.mms.startMsg)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/mxeds6/adblocker_detectet_only_first_post_available/
 photovoltaikforum.com##+js(acis, $, offsetHeight)
-photovoltaikforum.com##.wcfAdLocation:upward(li)
+photovoltaikforum.com##li:has(> .wcfAdLocation)
 
 ! fix streamanimetv.net, mangahere.onl ads & anti adb
 mangahere.onl,streamanimetv.net##+js(aopr, AdservingModule)
@@ -16599,7 +16594,7 @@ cheatsquad.gg##.tooltip::after
 updown.link##+js(nano-stb, startDownload, 8000)
 ! https://github.com/uBlockOrigin/uAssets/issues/7273#issuecomment-966551769
 @@||work.ink^$ghide
-work.ink##.desc:upward([class*="adb"])
+work.ink##[class*="adb"]:has(.desc)
 *$frame,redirect-rule=noopframe,domain=work.ink
 ! https://zodhacks.com/pet-simulator-x-saza-hub-easter/ timer
 *$script,domain=work.ink,redirect-rule=noopjs
@@ -16689,7 +16684,7 @@ ur-files.com##[href*="/api/redirect"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/115682
 @@||wallpaperwaifu.com^$ghide
 wallpaperwaifu.com##+js(nostif, show)
-wallpaperwaifu.com##.ads-between-post:upward(.post-item)
+wallpaperwaifu.com##.post-item:has(.ads-between-post)
 wallpaperwaifu.com##.adsbygoogle
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/72087
@@ -16916,7 +16911,6 @@ pccomponentes.com##div[id^="div-gpt-ad-"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/2475
 techradar.com##+js(aopr, _sp_._networkListenerData)
-gamesradar.com,techradar.com,tomsguide.com,tomshardware.com,whathifi.com##.mobile-leaderboard-320-50:upward([style])
 gamesradar.com,livescience.com,pcgamer.com,techradar.com,tomsguide.com,tomshardware.com,whathifi.com,windowscentral.com##.related-articles-block
 gamesradar.com,livescience.com,pcgamer.com,techradar.com,tomsguide.com,tomshardware.com,whathifi.com,windowscentral.com##.van_taboola
 whathifi.com##.dfp-leaderboard-container

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -3201,7 +3201,6 @@ watcho.com##+js(nano-stb, isPeriodic, *)
 uschovna.cz#@#body:style(background:none !important;)
 uschovna.cz##body:style(background-image:none !important)
 @@||cz.mrezadosa.com^$xhr,domain=uschovna.cz
-uschovna.cz##.branding:upward([target="_blank"])
 
 ! https://github.com/easylist/easylist/issues/7462#issuecomment-803561739
 ||milkygoodness.xyz^$badfilter


### PR DESCRIPTION
Procedural filters are relatively expensive to query, as they require running an in-page `MutationObserver`. The more recent native `:has()` selector allows many procedural filters to be rewritten as just native CSS selectors, which can be handled by browsers very efficiently. Chromium and Safari have support for native `:has()`; Firefox has it behind a flag and should have it relatively soon as well.

`a:upward(b)` is almost exactly equivalent to `b:has(a)`, with a couple of caveats:
- `a:upward(b)` will select the first `b` element above `a`; `b:has(a)` selects _all_ of them. `a:has(> b)` is a very useful tool.
- Lots of `:upward` filters were originally written as `a b:upward(a)` or similar, which should simplify to `a:has(b)` instead of `a:has(a b)`. This actually reduces duplication in the lists.

This PR replaces most of the `:upward` filters that use a selector rather than a number. The few remaining ones are more challenging, but could be handled as followups. I suspect that it might be possible to deprecate the `:upward(selector)` form, since native `:has` and others are quite expressive.

I've manually looked over the relevant sites and these filters seem to be either the same or improved in terms of blocking and breakage, as far as I can tell.

Apologies for the gigantic PR - I'm happy to split this into smaller changes if that makes it easier to review!