### PR TITLE
muropaketti.com no images fix (googletagmanager issue)

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4785,3 +4785,6 @@ mediaite.com##.adthrive-video-player:style(padding-bottom: 0 !important;)
 ! https://github.com/uBlockOrigin/uAssets/issues/17124
 ||scandichotels.com/Static/js/tracking/tracking-data-init.js^$script,1p,important
 scandichotels.com##+js(set, datalayer, [])
+
+! https://github.com/uBlockOrigin/uAssets/pull/17134
+muropaketti.com##body.noImages .content img:style(display: inline-block !important)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://muropaketti.com/pelit/peliuutiset/the-last-of-us-tahti-pedro-pascal-esiintyy-suomalaispelia-esittelevassa-lyhytelokuvassa/`

### Describe the issue

Easyprivacy and Lowe's list block googletagmanager. When it's blocked, it causes some images not to load. Added a fix to force the images to display.

### Screenshot(s)

![kuva](https://user-images.githubusercontent.com/17256841/224531412-32d63521-9c46-4615-842c-fc6e77763136.png)

After fix applied:

![kuva](https://user-images.githubusercontent.com/17256841/224531446-64c34b52-fc8b-433f-a536-4ef4661345e5.png)

### Versions

- FF 110.0.1
- uBO 1.47.5b6

### Settings

- Defaults

### Notes

The issue is caused by this piece of code:

> <script>
> 
> if (/\/viihde\/|\/peliuutiset\/|\/elokuvauutiset\//.test(window.location.href)) {
>     console.log('add "noImages" class to body')
>     document.body.classList.add("noImages");
> }
> 
> </script>

Discussed here:

https://github.com/finnish-easylist-addition/finnish-easylist-addition/issues/433
