### PR TITLE
Another bad filterlist

### DIFF
--- a/filters/badlists.txt
+++ b/filters/badlists.txt
@@ -32,6 +32,7 @@ https://www.topcashback.co.uk/misc/AdBlockWhiteList.aspx
 https://www.topcashback.co.uk/Misc/AdBlockWhiteList.aspx
 https://ads-for-open-source.readthedocs.io/en/latest/_static/lists/opensource-ads.txt
 https://ads-for-open-source.readthedocs.io/en/latest/_static/lists/readthedocs-ads.txt
+https://www.aadvantageeshopping.com/adBlockWhitelist.php
 
 # obsolete lists
 https://cdn.rawgit.com/NanoAdblocker/NanoFilters/master/NanoFilters/NanoAnnoyance.txt


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.aadvantageeshopping.com/adBlockWhitelist.php`

### Describe the issue

This is yet another allowlist designed for the sole purpose of unblocking trackers in order to "save money" and "earn miles". This allows doubleclick and other major ad/tracking servers.

### Screenshot(s)

N/A

### Versions

- Browser/version: Firefox 112.0.2
- uBlock Origin version: uBlock Origin 1.49.2

### Settings

- Defaults + `https://www.aadvantageeshopping.com/adBlockWhitelist.php`

### Notes

I haven't been able to find anything telling users to install this list, even after installing the extension, so not sure this is "in the wild" currently.
