### PR TITLE
Remove obsolete filter

### DIFF
--- a/filters/annoyances.txt
+++ b/filters/annoyances.txt
@@ -6186,9 +6186,6 @@ onna.kr##+js(aopw, document.onselectstart)
 ! frameboxxindore. com clipboard manipulation
 frameboxxindore.com##+js(aeld, copy, pagelink)
 
-! dtdc .in contextmenu
-dtdc.in##+js(aopr, document.oncontextmenu)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/15106
 *$script,domain=geotastic.net,redirect-rule=noopjs
 


### PR DESCRIPTION
I have not found a page from `dtdc.in` with anti contextmenu