### PR TITLE
Add google.com to anti click trackers list

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -691,8 +691,8 @@ nowinstock.net##+js(href-sanitizer, a[href*="?"][href*="&u=http"], ?u)
 paypal.com##+js(href-sanitizer, a[href^="https://app.adjust.com/"][href*="?fallback=http"], ?fallback)
 ! https://www.elotrolado.net/hilo_el-podcast-de-eol-episodio-43-e3-cronica-de-una-muerte-anunciada_2360079
 elotrolado.net##+js(href-sanitizer, a[href^="https://go.redirectingat.com?url=http"], ?url)
-! https://google.com
-google.com##+js(href-sanitizer, a[href^="/url"][href*="&url=http"], &url)
+! https://www.google.com/search?q=example.com%2Ftest%3Fq%3Dtest
+www.google.*##+js(href-sanitizer, a[href^="/url"][href*="&url=http"], &url)
 
 ! https://chataigpt.org
 /detroitchicago/dpv.gif?$image

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -691,6 +691,8 @@ nowinstock.net##+js(href-sanitizer, a[href*="?"][href*="&u=http"], ?u)
 paypal.com##+js(href-sanitizer, a[href^="https://app.adjust.com/"][href*="?fallback=http"], ?fallback)
 ! https://www.elotrolado.net/hilo_el-podcast-de-eol-episodio-43-e3-cronica-de-una-muerte-anunciada_2360079
 elotrolado.net##+js(href-sanitizer, a[href^="https://go.redirectingat.com?url=http"], ?url)
+! https://google.com
+google.com##+js(href-sanitizer, a[href^="/url"][href*="&url=http"], &url)
 
 ! https://chataigpt.org
 /detroitchicago/dpv.gif?$image


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.google.com`

### Describe the issue

When clicking on search results, google.com redirects it via their own server. Try `https://www.google.com/search?q=example.com%252Ftest%253Fq%253Dtest` as a test

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: 116.0.2
- uBlock Origin version: 1.51.0

### Settings

None of them affects this problem.

### Notes
Maybe, the rule should be narrowed down to only `https://www.google.com/search?` since their are more outgoing links and we don't want to break other links of google