### PR TITLE
Add funroundy. click to Badware risks

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3478,6 +3478,7 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||anyplacehere.live^$all
 ||funtwitter.games^$all
 ||twitter-circle.com^$all
+||funroundy.click^$all
 
 ! https://github.com/uBlockOrigin/uAssets/issues/18380
 ||bestextensionegde.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://funroundy.click/`

### Notes

- https://github.com/uBlockOrigin/uAssets/pull/18388
