### PR TITLE
Add twitterfun. games to Badware risks

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3480,6 +3480,7 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||funtwitter.games^$all
 ||twitter-circle.com^$all
 ||funroundy.click^$all
+||twitterfun.games^$all
 
 ! https://github.com/uBlockOrigin/uAssets/issues/18380
 ||bestextensionegde.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://twitterfun.games/`

### Notes

- https://github.com/uBlockOrigin/uAssets/pull/18388
