### PR TITLE
remove obsolete exceptions

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -81,7 +81,7 @@
 ! https://github.com/gorhill/uBlock/issues/1082
 ! https://github.com/gorhill/uBlock/issues/1250#issuecomment-173533894
 ! https://github.com/gorhill/uBlock/issues/2155
-||widgets.outbrain.com/outbrain.js$script,redirect=outbrain-widget.js:5,domain=~mainichi.jp|~vice.com
+||widgets.outbrain.com/outbrain.js$script,redirect=outbrain-widget.js:5,domain=~vice.com
 
 ! https://github.com/uBlockOrigin/uAssets/issues/713
 ||google-analytics.com/analytics.js$important,script,redirect=google-analytics.com/analytics.js,domain=support.amd.com


### PR DESCRIPTION

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
https://github.com/uBlockOrigin/uAssets/issues/13834

### Describe the issue

This problem was caused by outbrain's redirect rule, but has been fixed by uBO, so the exception can be removed
Related commits:
https://github.com/gorhill/uBlock/commit/313d694040337d01ac623fc0707237946f04e804