### PR TITLE
Adding presearch filters

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -5551,3 +5551,7 @@ soccerinhd.com##+js(aopw, _pop)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/20850
 gameshdlive.net##+js(aopw, _pop)
+
+! 2023-11-25 https://presearch.com ads disguised as "backgrounds"
+presearch.com##div:matches-attr(":class"="/.*showAdInfo.*/")
+||assets.presearch.com/backgrounds/$image,1p


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://presearch.com`

### Describe the issue

Presearch started serving annoying ads of various nature (crypto-scam, VPN-scam) disguised as "backgrounds".

### Versions

- Browser/version: Librewolf
- uBlock Origin version: 1.54.1b0

### Settings

Defaults, nothing changed besides adding these rules for myself.

### Notes

See "Describe the issue"