### PR TITLE
emurom.net: detection

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -8026,6 +8026,7 @@ aniwatcher.com##.cjrm
 ! https://github.com/uBlockOrigin/uAssets/issues/16693
 ! https://github.com/uBlockOrigin/uAssets/issues/18099
 emurom.net##+js(set, dvsize, 51)
+emurom.net##+js(aost, jQuery, blockDLElements)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4399
 ! https://www.reddit.com/r/uBlockOrigin/comments/u72fym/dailymotion_adblock_detected/


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.emurom.net/emulation/roms-atari-2600/detail-4747-adventure.html`

### Describe the issue

Site doesn't allow the user to download files if an adblocker is detected

### Screenshot(s)

### Versions

- Browser/version: LibreWolf 113.0.1
- uBlock Origin version: 1.51.0

### Settings

### Notes

