### PR TITLE
Update badware.txt

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -1003,6 +1003,7 @@ tech4yougadgets.com##+js(aopr, Notification)
 ||possessedcrackinghart.com^$all
 ||adblock-pro-download.com^$all
 ||reepratic.com^$all
+||5vcjzwb1tsnd82g.caflu87p1d.ru^$all
 
 
 ! phishing /scam /malware


### PR DESCRIPTION
Adding 5vcjzwb1tsnd82g.caflu87p1d.ru
Note: Apologies if I have done this incorrectly - it's my first contribution to this project, but I would like to try and help build these threat lists to minimise impact to other users. 


### URL(s) where the issue occurs

`5vcjzwb1tsnd82g.caflu87p1d.ru`

### Describe the issue

The domain is being used for phishing by trying to mimic the Microsoft 365 login page. 

### Versions

- Browser/version: Brave 
- uBlock Origin version: 1.53.0

### Settings

No changes made , just requesting an addition to the list of badware domains.

### Notes

I have reported the domain to Google and NCSC (UK). There doesn't appear to be any malicious payload on the site, just a form (styled similar to Microsoft 365) to steal user credentials.
