### PR TITLE
Update filters.txt (mail.yahoo.com)

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -504,6 +504,9 @@ mail.yahoo.com##.ab_C.I_Zjpytw:has-text(blocker)
 mail.yahoo.com##div#modal-outer[aria-labelledby="adblock-unblock-cue"]
 ! https://github.com/uBlockOrigin/uAssets/issues/13439
 mail.yahoo.com##[data-test-id="video-container"]
+mail.yahoo.com##[data-test-id="efv-header"]:has(~ [data-test-id="video-container"]) > [data-test-id="efv-subheader"]
+mail.yahoo.com###messageListContainer #video-player iframe[src*="yimg.com"]
+mail.yahoo.com###messageListContainer DIV[class]:has(~ DIV#video-player > IFRAME)
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=31322&start=30
 ndtv.com###ndtv-myModal

--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -505,8 +505,8 @@ mail.yahoo.com##div#modal-outer[aria-labelledby="adblock-unblock-cue"]
 ! https://github.com/uBlockOrigin/uAssets/issues/13439
 mail.yahoo.com##[data-test-id="video-container"]
 mail.yahoo.com##[data-test-id="efv-header"]:has(~ [data-test-id="video-container"]) > [data-test-id="efv-subheader"]
-mail.yahoo.com###messageListContainer #video-player iframe[src*="yimg.com"]
-mail.yahoo.com###messageListContainer DIV[class]:has(~ DIV#video-player > IFRAME)
+mail.yahoo.com###messageListContainer div#video-player iframe[src*="yimg.com"]
+mail.yahoo.com###messageListContainer div[class]:has(~ div#video-player > iframe)
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=31322&start=30
 ndtv.com###ndtv-myModal


### PR DESCRIPTION
> https://github.com/uBlockOrigin/uAssets/issues/13439#issuecomment-1440962352

hide text "Catch up on the most popular videos on Yahoo" (long version of "advert" text above normal ads)

![obraz](https://user-images.githubusercontent.com/35370833/227730977-9b617a8e-acbb-447b-b6cf-5b397eafd46c.png) | ![obraz](https://user-images.githubusercontent.com/35370833/227731033-21d09590-b8ae-4055-98f6-e2c01c97c8fe.png)
--- | ---
modern layout | legacy layout

---

cover legacy layout as long active:  `https://mail.yahoo.com/b/folders/2?folderType=SENT` (must be empty to reproduce)

https://user-images.githubusercontent.com/35370833/227731076-b2b16b7a-4c65-4d5a-b4d1-a1b15f613eef.png - network filtering
https://user-images.githubusercontent.com/35370833/227731161-d5d47e34-397b-41a8-a3bf-4c6c3f62ea59.png - CSS4/procedural filtering


