### PR TITLE
skk.moe: url variant bypass method filter

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -320,6 +320,7 @@ tacobell.com##+js(set, bmak.js_post, false)
 ! https://github.com/uBlockOrigin/uAssets/pull/15692#issuecomment-1321098072
 blog.skk.moe##+js(no-fetch-if, body:/[\w\W]{700}/)
 skk.moe##+js(no-fetch-if, method:/post|posT|poSt|poST|pOst|pOsT|pOSt|pOST|Post|PosT|PoSt|PoST|POst|POsT|POSt|POST/)
+blog.skk.moe##+js(no-fetch-if, url:/post/)
 /cfga/jquery.js?$image
 /npm/sks@0.*/lazyload.js$script,3p
 


### PR DESCRIPTION
### URL(s) where the issue occurs

blog.skk.moe

### Describe the issue

When `POST` failed, fetch will be execute with URL `/post/` and handled as post internally. This PR catch this case.

### Screenshot(s)

N/A

### Versions

- Browser/version: [here]
- uBlock Origin version: [here]

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

![image](https://github.com/uBlockOrigin/uAssets/assets/17120571/933a659a-8dbe-4e76-b9b5-66d74e62dec5)

