### PR TITLE
Update badware.txt: Remove 42.zip

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3399,9 +3399,6 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||skyblockmaniacs.net^$all
 ||fragbots.net^$all
 
-! https://github.com/uBlockOrigin/uAssets/discussions/18179#discussioncomment-5966400
-||42.zip^$all
-
 ! https://github.com/uBlockOrigin/uAssets/pull/17845#issuecomment-1556263873
 ! https://www.virustotal.com/gui/domain/allmovies.gg
 ! https://safeweb.norton.com/report/show?url=https://allmovies.gg


### PR DESCRIPTION
### URL(s) where the issue occurs

https://42.zip

### Describe the issue

The domain 42.zip is incorrectly blocklisted, when the content of the domain is not malicious.

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/14918218/7fabbb85-d496-43ca-8fc1-3e4be0162886)

When visiting 42.zip, the domain simply redirects to a harmless tweet on Twitter.

### Versions

- Browser/version: Chrome 113
- uBlock Origin version: 1.49.2

### Settings

- Stock settings

### Notes

When visiting 42.zip, the domain simply redirects to a harmless tweet on Twitter.
