### PR TITLE
lmhmod.me tracking

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -583,5 +583,9 @@ androidauthority.com##+js(href-sanitizer, a[href^="https://androidauth.wpengine.
 pcgamingwiki.com##+js(href-sanitizer, a[href^="https://www.dpbolvw.net/click-"][href*="?url="], ?url)
 pcgamingwiki.com##+js(href-sanitizer, a[href^="https://greenmangaming.sjv.io/c/"][href*="?u="], ?u)
 
+! https://github.com/uBlockOrigin/uAssets/pull/18463
+||xapkgame.com^$3p
+||lmhmod.me/wp-admin/admin-ajax.php
+
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://lmhmod.me/en/efootball-pes-2021-mod`

### Describe the issue
Upon visiting a page, the site sends a request to `/wp-admin/admin-ajax.php` with the action `willgroup_update_post_views` and the associated post ID of the page in the POST parameters
And with a inline script, the site also sends a GET request to `https://xapkgame.com/visit.php` with the domain and URL in the paramters
For example: visiting `https://lmhmod.me/en/efootball-pes-2021-mod` makes it send a request to `https://xapkgame.com/visit.php?domain=lmhmod.me&uri=/en/efootball-pes-2021-mod`

Looking at xapkgame.com (screenshot listed below), the site has nothing but a login prompt with the button "Login Report"
I'm considering that this is just an analytics server, so I've decided to block 3rd party requests to it entirely
### Screenshot(s)
![login](https://github.com/uBlockOrigin/uAssets/assets/114311037/8b357d23-d243-4e56-9d08-36f8bf62e505)


### Versions

- Browser/version: LibreWolf (Firefox fork) 113.0.1
- uBlock Origin version: 1.49.2

### Settings

- Added uBlock Filters - Annoyances
