### PR TITLE
Add TP-Link domains used for LAN configuration

### DIFF
--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -89,6 +89,11 @@
 ||samsung.router^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||speedport.ip^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||steamloopback.host^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
+||tplinkap.net^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
+||tplinkeap.net^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
+||tplinkmodem.net^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
+||tplinkplclogin.net^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
+||tplinkrepeater.net^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||tplinkwifi.net^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||web.setup^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||web.setup.home^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local


### PR DESCRIPTION
This adds five additional domains that is used by TP-Link for end-user configuration of their products. Four of them (tplinkap.net, tplinkmodem.net, tplinkplclogin.net and tplinkrepeater.net) have a self-demonstrating fallback webpage that is shown if not connected to their products.

The fifth one (tplinkeap.net) does not have a self-demonstrating fallback webpage but it is listed in their guide at https://static.tp-link.com/configurationguide/quick_start_guide_standalone_eap.pdf#page=5 with the likely explanation being that this domain is intended for enterprise users where administratiors would know how to access the equipment using IP addresses if this domain somehow won't work.