### PR TITLE
Add fextralife twitch stream blocker

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -3025,3 +3025,6 @@ online2pdf.com##div[id*="title_vertical"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/18534
 burbuja.info##+js(acs, RegExp, $)
+
+! https://github.com/uBlockOrigin/uAssets/issues/11883
+fextralife.com###sidebar-wrapper

--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -3027,4 +3027,4 @@ online2pdf.com##div[id*="title_vertical"]
 burbuja.info##+js(acs, RegExp, $)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11883
-fextralife.com###sidebar-wrapper
+||embed.twitch.tv^$frame,redirect=click2load.html,domain=wiki.fextralife.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://eldenring.wiki.fextralife.com/Elden+Ring+Wiki`
Any every other wiki page in Fextralife.

### Describe the issue

The fextralife wiki adds a sidebar to every wiki page to display their Twitch stream, if it's currently live. This is a massive waste of bandwidth for most people, as every new tab opens up another instance. This is a huge issue, because people tend to open multiple wiki pages at once. Also highly unethical to inflate twitch viewer count this way.

### Screenshot(s)

![Twitch stream to the top left corner](https://files.catbox.moe/2djmar.png)

### Versions

- Browser/version: FireFox/114.0.1
- uBlock Origin version: 1.50.0

### Settings

- Default.

### Notes

This PR adds a filter for blocking the sidebar content and shouldn't affect all Twitch sidebar streams injected into other websites. If enough users complain about similar practices, perhaps this could be added as a filter rule later:
`||player.twitch.tv^$third-party `
