### PR TITLE
Proposing filter for uol.com.br floating ad banner

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -6840,3 +6840,7 @@ kmo.to##+js(set, console.clear, undefined)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/18606
 9now.com.au##[id="toggle_notification_notification-ad-blocker"]:upward(1)
+
+! noticias.uol.com.br floating ad banner 
+noticias.uol.com.br##.up-floating
+noticias.uol.com.br##.down-floating

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -6841,6 +6841,6 @@ kmo.to##+js(set, console.clear, undefined)
 ! https://github.com/uBlockOrigin/uAssets/issues/18606
 9now.com.au##[id="toggle_notification_notification-ad-blocker"]:upward(1)
 
-! noticias.uol.com.br floating ad banner 
-noticias.uol.com.br##.up-floating
-noticias.uol.com.br##.down-floating
+! uol.com.br floating ad banner 
+uol.com.br##.up-floating
+uol.com.br##.down-floating


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://www.uol.com.br and subdomains

### Describe the issue

UOL have a floating ad banner at the bottom. Those filters hide them.

### Screenshot(s)

N/A

### Versions

- Browser/version: Chromium 114.0.5735.133
- uBlock Origin version: 1.50.0

### Settings

N/A

### Notes

N/A
