### PR TITLE
Fix https://github.com/easylist/easylist/issues/15552

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -547,3 +547,6 @@ zhihu.com##+js(no-xhr-if, log-sdk.ksapisrv.com/rest/wd/common/log/collect method
 ||tranderous.com^
 ||cjewz.com^
 ||chpok.site^
+
+! https://github.com/easylist/easylist/issues/15552
+||admin.ro^$3p


### PR DESCRIPTION
It's supposed to drop an analytic script. I find it more important due `https://www.despretrafic.ro/stats/httpslaf` (information blocked by EasyPrivacy rule `/livestats.php?`)