### PR TITLE
Fix discussions on seznam.cz

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -222,7 +222,7 @@ seznam.cz##.sticky-content:has-text(Rek)
 seznam.cz##.sticky-content:has-text(klama)
 seznam.cz##[class*="advert"]
 ||seznam.cz/$frame,1p
-@@||diskuze.seznam.cz/*/fulltext/discussion/$frame
+@@||diskuze.seznam.cz$frame
 @@||seznam.cz/html/cmp.html$frame,1p
 seznam.cz##+js(nostif, 0x)
 @@||seznam.cz^$ghide,badfilter
@@ -238,7 +238,7 @@ seznamzpravy.cz##.sticky-content:has-text(Rek)
 seznamzpravy.cz##.sticky-content:has-text(klama)
 seznamzpravy.cz##[class*="advert"]
 ||seznamzpravy.cz/$frame,1p
-@@||diskuze.seznamzpravy.cz/*/fulltext/discussion/$frame
+@@||diskuze.seznamzpravy.cz$frame
 @@||seznamzpravy.cz/html/cmp.html$frame,1p
 seznamzpravy.cz##+js(nostif, 0x)
 @@||seznamzpravy.cz^$ghide,badfilter


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

From an easylistczechandslovak user: `https://www.seznam.cz/profil/jan-heinz-6d7766da11ee1fd154d8c3ce44cb9d7ec0a87e43ae2f5b156ee7/prispevek/Q29tbWVudE5vZGU6Mzc3NDI5NDA4`

### Describe the issue

The filters modified in this PR caused discussions on seznam.cz not to load. This is because of this filter: https://github.com/uBlockOrigin/uAssets/blob/ddb4acf5e6d373cd51c3279b40be3c830f77afad/filters/filters-2023.txt#L224

### Notes

Originally reported in easylistczechandslovak: https://github.com/tomasko126/easylistczechandslovak/issues/380

Fix confirmed to be working by the user, although I'm not sure about any potential side effects: https://github.com/tomasko126/easylistczechandslovak/issues/380#issuecomment-1810961230