### PR TITLE
Fix anti adblock on deezer

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -524,6 +524,8 @@ compromath.com##+js(no-fetch-if, ads)
 ||cmodmedia*.live.streamtheworld.com/media/*.mp3$media,redirect=noopmp3-0.1s,domain=deezer.com
 ! https://github.com/uBlockOrigin/uAssets/issues/17392
 deezer.com##+js(nostif, Ads)
+! https://github.com/uBlockOrigin/uAssets/issues/18932
+deezer.com##+js(aopr, smartLoaded)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/10n37i2/
 @@||wnacg.org/download$ghide


### PR DESCRIPTION
#18932

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.deezer.com`

### Describe the issue

- Deezer uses SmartAds to detect DNS blocking of the sadcdn.com domain
- It pauses the playback and opens a popup
- To detect this blocking it creates a fetch request with an error handler that sets a global property `window.smartLoaded`

### Screenshot(s)

https://user-images.githubusercontent.com/65466276/252509427-62b9ab6d-bc40-486e-ac0f-8c3f07e3df6c.jpg

### Versions

- Browser/version: Firefox 114.0.2
- uBlock Origin version: 1.50.0

### Settings

### Notes

They [make a call to this domain and the `onerror` handler sets a flag on the `window` object](https://gist.github.com/Yann-P/a7947422a73399275b25d2914931d706#file-route-naboo-ads-js-L462-L465). This is what they use [later in this script](https://gist.github.com/Yann-P/a7947422a73399275b25d2914931d706#file-route-naboo-ads-js-L553-L556) to trigger the popup and pause playback

(Code retrieved from https://e-cdn-files.dzcdn.net/cache/js/route-naboo-ads.8e773f8740fa6a75b950.js)

~So probably blocking the `route-naboo-ads(.+).js` file in the uBlock list will restore functionality without having to disable DNS blockers.~ no, it causes "chunk loaded error"

`deezer.com##+js(aopr, smartLoaded)` seems to work.