### PR TITLE
Privacy: add join-ad-interest-group and run-ad-auction permission policy

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -651,6 +651,8 @@ lite.duckduckgo.com##+js(href-sanitizer, a[href^="//duckduckgo.com/l/?uddg="], ?
 !#if env_chromium
 *$permissions=browsing-topics=(),from=~localhost
 *$permissions=idle-detection=(),from=~localhost
+*$permissions=join-ad-interest-group=(),from=~localhost
+*$permissions=run-ad-auction=(),from=~localhost
 !#endif
 
 ! https://github.com/uBlockOrigin/uAssets/issues/19100


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

 - ("deprecated" after rebranding) FLEDGE demo:
   - docs at `https://fledge-demo.glitch.me/`
   - advertisers:
      - `https://shopping-fledge-demo.glitch.me/advertiser/shopping.html`
      - `https://travel-fledge-demo.glitch.me/advertiser/travel.html`
   - publisher:
      - `https://publisher-fledge-demo.glitch.me/publisher/index.html`
      - `https://publisher-fledge-demo.glitch.me/publisher/index.html?fencedframe`

 - (new name) Protected Audience demo:
   - docs at `https://protected-audience-demo.web.app/`
   - advertiser `https://protected-audience-demo-advertiser.web.app/`
   - publisher `https://protected-audience-demo-publisher.web.app/`

### Describe the issue

Please see #19343.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Google Chrome 115.0.5790.170
- uBlock Origin version: 1.51.0

### Settings

- Default settings.

### Notes

[`ublock-privacy`](https://github.com/uBlockOrigin/uAssets/blob/master/filters/privacy.txt) list already has directives for `browsing-topics` and `idle-detection` permissions. I propose adding `join-ad-interest-group` and `run-ad-auction` directives.

These directives control (deprecated but still working ) FLEDGE API [(docs)](https://developer.chrome.com/blog/fledge-api/) and the new rebrand of FLEDGE API called "Protected Audience".
