### PR TITLE
Fix minor typo

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -55,7 +55,7 @@ freepik.com##.spr > .container-fluid:not([data-autopromo-name="freepik"]):upward
 freepik.com##+js(set, FEATURE_DISABLE_ADOBE_POPUP_BY_COUNTRY, true)
 
 ! dmcdn. xyz annoying popup
-dmcdn.zyz,dmcdn2.xyz##+js(nowoif)
+dmcdn.xyz,dmcdn2.xyz##+js(nowoif)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16240
 ddwloclawek.pl##+js(set, questpassGuard, noopFunc)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

N/A

### Describe the issue

Minor typo. `dmcdn.zyz` should be `dmcdn.xyz`

### Screenshot(s)

N/A

### Versions

N/A

### Settings

N/A

### Notes


