### PR TITLE
Fix masterduelmeta.com anti-adblock popup removal

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -532,7 +532,7 @@ javguru.top##a[href^="https://media.r18.com/"]
 ||javevil.com^$3p
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/sdowvy/masterduelmeta_and_duelinksmeta_adblock_popups/
-masterduelmeta.com##:xpath('//*[contains(text(),"adblock")]'):upward(3)
+masterduelmeta.com##:xpath('//*[contains(text(),"allow ads")]'):upward(3)
 masterduelmeta.com##html,body:style(overflow: auto !important;)
 *$xhr,redirect-rule=nooptext,domain=masterduelmeta.com
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.masterduelmeta.com/articles/news/april-27-2023/master-duel-datamines`

### Describe the issue

The filter is supposed to remove an annoying anti-adblock popup that shows up in every single page of the website, they removed the word "adblock" from the text so the old filter doesn't work anymore.

### Screenshot(s)

![image](https://user-images.githubusercontent.com/14946679/235176287-fd643c53-9c97-422e-98cd-b61a2051039a.png)


### Versions

- Browser/version: Opera 97.0.4719.63
- uBlock Origin version: 1.49.2

### Settings

No settings were changed.

### Notes

I've determined that the text of the popup changed and thus needed updating, the new filter works (for now).
