### PR TITLE
murha.info generichide removed

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -2035,9 +2035,6 @@ blog.kwick.de##+js(aopr, document.onkeydown)
 ! https://github.com/NanoMeow/QuickReports/issues/2257
 laptopmag.com##+js(aopr, _sp_.mms.startMsg)
 
-! https://github.com/NanoMeow/QuickReports/issues/2267
-@@||murha.info^$ghide
-
 ! https://github.com/uBlockOrigin/uAssets/issues/6572
 windows101tricks.com##+js(aopr, __cmpGdprAppliesGlobally)
 windows101tricks.com##+js(set, better_ads_adblock, 0)


### PR DESCRIPTION
I don't see this filter necessary. I don't see any anti-adblock messages if that is disabled.

### URL(s) where the issue occurs

`https://www.murha.info/rikosfoorumi/viewforum.php?f=20&sid=5c5f409ba33142a3c826a88696a59dbb`

### Describe the issue

Unnecessary filter, no anti adblock anymore.

### Screenshot(s)

### Versions

FF 110.0.1
uBO 1.47.3b6

### Settings

Defaults

### Notes