### PR TITLE
Remove gumtree featured ads

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -15,7 +15,7 @@ guccihide.com##+js(nowoif)
 filelions.to,guccihide.com,streamhide.to,streamwish.to##+js(aopr, __Y)
 /assets/jquery/adult100.js?v=$script,1p
 /assets/jquery/main100.js?v=$script,1p
-! javfas.com => player  javb1.com 
+! javfas.com => player  javb1.com
 /assets/jquery/adult0.js?v=$script,1p
 
 ! https://www.parents. at anti adb
@@ -227,7 +227,7 @@ darkwanderer.net,truckingboards.com##+js(nostif, show)
 *$xhr,domain=luffytra.xyz,redirect-rule=nooptext
 luffytra.xyz##+js(no-xhr-if, tag)
 
-! 
+!
 ||googlesyndication.com^$image,domain=smartkhabrinews.com,redirect-rule=1x1.gif
 smartkhabrinews.com##+js(no-fetch-if, /freychang|passback|popunder|tag/)
 
@@ -4238,3 +4238,6 @@ animeszone.net##+js(no-fetch-if, googlesyndication)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/19541
 heavy.com##+js(no-fetch-if, ads)
+
+! Remove gumtree featured ads
+www.gumtree.com##div>article>a>div>div:has-text(/Featured/):nth-ancestor(3)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.gumtree.com/search?featured_filter=false&q=&search_location=london&search_category=community`

### Describe the issue

Featured ads appear at the top of gumtree's search results. This filter removes them.

### Screenshot(s)

![featured ads](https://github.com/uBlockOrigin/uAssets/assets/7630866/1993c3d0-dd7e-423c-9e47-e1f3a0924690)

### Versions

- Browser/version: Version 1.56.14 Chromium: 115.0.5790.114 (Official Build) (64-bit)
- uBlock Origin version: 1.51.0

### Settings

- added one filter to filters-2023.txt

### Notes

Steps to reproduce
- Visit https://www.gumtree.com/search?featured_filter=false&q=&search_location=london&search_category=community
- Confirm that featured ads are visible when uBlock Origin disabled
- Enable uBlock Origin with [the commit contained within this PR](https://github.com/forgetso/uAssets/commit/70e4c55bec2207674f5a27b7d8facb60abe9eba4) commit
- Visit the web site again and confirm that the featured ads are not shown
