### PR TITLE
Remove `magiskcn.com`

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3489,7 +3489,6 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ! https://github.com/hagezi/dns-blocklists/issues/1744
 ||magiskmanager.com^$all
 ||magisk.me^$all
-||magiskcn.com^$all
 ||magiskapp.com^$all
 ||magiskroot.com^$all
 ||magiskroot.net^$all


### PR DESCRIPTION


<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://magiskcn.com/`

### Describe the issue

Apparently this is a fan site.
Thanks

### Screenshot(s)



### Versions

N/A

### Settings

N/A

### Notes

See https://github.com/hagezi/dns-blocklists/issues/1744#issuecomment-1837154759
