### PR TITLE
Privacy: add keyboard-map permission policy

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -615,6 +615,7 @@ bikesales.com.au##^html > head > :is([name="canonical"], [rel="canonical"]):not(
 *$permissions=browsing-topics=(),from=~localhost
 *$permissions=idle-detection=(),from=~localhost
 *$permissions=join-ad-interest-group=(),from=~localhost
+*$permissions=keyboard-map=(),from=~localhost
 *$permissions=run-ad-auction=(),from=~localhost
 *$permissions=attribution-reporting=(),from=~localhost
 !#endif


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://example.com`

### Describe the issue

uBlock Origin does not restrict usage of Keyboard Map API, even though it could. Please see #20142.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Chromium 118.0.5993.70
- uBlock Origin version: 1.52.2

### Settings

- None

### Notes

Fixes #20142.