### PR TITLE
Fix https://github.com/easylist/easylist/issues/17937

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -5154,3 +5154,6 @@ lumens.com##+js(set, _satellite.track, noopFunc)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/21050
 ||inmobi.com^$badfilter
+
+! https://github.com/uBlockOrigin/uAssets/issues/19370
+edition.cnn.com#@##onetrust-consent-sdk

--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -5155,5 +5155,5 @@ lumens.com##+js(set, _satellite.track, noopFunc)
 ! https://github.com/uBlockOrigin/uAssets/issues/21050
 ||inmobi.com^$badfilter
 
-! https://github.com/uBlockOrigin/uAssets/issues/19370
+! https://github.com/easylist/easylist/issues/17937
 edition.cnn.com#@##onetrust-consent-sdk


### PR DESCRIPTION
`https://edition.cnn.com/`

easylist cookie detection

use a EU IP address