### PR TITLE
Update revanced.app rule in badware.txt

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3602,7 +3602,7 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ! https://safeweb.norton.com/report/show?url=revanced.io
 ! https://sitecheck.sucuri.net/results/revanced.io
 ! https://github.com/uBlockOrigin/uAssets/pull/17469
-||revanced.*^$all,domain=~revanced.app
+||revanced.*^$all,from=~revanced.app,to=~revanced.app
 ||revancedapk.*^$all,domain=~revanced.app
 ||revancedapp.*^$all,domain=~revanced.app
 ||youtubevanced.*^$all,domain=~revanced.app


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://madkarmaa.github.io/revanced/`

### Describe the issue

revanced api (`https://api.revanced.app`) or other official resources cannot be called from other sites because filter is too strict

### Versions

- Browser/version: Firefox Dev (118.0b3)
- uBlock Origin version: 1.51.0

- Browser/version: Edge (116.0.1938.69)
- uBlock Origin version: 1.51.0

- Browser/version: Firefox Android (117.0)
- uBlock Origin version: 1.51.0

### Settings

- ~~move revanced.* rule to the end of revanced block~~
- ~~add exception for revanced.app (the official domain which should be allowed/callable by others)~~
- update revanced.app filter (the official domain which should be allowed/callable by others):
`||revanced.*^$all,domain=~revanced.app` -> `||revanced.*^$all,from=~revanced.app,to=~revanced.app`

### Notes

revanced api is a public api which should be callable by other websites
