### PR TITLE
Add a fake download page

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3093,3 +3093,8 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ! https://www.reddit.com/r/uBlockOrigin/comments/12pues7/
 ! https://www.virustotal.com/gui/url/30cd25755793be38b2757aad283bc0391763f6f0a8c17707d7f928c1102cde08
 ||123moviesgo.ga^$all
+
+! https://www.reddit.com/r/uBlockOrigin/comments/12r255v/gamingnewsanalystcom_badware/
+! https://tria.ge/230418-1r2zqsgd2w/behavioral1
+||gamingnewsanalyst.com^$all
+||gamingdebates.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://gamingnewsanalyst.com/thesetup/`

### Describe the issue

Fake "installer" which claims you need a key. To get the "key", you need to complete a (fake) CAPTCHA by doing surveys and completing offers. Reported at https://www.reddit.com/r/uBlockOrigin/comments/12r255v/gamingnewsanalystcom_badware/, all credit to the OP

### Screenshot(s)

<details>
<summary>Images</summary>
<img src="https://user-images.githubusercontent.com/84232764/232916449-73474733-2aac-417a-bef9-c74fc2abc1ca.png">
<img src="https://user-images.githubusercontent.com/84232764/232916518-c60817d8-fffb-44cb-b459-bd630451df5c.png">
<img src="https://user-images.githubusercontent.com/84232764/232916547-3248169c-8c15-4c0c-a32c-f5a8941be26c.png">

</details>

### Versions

N/A

### Settings

N/A

### Notes

Sandbox analysis by me at https://tria.ge/230418-1r2zqsgd2w/behavioral1
