### PR TITLE
Remove truesexcam[.]com

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -718,7 +718,6 @@ twistedporn.com##+js(nowoif)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/54964
 arabnaar.com##+js(nosiif, visibility, 1000)
-truesexcam.com##+js(aopr, open)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/54961
 @@||althub.club^$ghide


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`truesexcam.com`

### Describe the issue

Appears dead. Domain doesn't resolve and WHOIS record's gone.

### Screenshot(s)
![image](https://user-images.githubusercontent.com/84232764/236693285-01b3bbbe-f641-4096-a220-1ab4393c444d.png)



### Versions

N/A

### Settings

N/A

### Notes

N/A
