### PR TITLE
remove autoplay from reddit embeds

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -6800,3 +6800,6 @@ film4e.com,zamundatv.com##+js(acs, AudiosL10n)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/18421
 daysoftheyear.com##+js(aopr, googletag)
+
+! remove autoplay from reddit embeds
+embed.reddit.com##shreddit-player:remove-attr(autoplay)

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -6803,3 +6803,4 @@ daysoftheyear.com##+js(aopr, googletag)
 
 ! remove autoplay from reddit embeds
 embed.reddit.com##shreddit-player:remove-attr(autoplay)
+embed.reddit.com##a:has(shreddit-player):remove-attr(href)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://embed.reddit.com/r/oddlyterrifying/comments/1463lck/what_is_happening_here_will_it_go_in_2_pieces_in/`

### Describe the issue

Reddit embedded videos auto-play, with no option to not do so even when creating a new embed from a post. This removes the 'autoplay' attribute from the 'shreddit-player' tag and keeps the player from starting playback. It's now click-to-play.

### Versions

- Browser/version: I tried in Chrome 112
- uBlock Origin version: 1.49.2
