### PR TITLE
Address https://github.com/AdguardTeam/AdguardFilters/issues/160924

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -1072,9 +1072,8 @@ online123movies.live##+js(nowoif)
 artunnel57.com##+js(nosiif, adb)
 @@||artunnel57.com^$ghide
 
-! https://github.com/uBlockOrigin/uAssets/issues/11950
-zeroupload.com##+js(acs, document.addEventListener, nextFunction)
-@@||zeroupload.com/js/js/$script,1p
+! https://github.com/AdguardTeam/AdguardFilters/issues/160924
+zeroupload.com##+js(rmnt, script, adblock)
 
 ! streamas.cloud popup
 streamas.cloud##+js(aopr, __Y)


### PR DESCRIPTION
upd #11950

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
`[https://zeroupload.com/1fe0de7521451e88dbaccbf739eeef4b](https://adguardteam.github.io/AnonymousRedirect/redirect.html?url=https%3A%2F%2Fzeroupload.com%2F1fe0de7521451e88dbaccbf739eeef4b)`

### Describe the issue
- anti-adblock
- new code => old code obsolete

### Versions

- Browser/version: Google Chrome Version 116.0.5845.141 (Official Build) (64-bit)
- uBlock Origin version: 1.51.0
