### PR TITLE
Update fix for monstercampaigns[.]com

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4950,6 +4950,7 @@ szbz.de##+js(set, iom, {})
 ! https://github.com/AdguardTeam/AdguardFilters/issues/158410
 @@||a.omappapi.com/app/campaign-views/*-optin.json$xhr,domain=app.monstercampaigns.com
 @@||a.omappapi.com/users/*/images/$image,domain=app.monstercampaigns.com
+@@||a.omappapi.com/app/campaign-views/*-success.json$xhr,domain=app.monstercampaigns.com
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/158351
 @@||googletagmanager.com/gtm.js$script,domain=villeroy-boch.fr


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://app.monstercampaigns.com/c/ymoaltjjkbqsoosd8nrf/`

### Describe the issue

Blocking `https://a.omappapi.com/app/campaign-views/dc6b4bd4928c/ymoaltjjkbqsoosd8nrf/941d8bff06710d0e2572d297c3abda90-success.json` causes an infinite loading icon. With that request unblocked or uBo disabled, a success message is shown. This JSON file seems to contain the HTML to render the success message.
I propose `@@||a.omappapi.com/app/campaign-views/*-success.json$xhr,domain=app.monstercampaigns.com` (based on existing filter)
Thanks

### Screenshot(s)

Blocked:
![image](https://github.com/uBlockOrigin/uAssets/assets/84232764/6edbbd68-8092-497a-8139-1b5f1468fbf7)
Unblocked:
![image](https://github.com/uBlockOrigin/uAssets/assets/84232764/23659d6a-d512-4dc3-9e5b-f692a4cc056b)


### Versions

- Browser/version: 118.0.1 (64-bit)
- uBlock Origin version: uBlock Origin 1.52.2 (can repro with 1.52.3b5 in a different profile)

### Settings

Default settings (new install of uBo in a new test profile)

### Notes


