### PR TITLE
vencord.app: badware

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3570,3 +3570,6 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ! https://github.com/AdguardTeam/AdguardFilters/issues/158317
 ||asdmcm.com^$all
 .com/bot-captcha-1?h=$doc
+
+! https://github.com/uBlockOrigin/uAssets/pull/placeholder
+||vencord.app^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://vencord.app`

### Describe the issue

this site is deceptively impersonating the real site by mimicking the design

the real site can be found at https://vencord.dev

### Sources

- <https://github.com/Vendicated/Vencord> (see url in repository description)
- <https://github.com/Vencord> (see url in organisation description)
- <https://vencord.dev/faq/#What-are-the-official-websites-for-Vencord?>