### PR TITLE
Added coverage for Reddit's Tor domain + Improved coverage for Facebook's Tor domain

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -4961,7 +4961,7 @@ mikl4forex.com##+js(nano-sib, counter, 2000)
 michaelemad.com##+js(nano-sib, timer)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10102
-reddit.com##.adLinkBar:upward(article[style="z-index: 1;"])
+reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion##.adLinkBar:upward(article[style="z-index: 1;"])
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10104
 @@||xtremestream.co^$ghide

--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -3523,11 +3523,11 @@ xxx18.uno##+js(aopw, _pop)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/13870
 !#if env_mobile
-reddit.com##.XPromoBlockingModal
-reddit.com##xpromo-nsfw-blocking-modal
-reddit.com##.m-blurred:style(filter: none !important;)
-reddit.com##xpromo-new-nsfw-blocking-modal
-reddit.com##[style^="filter:"]:style(filter: none !important;)
+reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion##.XPromoBlockingModal
+reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion##xpromo-nsfw-blocking-modal
+reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion##.m-blurred:style(filter: none !important;)
+reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion##xpromo-new-nsfw-blocking-modal
+reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion##[style^="filter:"]:style(filter: none !important;)
 !#endif
 
 ! https://github.com/uBlockOrigin/uAssets/issues/13874

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -485,8 +485,8 @@ facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##htm
 facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##html[lang="vi"] div[aria-posinset] svg[style$="width: 65px;"] use:upward(div[aria-posinset])
 !#endif
 facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##div[aria-posinset]:has(a[aria-label="広告"])
-facebook.com##div[aria-posinset] h4 > span > a[href]:not([href*="section_header_type"]):matches-attr(href="/__cft__\[0\]=[-\w]{270,}/"):upward(div[aria-posinset])
-facebook.com##div[aria-describedby] h4 > span > a[href]:not([href*="section_header_type"]):matches-attr(href="/__cft__[0]=[-w]{270,}/"):upward(div[aria-describedby])
+facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##div[aria-posinset] h4 > span > a[href]:not([href*="section_header_type"]):matches-attr(href="/__cft__\[0\]=[-\w]{270,}/"):upward(div[aria-posinset])
+facebook.com,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##div[aria-describedby] h4 > span > a[href]:not([href*="section_header_type"]):matches-attr(href="/__cft__[0]=[-w]{270,}/"):upward(div[aria-describedby])
 
 ! mail.yahoo.com stuff
 ! This removes blank space the right-hand side
@@ -4436,11 +4436,11 @@ downloadpirate.com##+js(aopw, Fingerprint2)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/1833
 ! https://github.com/uBlockOrigin/uAssets/issues/2253
-reddit.com##.size-compact.Post:has([class*="promoted"])
-reddit.com##div[id*="sidebar"][data-before-content="advertisement"]:upward(3)
-reddit.com##div[class][data-before-content="advertisement"]:not([id])
+reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion##.size-compact.Post:has([class*="promoted"])
+reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion##div[id*="sidebar"][data-before-content="advertisement"]:upward(3)
+reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion##div[class][data-before-content="advertisement"]:not([id])
 ! https://github.com/uBlockOrigin/uAssets/issues/13072
-reddit.com##[id^="t3"].promotedlink:upward(.rpBJOHq2PR60pnwJlUyP0 > div)
+reddit.com,reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion##[id^="t3"].promotedlink:upward(.rpBJOHq2PR60pnwJlUyP0 > div)
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=40330
 toyoheadquarters.com##+js(aopr, document.dispatchEvent)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
https://reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion/r/engrish
https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion
https://facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion
```

### Describe the issue

Reddit made a Tor domain some months ago, which I saw tonight had not been covered in any major lists yet. So I made this PR to hopefully cover it, and to polish Tor domain coverage in general while I was at it.

Likely related: https://github.com/easylist/easylist/pull/15087

### Screenshot(s)

![image](https://user-images.githubusercontent.com/22780683/221485786-ea2f8d57-7464-4662-8628-3dd414901c9f.png)

### Versions

- Browser/version: Tor Browser 12.0.2 x64
- uBlock Origin version: 1.47.0

### Settings

- Had turned on Dandelion Sprout's Nordic Filters, Block Outsider Intrusion into LAN, and AdGuard Base; everything else was factory stock.

### Notes

None that I'm currently aware of. I'd be ready to answer any question, and the "Allow edits by maintainers" button is turned on.
