### PR TITLE
fix: remove github copilot promotion button

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -6920,3 +6920,7 @@ raenonx.cc##+js(nostif, show)
 
 ! https://deccanherald.com/india/delhi/people-detained-from-jantar-mantar-for-denouncing-israel-over-gaza-action-2728594 - Copy manipulation
 deccanherald.com##+js(aopr, document.oncopy)
+
+
+! GitHub copilot promotion when viewing files
+github.com##button[data-testid="copilot-popover-button"]


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://github.com/uBlockOrigin/uAssets/blob/master/README.md or any other github file.

### Describe the issue

This removes the "Your organization can pay for GitHub Copilot" or "Code 55% faster with GitHub Copilot" promotion buttons when viewing a file in github web.

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/41706133/011829d5-a651-40b0-b764-6f45c49ff987)

![image](https://github.com/uBlockOrigin/uAssets/assets/41706133/0fbc41a7-7996-4d4b-aa82-9458b3cde7d4)

### Versions

- Browser/version: Firefox 118.0.2 / Chromium 118
- uBlock Origin version: 1.52.2

### Settings

defaults + 
- uBlock filters – Annoyances
- uBlock filters – Cookie Notices

### Notes

This is not always shown, especially if you've clicked on the "Don't show again" button before. I see these while I'm signed in with accounts I've not pressed the "Don't show again" button.
