### PR TITLE
Added phishing site (Updated badware.txt)

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1065,6 +1065,10 @@ okashimag.com,tech4yougadgets.com##+js(aopr, Notification)
 ! https://github.com/uBlockOrigin/uAssets/commit/5832dfebb4021c639b90c2973946ff7638c2290f#commitcomment-57642161
 ||foxmods.xyz^$doc
 
+! Phishing/Malware/Scams
+! https://www.virustotal.com/gui/collection/cf2c760f511d9331e578461fed09717054ec23413a93834a83371634e5aad73c
+||octopus-warriors.com^$all
+
 ! phishing /malicious
 ||gesas.it^$doc
 ||techinnsrl.com^$doc


### PR DESCRIPTION
Added a phishing site that contains a download to Discord token stealer malware. (bbystealer)

Site:
https://www.virustotal.com/gui/url/afd4cf994640c527856d0a5cf70b5f7117867d38510b5d9b1503dfbf8b0982d1
https://www.virustotal.com/gui/url/13fb46970a39c031f1720c33f1266f3c87b0b475a8239f9d21d51038956c8ac9 

Analysis of the downloaded file (bbystealer):
https://www.virustotal.com/gui/file/782642a5970b7a2f44572f9aee5a49ce5394e420386d6f022abec97cb0be00a5 https://www.virustotal.com/gui/file/b5f7c8ecb47dac39008626ca8f2ac0748374717ea9e513e41b84dcbd038464e3
