### PR TITLE
Add roundyearfun. org to Badware risks

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3369,3 +3369,8 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/18353
 ||easylist.club^$all
+
+! https://www.forbes.com/sites/jacksonweimer/2021/04/10/that-twitter-family-tree-trend-is-secretly-following-random-accounts--without-your-consent
+||roundyearfun.org^$all
+||anyplacehere.me^$all
+||funaroundy.click^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://roundyearfun.org/`
`https://anyplacehere.me/`
`https://funaroundy.click/`

### Describe the issue

This website is treating people by granting access to a Twitter API, allowing it to control users' accounts and follow other accounts without their knowledge.

https://www.forbes.com/sites/jacksonweimer/2021/04/10/that-twitter-family-tree-trend-is-secretly-following-random-accounts--without-your-consent