### PR TITLE
Remove dead domains

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1119,7 +1119,6 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ||phpstat.cntcm.com.cn/phpstat/count/abceffgh/abceffgh.js^$script
 
 ! https://github.com/uBlockOrigin/uAssets/pull/11041
-||sites.google.com/view/hypixeldupemethod/*^$doc
 ||cdn.discordapp.com/attachments/916391647955279943/*^$all
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11157

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -866,9 +866,6 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ! https://github.com/uBlockOrigin/uAssets/issues/8378
 ||ogtrk.net^
 
-! https://www.joesandbox.com/analysis/300638/0/html
-||antivirus-protection.me^$all
-
 ! https://www.hybrid-analysis.com/sample/3ad8f4dc6a021e82d25247c266d89d20d981f7187413405f0b2e35d984bd60cb
 ||secureconv-dl.com^$all
 
@@ -1246,9 +1243,6 @@ cracksoftwaress.net##div[style="float: none; margin:10px 0 10px 0; text-align:ce
 ||ferme-lesca.fr^
 ||odulunual.sa.com^
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/129493
-||ucetnictvi-liberec.eu^$all
-
 ! https://github.com/uBlockOrigin/uAssets/pull/14985
 ||skymods.net^$all
 
@@ -1353,9 +1347,6 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/136693
 /axad/?lpkey=$doc
-
-! https://twitter.com/AP_Zenmashi/status/1601866583194107904
-||aeno.shop^$all
 
 ! https://github.com/uBlockOrigin/uAssets/issues/15990
 ||vlcdownloads.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

N/A

### Describe the issue

3 domains appear dead (based on PyFunceble, and me checking the WHOIS and DNS). This PR removes them & their related comments.
I also removed the rule blocking `https://sites.google.com/view/hypixeldupemethod/home` as it [just redirects to a Google signin page](https://app.any.run/tasks/9fe47b5c-603a-4de4-bdc4-7dc289d34c58), and the domain redirecting to it is now dead.

### Screenshot(s)

Not a visual issue

### Versions

- Browser/version: Firefox 110.0
- uBlock Origin version: uBlock Origin 1.47.3b0

### Settings

N/A

### Notes


