### PR TITLE
Add funtwitter. games & twitter-circle. com to Badward risks

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3509,12 +3509,15 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ! https://github.com/uBlockOrigin/uAssets/issues/18353
 ||easylist.club^$all
 
+! https://github.com/uBlockOrigin/uAssets/pull/18388
 ! https://www.forbes.com/sites/jacksonweimer/2021/04/10/that-twitter-family-tree-trend-is-secretly-following-random-accounts--without-your-consent
 ||roundyearfun.org^$all
 ||roundyearfun.com^$all
 ||anyplacehere.me^$all
 ||funaroundy.click^$all
 ||anyplacehere.live^$all
+||funtwitter.games^$all
+||twitter-circle.com^$all
 
 ! https://github.com/uBlockOrigin/uAssets/issues/18380
 ||bestextensionegde.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://funtwitter.games/`
`https://twitter-circle.com/`

### Notes

- https://github.com/uBlockOrigin/uAssets/pull/18388
