### PR TITLE
fix problematic selector

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -4397,7 +4397,7 @@ financerites.com,skincarie.com###orquidea-slideup
 enit.in,financerites.*,skincarie.com##+js(nano-stb, downloadBtn, *)
 enit.in,financerites.*,skincarie.com##.footerLink.hidden:style(display: block !important;)
 enit.in,financerites.*,skincarie.com##.getlink:others()
-financerites.*##p:has-text([ad_)
+financerites.*##p:has-text('[ad_')
 financerites.*##h4:has-text(Ads)
 ||push-sdk.$3p
 


### PR DESCRIPTION
Since square brackets are unbalanced, CSSTree cannot parse this selector without quote marks