### PR TITLE
Add quantiy badware site

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3538,3 +3538,6 @@ cambe.pr.gov.br,paranhos.ms.gov.br##^script[language][type]:has-text(window.loca
 
 ! https://github.com/uBlockOrigin/uAssets/issues/20400
 ||ets2.gr^$all
+
+! https://github.com/uBlockOrigin/uAssets/issues/20437
+||api.quantiy.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://api.quantiy.com/api/v2/auth/callback/?state=f1db82dfa1b31cd3cc103c09d806dc498eb54067efd98e5b2b851eb2ed6d809a` hosts redirects to a Minecraft phishing page

### Describe the issue

Once the user enters their passwords the data is sent to the attacker
### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/101084582/7fc327b5-b4c0-4b4e-b690-3f5cfad12b0c)
### Versions

all

### Settings

None
### Notes

Part of a Minecraft phishing campaign