### PR TITLE
update quick-fixes.txt

### DIFF
--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -254,10 +254,7 @@ exactpay.online##+js(nostif, offsetWidth)
 igg-games.com##a[href^="https://igg-games.com/nfl"]
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/15hcpfj/tgx_ads/
-||startgaming.net/tienda/*/?$doc,removeparam=/^(?!offer_id=).*/
 /^https:\/\/img\.wonkychickens\.org\/data\/cover\/imdb\/[\/A-Za-z0-9]+_/$image,domain=torrentgalaxy.to
-startgaming.net##+js(set-cookie, REFERER, OK)
-startgaming.net##+js(set-cookie, _monsterinsights_uj, OK, , reload, 1)
 
 ! https://github.com/easylist/easylist/commit/0429611abf62f5b24592b43f16b61476b25142e0
 /invoke.js$badfilter


### PR DESCRIPTION
### URL(s) where the issue occurs

startgaming.net

### Describe the issue

I've reviewed the proposed changes and noticed that these two filters might be impacting the functionality of the online store. The changes in question are:

```
||startgaming.net/tienda/*/?$doc,removeparam=/^(?!offer_id=).*/
startgaming.net##+js(set-cookie, REFERER, OK)
startgaming.net##+js(set-cookie, _monsterinsights_uj, OK, , reload, 1)
```

Since our goal is to maintain performance and user experience on the store, I suggest we reconsider these changes and look for alternative ways to achieve our objectives without compromising functionality.

Please let's take a closer look at these modifications and see how we can adjust them to ensure everything runs smoothly.

### Screenshot(s)

None

### Versions

- Browser/version: N/A
- uBlock Origin version: N/A

### Settings

- quick-fixes.txt

### Notes

N/A
