### PR TITLE
Exclude MusicBrainz localhost 3P from LAN block filter

### DIFF
--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -102,4 +102,7 @@
 ! https://github.com/uBlockOrigin/uAssets/issues/19005
 @@||127.0.0.1^$xhr,domain=battlelog.battlefield.com
 !
+! https://github.com/uBlockOrigin/uAssets/pull/20768
+@@||127.0.0.1^$3p,domain=musicbrainz.org
+!
 ! ——— END


### PR DESCRIPTION
### URL(s) where the issue occurs

MusicBrainz pages where Picard is being used, e.g. `https://musicbrainz.org/search/textsearch?limit=50&type=recording&query=iyowa&tport=8000` -> click 'TAGGER'

(Once visited with tport, it will remember the port and use it across the site, e.g. release info, etc)

### Describe the issue

On using MusicBrainz with Picard, to use the Tagger feature, clicking the button issues a request to `127.0.0.1:<tport>` in order to relay the result clicked to the local client. LAN block filter breaks this, so we add an exclusion here for it.