### PR TITLE
update developer.com

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -4474,3 +4474,5 @@ ithinkilikeyou.net##+js(noeval-if, ads)
 
 ! https://github.com/uBlockOrigin/uAssets/discussions/17361#discussioncomment-6926938
 otechno.net###devozon-snp, #submitBtn, #go_d:style(display: block !important;)
+
+www.developer.com###sticky-bottom


### PR DESCRIPTION
### URL(s) where the issue occurs

[developer.com](https://www.developer.com/) and any pages on that website

### Describe the issue

There is an empty container with a close button at the bottom of the page that seems to have its content blocked, but still appears as a frame. This merge request should fix that.

### Screenshot(s)

![obraz](https://github.com/uBlockOrigin/uAssets/assets/27138416/a3eda92b-089d-4f6b-85bc-1c4a86bfc724)

### Versions

- Browser/version: Firefox 117.0
- uBlock Origin version: 1.51.0

### Settings

uBlock Origin auto-generated filter:

```
! 2023-09-10 https://www.developer.com
www.developer.com###sticky-bottom
```

This seems to fix the issue.
