### PR TITLE
Block 5eTools `cancer__` Advertising placeholder regions

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -3017,3 +3017,6 @@ rekidai-info.github.io##+js(no-fetch-if, googlesyndication)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/69447
 online2pdf.com##div[id*="horizontal_box"]
 online2pdf.com##div[id*="title_vertical"]
+
+! https://github.com/uBlockOrigin/uAssets/issues/18531
+5e.tools##div[class*="cancer__"]


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://5e.tools`

### Describe the issue

See https://github.com/uBlockOrigin/uAssets/issues/18531
