### PR TITLE
Fix https://github.com/easylist/easylist/issues/17915

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -5661,3 +5661,7 @@ filmweb.pl##.faDesktopBillboard__content
 fwcdn.pl###clickArea
 fwcdn.pl###link-container-all
 fwcdn.pl##[id*="banner"]
+
+! https://github.com/easylist/easylist/issues/17915
+thespurce.com#@#.mntl-leaderboard-spacer
+thespruce.com##.mntl-leaderboard-spacer:style(min-height: 0px !important;)

--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -5663,5 +5663,4 @@ fwcdn.pl###link-container-all
 fwcdn.pl##[id*="banner"]
 
 ! https://github.com/easylist/easylist/issues/17915
-thespurce.com#@#.mntl-leaderboard-spacer
 thespruce.com##.mntl-leaderboard-spacer:style(min-height: 0px !important;)


### PR DESCRIPTION
`https://www.thespruce.com/grow-bamboo-inside-1902611`

article title gets crammed