### PR TITLE
Added ea.qwerpdf.com

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -679,3 +679,5 @@ bing.com##+js(cookie-remover, MicrosoftApplicationsTelemetryDeviceId)
 
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt
+
+||ea.qwerpdf.com^


### PR DESCRIPTION
ea.qwerpdf.com is used by XyzTab and possibly other extensions for tracking pixels

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`xyztab.com`

### Describe the issue

The XyzTab extension, and possibly other extensions, use ea.qwerpdf.com for what appears to be a tracking pixel. This can be seen in the Network tab of Firefox's developer tools. It also shows up when using Google Chrome.

### Versions

- Browser/version: Firefox 115.0.3
- uBlock Origin version: 1.51.0

### Settings

- Enabled advanced settings, added several filter lists of my own, one of which blocks qwerpdf.com entirely. Perhaps that's overkill, but I'm not taking any chances.

### Notes

URL used for the tracking pixel in Firefox: https://ea.qwerpdf.com/collect?eid=1&uid=d0304c30-5bcd-c750-813f-ac41ba807117&name=pageview&c1=Customize%20You%20New%20Tab%20-%20Xyztab.com&c2=xyztab.com&label=%2F

Chrome: https://ea.qwerpdf.com/collect?eid=1&uid=4523a631-eddf-303c-12da-bb8c1c075134&name=pageview&c1=Customize%20You%20New%20Tab%20-%20Xyztab.com&c2=xyztab.com&label=%2F
