### PR TITLE
Add funxgames. site & funroundy. online to Badware risks

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3548,6 +3548,7 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||funroundy.click^$all
 ||twitterfun.games^$all
 ||funxgames.site^$all
+||funroundy.online^$all
 
 ! https://github.com/uBlockOrigin/uAssets/issues/18380
 ||bestextensionegde.com^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3547,6 +3547,7 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||twitter-circle.com^$all
 ||funroundy.click^$all
 ||twitterfun.games^$all
+||funxgames.site^$all
 
 ! https://github.com/uBlockOrigin/uAssets/issues/18380
 ||bestextensionegde.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://funxgames.site/`
`https://funroundy.online/`

### Notes

- https://github.com/uBlockOrigin/uAssets/pull/18388
