### PR TITLE
docs.atlasos.net: breakage

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4651,7 +4651,7 @@ tieba.baidu.com##+js(set, passFingerPrint, noopFunc)
 @@||analytics-*.clickdimensions.com/*/pages/$frame,domain=crm.digital.nhs.uk
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16440
-@@||h-microsoft.online-metrix.net^$xhr,domain=ave9858.github.io|massgrave.dev
+@@||h-microsoft.online-metrix.net^$xhr,domain=ave9858.github.io|massgrave.dev|docs.atlasos.net
 
 ! https://github.com/uBlockOrigin/uAssets/issues/17621#issuecomment-1567160350
 sofascore.com#@#[display^="block,none"]


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://docs.atlasos.net/getting-started/installation/#download-an-iso`

### Describe the issue

Currently uBlock Origin blocks the `vlscppe.microsoft.com` endpoint when being fetched by other pages.

This causes the Microsoft ISO downloader built into the `docs.atlasos.net` installation page to fallback to using a proxy, which isn't ideal, as it will use more resources (on the proxy's end) and make the download process slower.

`docs.atlasos.net` has a modified version of MSDL (an online Windows ISO downloader) so that users can easily download Windows ISOs on our site from Microsoft. For MSDL, this was already fixed in issue https://github.com/uBlockOrigin/uAssets/issues/16440, but `docs.atlasos.net` also needs to be added to the `unbreak.txt`.

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/65787561/d6e50422-c644-42e5-bdcb-5bf271e158d7)

### Versions

- Browser/version: Firefox 119.0.1
- uBlock Origin version: 1.53.0

### Settings

- No changes from defaults