### PR TITLE
player.popfun.co.uk: anti-adb

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -4495,3 +4495,7 @@ jornaldigital.org##+js(set-cookie, Ads, 2)
 ||media.toxtren.com^$all
 superembeds.com##+js(nowoif)
 superembeds.com###adStop
+
+! popplayer anti adb
+||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=player.popfun.co.uk,redirect-rule=google-ima.js
+player.popfun.co.uk##+js(json-prune, response.ads)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://player.popfun.co.uk/shows/65032edf-2dc9-11ed-b4c6-0af62ebc70d1`
`https://player.popfun.co.uk/shows/9666191c-995a-11ec-b4c6-0af62ebc70d1`

### Describe the issue

POP Player is detecting adblock and denying playback until the adblocker is disabled.

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/2660574/84eff883-6323-4a1d-b6af-556345391a38)

### Versions

- Browser/version: Chrome 116
- uBlock Origin version: 1.51.0

### Settings

Added custom filters to block the SSAI m3u8 from loading

### Notes

This PR completely solves the anti-adblock issues on player.popfun.co.uk.