### PR TITLE
Scam page -> TotalAdBlock scam

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3496,3 +3496,6 @@ cambe.pr.gov.br,paranhos.ms.gov.br##^script[language][type]:has-text(window.loca
 ||cutterbijes.com^$all
 ||dhotelzao.com^$all
 ||tamilislamgate.com^$all
+
+! https://tria.ge/231024-3lc5jace3w/behavioral1 & https://tria.ge/231024-3s7ygsbg39/behavioral1
+||adblock1.com^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3498,4 +3498,5 @@ cambe.pr.gov.br,paranhos.ms.gov.br##^script[language][type]:has-text(window.loca
 ||tamilislamgate.com^$all
 
 ! https://tria.ge/231024-3lc5jace3w/behavioral1 & https://tria.ge/231024-3s7ygsbg39/behavioral1
+! https://github.com/uBlockOrigin/uAssets/pull/20272
 ||adblock1.com^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3500,3 +3500,6 @@ cambe.pr.gov.br,paranhos.ms.gov.br##^script[language][type]:has-text(window.loca
 ! https://tria.ge/231024-3lc5jace3w/behavioral1 & https://tria.ge/231024-3s7ygsbg39/behavioral1
 ! https://github.com/uBlockOrigin/uAssets/pull/20272
 ||adblock1.com^$all
+||newupdatesnow.com^$all
+||thefinanceadvice.com^$all
+||fralstamp-genglyric.icu^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`http://adblock1.com`

### Describe the issue

This is a scam website which tricks users into installing the malicious TotalAdBlock browser extension (made by TotalAV and blocked in EasyList). It is being promoted via spam notifications.
I also added some related scam domains.
Sources (both behind CloudFlare):
https://tria.ge/231024-3lc5jace3w/behavioral1
https://tria.ge/231024-3s7ygsbg39/behavioral1

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/84232764/2b9273ea-c626-4f83-944d-c9b6cf2ddc62)
![image](https://github.com/uBlockOrigin/uAssets/assets/84232764/b7fc011b-a01b-4ba9-9f2b-936c249492e6)


### Versions

N/A

### Settings

N/A

### Notes

I chose not to add TotalAdBlock because it is already blocked in EasyList, but I can if needed (just in case someone remove EasyList?)
Thank you.
