### PR TITLE
Update FFA block

### DIFF
--- a/filters/badlists.txt
+++ b/filters/badlists.txt
@@ -56,3 +56,4 @@ https://cdn.statically.io/gh/bogachenko/fuckfuckadblock/master/fuckfuckadblock.t
 https://raw.githack.com/bogachenko/fuckfuckadblock/master/fuckfuckadblock.txt
 https://cdn.jsdelivr.net/gh/bogachenko/fuckfuckadblock/fuckfuckadblock.txt
 https://cdn.jsdelivr.net/gh/bogachenko/fuckfuckadblock@master/fuckfuckadblock.txt
+https://fuckfuckadblock.pages.dev/fuckfuckadblock.txt


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://fuckfuckadblock.pages.dev/fuckfuckadblock.txt`

### Describe the issue

`bogachenko` tried to bypass badlists in https://github.com/bogachenko/fuckfuckadblock/commit/bfad3132b1429e4483bea0b4827d8c58d09589d3

### Screenshot(s)



### Versions

- Browser/version: Firefox 113.0.1
- uBlock Origin version: uBlock Origin 1.49.2

### Settings



### Notes


