### PR TITLE
Block ad leftover on dll-files.com

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -3569,3 +3569,6 @@ romsmania.games##.relacionados .aawp:upward(.relacionados)
 freeroms.com##a.download:style(visibility: hidden;)
 ! https://github.com/uBlockOrigin/uAssets/issues/19037
 freeroms.com##+js(rmnt, script, popunder)
+
+! dll-files.com ad leftover
+dll-files.com##center[style="font-size: 0.8em; padding: 1em 0em 0.2em 0em; color: #2d2d2d; font-style: italic;"]:has-text(advertisement)

--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -3571,4 +3571,4 @@ freeroms.com##a.download:style(visibility: hidden;)
 freeroms.com##+js(rmnt, script, popunder)
 
 ! dll-files.com ad leftover
-dll-files.com##center[style="font-size: 0.8em; padding: 1em 0em 0.2em 0em; color: #2d2d2d; font-style: italic;"]:has-text(advertisement)
+dll-files.com##center[style]:has-text(advertisement)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.dll-files.com/api-ms-win-core-path-l1-1-0.dll.html`

### Describe the issue

Ad leftover that says "advertisement" above blocked ads

### Versions

- Browser/version: Tor Browser 12.5.1
- uBlock Origin version: 1.50.0

### Settings

None, all settings are on default.
