### PR TITLE
Update privacy.txt

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -884,5 +884,19 @@ airtel.in##+js(no-xhr-if, analytics/bulk-pixel)
 ! https://elevenlabs.io/dubbing - Stores the last dubbing result
 elevenlabs.io##+js(set-local-storage-item, IIElevenLabsDubbingResult, $remove$)
 
+! Pepper redirection - pepper.ru/deals/post-428233 | pepper.pl/promocje/post-750379 | dealabs.com/bons-plans/post-2674687
+chollometro.com##+js(href-sanitizer, a[href*="https://www.chollometro.com/visit/"][title^="https://"], [title])
+dealabs.com##+js(href-sanitizer, a[href*="https://www.dealabs.com/visit/"][title^="https://"], [title])
+hotukdeals.com##+js(href-sanitizer, a[href*="https://www.hotukdeals.com/visit/"][title^="https://"], [title])
+mydealz.de##+js(href-sanitizer, a[href*="https://www.mydealz.de/visit/"][title^="https://"], [title])
+nl.pepper.com##+js(href-sanitizer, a[href*="https://nl.pepper.com/visit/"][title^="https://"], [title])
+pepper.it##+js(href-sanitizer, a[href*="https://www.pepper.it/visit/"][title^="https://"], [title])
+pepper.pl##+js(href-sanitizer, a[href*="https://www.pepper.pl/visit/"][title^="https://"], [title])
+pepper.ru##+js(href-sanitizer, a[href*="https://www.pepper.ru/visit/"][title^="https://"], [title])
+preisjaeger.at##+js(href-sanitizer, a[href*="https://www.preisjaeger.at/visit/"][title^="https://"], [title])
+promodescuentos.com##+js(href-sanitizer, a[href*="https://www.promodescuentos.com/visit/"][title^="https://"], [title])
+pelando.com.br##+js(href-sanitizer, a[href*="https://www.pelando.com.br/api/redirect?url="], ?url)
+! desidime.com##+js(href-sanitizer, a[href*="https://www.desidime.com/links?ref=][href*="&url="], &url)
+
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt


### PR DESCRIPTION
#20859

### Describe the issue

Direct links based on title as long is out of users to edit in BBcode/HTML/Markdown syntax:

> https://github.com/uBlockOrigin/uAssets/assets/35370833/17225240-9053-4ded-9012-9b9f7cf957bc - now is not possible edit title attr now by users/community.

I haven't checked to see if any regional list has fixed the problem in a long time, and I don't see an option for the Indian version (the scriptlet doesn't seem to intentionally allow you to select an attribute/parameter other than first).

It is possible that the Brazilian version will one day change the layout or all the rest so that it is not hide URL in the title.
