### PR TITLE
Update https://github.com/AdguardTeam/AdguardFilters/issues/161334

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -4594,11 +4594,11 @@ plumbersforums.net##+js(rmnt, script, /$.*adUnits/)
 ||wachipho.net^
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/161334
-beastplayer.tk,jiolive.tv,livesportsclub.pages.dev,madlink.biz,madstream.live,rogstream.fun###AdbModel
-livesportsclub.pages.dev,lolstreamz.pages.dev,madxsia.live,rogsports.pages.dev,rogstream.fun,rogstreamlive.eu.org##.ts-modal-overlay
-livesportsclub.pages.dev,lolstreamz.pages.dev,madxsia.live,rogsports.pages.dev,rogstream.fun,rogstreamlive.eu.org##body:style(overflow: auto !important;)
+livesportsclub.me,madstream.live,rogstream.fun###AdbModel
+livesportsclub.me,rogstream.fun##.ts-modal-overlay
+livesportsclub.me,rogstream.fun##body:style(overflow: auto !important;)
 ! telegram app download annoyance
-beastplayer.tk,livesportsclub.pages.dev,lolstreamz.pages.dev,madlink.biz,rogsports.pages.dev,rogstream.fun##+js(set, confirm, noopFunc)
+livesportsclub.me,rogstream.fun##+js(set, confirm, noopFunc)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/19693
 jornaldigital.org##+js(set-cookie, Ads, 2)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
various streams under
`madstream.live`

### Describe the issue

 update sites used & remove dead domains

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox a stable & microsoft edge
- uBlock Origin version: 1.53

### Settings

-  uBO's default settings

### Notes
