### PR TITLE
Address https://github.com/collinbarrett/FilterLists/issues/3794

### DIFF
--- a/filters/badlists.txt
+++ b/filters/badlists.txt
@@ -26,8 +26,6 @@ https://slickdeals.net/attachment/extension/allowlist.txt
 https://easylist-downloads.adblockplus.org/exceptionrules.txt
 https://letyshops.com/adblock.txt
 https://work.ink/adblock-whitelist.txt
-https://www.ebates.com/whitelist/ebates-cash-back-shopping.txt
-https://www.rakuten.com/whitelist/ebates-cash-back-shopping.txt
 https://www.aadvantageeshopping.com/adBlockWhitelist.php
 https://multiup.org/list_adblock.txt
 https://downloads.zohocdn.com/ulaa-browser/release/adb/stable/ulaa-filters.txt
@@ -36,6 +34,13 @@ https://downloads.zohocdn.com/ulaa-browser/release/adb/stable/ulaa-filters.txt
 https://www.topcashback.co.uk/misc/AdBlockWhiteList.aspx
 https://www.topcashback.co.uk/Misc/AdBlockWhiteList.aspx
 https://www.topcashback.com/Misc/AdBlockWhiteList.aspx
+
+# https://github.com/collinbarrett/FilterLists/issues/3794
+https://www.rakuten.ca/static/cashback-shopping-whitelist
+https://www.rakuten.ca/static/cashback-shopping-whitelist?title=Rakuten%20Cash%20Back%20Shopping
+# redirect to the new list
+https://www.ebates.com/whitelist/ebates-cash-back-shopping.txt
+https://www.rakuten.com/whitelist/ebates-cash-back-shopping.txt
 
 # obsolete lists
 https://cdn.rawgit.com/NanoAdblocker/NanoFilters/master/NanoFilters/NanoAnnoyance.txt


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs



### Describe the issue

The ebates list has moved to `https://www.rakuten.ca/static/cashback-shopping-whitelist?title=Rakuten%20Cash%20Back%20Shopping`

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/84232764/174742e1-b6b6-4de0-99fc-61fbc70f955e)


### Versions

- Browser/version: Firefox 116.0.3 (64-bit)
- uBlock Origin version: uBlock Origin 1.51.1b19

### Settings

- Irrelevant.

### Notes

See https://github.com/collinbarrett/FilterLists/issues/3794 for more details and a discussion on this list