### PR TITLE
add hket.com mobile app popup

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -6766,3 +6766,7 @@ romviet.com##+js(noeval-if, AdBlocker)
 
 ! jk-market.com devtool
 jk-market.com##+js(acs, jQuery, devtool)
+
+! hket.com mobile app popup
+hket.com##.app-redirect-panel
+hket.com##html.no-scroll:remove-class(no-scroll)


### PR DESCRIPTION
If you only remove the popup, the page won't scroll.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`[At least one URL for a web page where the clearly described issue occurs is **mandatory**. The backticks surrounding the URLs is important, it prevents the URL from being clickable. Warn with "NSFW" where applicable.]`
- `https://topick.hket.com/article/3499181/%E3%80%90%E6%B4%A9%E9%9C%B2%E8%A9%A6%E9%A1%8C%E3%80%91%E5%BE%B7%E4%BF%A1%E5%89%8D%E6%A0%A1%E9%95%B7%E6%B6%89%E7%9E%9E%E5%88%A9%E7%9B%8A%E6%B4%A9%E8%A9%A6%E9%A1%8C%20%E8%88%87%E8%A3%9C%E7%BF%92%E7%A4%BE%E5%89%8D%E8%91%A3%E4%BA%8B%E5%87%86%E4%BF%9D%E9%87%8B6%E6%9C%88%E5%86%8D%E8%A8%8A`
- `https://inews.hket.com/article/3498981/%E3%80%90%E6%B8%AF%E8%82%A1%E5%B8%82%E6%B3%81%E3%80%91%E7%BE%8E%E5%9C%98%E8%B7%8C4-%E3%80%81%E9%98%BF%E9%87%8C%E8%B7%8C%E9%80%BE3-%E3%80%80%E3%80%8C%E4%B8%AD%E5%AD%97%E8%82%A1%E3%80%8D%E9%80%86%E5%B8%82%E5%8F%88%E7%82%92%E4%B8%8A%E3%80%80%E6%81%92%E6%8C%87%E5%8D%8A%E6%97%A5%E8%B7%8C131%E9%BB%9E%EF%BC%88%E4%B8%8D%E6%96%B7%E6%9B%B4%E6%96%B0%EF%BC%89?mtc=20037`

### Describe the issue



When you scroll down the page, a mobile app pop up appears.

### Screenshot(s)


![image](https://user-images.githubusercontent.com/129025690/229690926-7be5ef24-19b5-4cae-a84b-b4f4d705cbb1.png)

### Versions

- Browser/version: [here]
- uBlock Origin version: [here]

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
