### PR TITLE
update anascrie.ro

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7030,7 +7030,7 @@ habuteru.com##*:style(-webkit-touch-callout: default !important; -webkit-user-se
 
 ! anascrie. ro anti right click, select, print, f-keys
 anascrie.ro##+js(rmnt, script, /document.onkeydown|document.ondragstart/)
-anascrie.ro##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -khtml-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important; -webkit-tap-highlight-color: revert !important;)
+anascrie.ro##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -khtml-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important; -webkit-tap-highlight-color: revert !important; cursor: revert !important;)
 anascrie.ro##style:has-text(@media print):remove()
 
 ! https://github.com/uBlockOrigin/uAssets/issues/20747


### PR DESCRIPTION
The `unselectable` class which exists on the `body` element sets the cursor to `default`, i.e., the "i-beam" cursor that shows normally when selecting text won't be shown.
```html
<style>
.unselectable
{
-moz-user-select:none;
-webkit-user-select:none;
cursor: default;
}
/* ... */
</style>
```

This PR removes that payload too.
