### PR TITLE
Fix https://github.com/hagezi/dns-blocklists/issues/1744

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3388,6 +3388,7 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ! https://forum.xda-developers.com/t/downloaded-a-fake-magisk.4581461/
 ! https://old.reddit.com/r/Android/comments/7r346t/psa_magiskmanagercom_is_not_the_official_website/
 ! https://github.com/topjohnwu/Magisk/issues/3435
+! https://github.com/hagezi/dns-blocklists/issues/1744
 ||magiskmanager.com^$all
 ||magisk.me^$all
 ||magiskcn.com^$all
@@ -3396,6 +3397,19 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||magiskroot.net^$all
 ||magisks.com^$all
 ||themagisk.com^$all
+||magiskzip.net^$all
+||magiskmanagerroot.com^$all
+||magisk.download^$all
+||magiskmanager.com^$all
+||magisk.info^$all
+! generic rules
+||magisk.$doc,domain=~topjohnwu.github.io
+||magiskzip.$doc,domain=~topjohnwu.github.io
+||magiskmanagerroot.$doc,domain=~topjohnwu.github.io
+||magiskmanager.$doc,domain=~topjohnwu.github.io
+||magiskcn.$doc,domain=~topjohnwu.github.io
+||magiskroot.$doc,domain=~topjohnwu.github.io
+||magiskapp.$doc,domain=~topjohnwu.github.io
 ! LibreTube - Official site: libretube.dev
 ! https://github.com/libre-tube/LibreTube/issues/4409
 ||libretube.*^$all,domain=~libretube.dev,to=~libretube.dev


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
magisk.info
magiskzip.net
magiskmanagerroot.com
```

### Describe the issue

Fake websites for https://github.com/topjohnwu/Magisk (https://github.com/topjohnwu/Magisk/issues/3435)
Thanks

### Screenshot(s)



### Versions
N/A

### Settings

N/A

### Notes

The first two websites are from https://github.com/hagezi/dns-blocklists/issues/1744
I added them and one other fake site I found as `$all` rules, plus a few broader rules which should cover all the known fake sites + any new ones. I am a bit worried they might cause false positives (ie fan sites, or the very unlikely chance something else is named the exact same thing), so `$doc` only. Kept the originals but can remove them if needed.
