### PR TITLE
Filter new speedrun.com ads

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -16752,6 +16752,9 @@ techdracula.com##ins.adsbygoogle
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,xhr,redirect=googlesyndication_adsbygoogle.js:5,domain=~zipextractor.app
 ||pagead2.googlesyndication.com^$xhr,redirect=noop.js
 
+! 2023-07-01 https://www.speedrun.com
+||any-pct.speedrun.com/a/*$image
+
 ! regex
 /[0-9a-f]{32}\/invoke\.js/$script,3p
 /^https?:\/\/(?:www\.|[0-9a-z]{7,10}\.)?[-0-9a-z]{5,}\.com\/\/?(?:[0-9a-f]{2}\/){2,3}[0-9a-f]{32}\.js/$script,xhr,3p


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.speedrun.com/`

### Describe the issue
Big annoying ads

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/43764702/d5bb7a1c-1f2e-4295-ad71-8f8590c2ec67)

### Versions

- Browser/version: Firefox 1.50.0
- uBlock Origin version: 1.50.0