### PR TITLE
Add roundyearfun. com to Badware risks

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3499,6 +3499,7 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 
 ! https://www.forbes.com/sites/jacksonweimer/2021/04/10/that-twitter-family-tree-trend-is-secretly-following-random-accounts--without-your-consent
 ||roundyearfun.org^$all
+||roundyearfun.com^$all
 ||anyplacehere.me^$all
 ||funaroundy.click^$all
 ||anyplacehere.live^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://roundyearfun.com/`

### Notes

- https://github.com/uBlockOrigin/uAssets/pull/18388
