### PR TITLE
twitch.tv `sponsorships-campaign` blocking

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -5569,5 +5569,6 @@ freepornsex.net##+js(aost, setTimeout, ads)
 dirtyvideo.fun##+js(nowoif)
 dirtyvideo.fun##+js(set, arrvast, [])
 
+! https://github.com/uBlockOrigin/uAssets/pull/20893
 twitch.tv##[style*="sponsorships-campaign-assets"]:upward(2)
 twitch.tv##.channel-skins-ribbon__container:upward(1)

--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -5568,3 +5568,6 @@ freepornsex.net##+js(aost, setTimeout, ads)
 ! https://www.reddit.com/r/uBlockOrigin/comments/183msm2/help_with_embeeded_player_from_netu_pop_ups_and/
 dirtyvideo.fun##+js(nowoif)
 dirtyvideo.fun##+js(set, arrvast, [])
+
+twitch.tv##[style*="sponsorships-campaign-assets"]:upward(2)
+twitch.tv##.channel-skins-ribbon__container:upward(1)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.twitch.tv/BLASTPremier`

### Describe the issue

Seems that some Twitch partnered channels can add some sponsored content on their channels. Adding filters to block them as they can't be closed or hidden by the user.

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/5881994/91b6f970-1b64-4391-8860-702cdd263266)

### Versions

- Browser/version: `Chrome 119.0.6045.160 (Official Build) (64-bit)`
- uBlock Origin version: `1.53.5rc13`

### Settings

_N/A_

### Notes

_N/A_
