### PR TITLE
Filters for alliance4creativity.com

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -897,5 +897,8 @@ promodescuentos.com##+js(href-sanitizer, a[href*="https://www.promodescuentos.co
 pelando.com.br##+js(href-sanitizer, a[href*="https://www.pelando.com.br/api/redirect?url="], ?url)
 ! desidime.com##+js(href-sanitizer, a[href*="https://www.desidime.com/links?ref=][href*="&url="], &url)
 
+||alliance4creativity.com^$3p
+||alliance4creativity.com/*utm_$doc
+
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt


### PR DESCRIPTION
e.g.:


`zoro.to` => redirects to `https://www.alliance4creativity.com/watch-it-legally/?utm_source=zoro.to&utm_medium=Domain&utm_campaign=Redirect`

`$3p` to address frames

can we add:

```
||zoro.to^
||2embed.to^
```
(without `$all` for Brave compatibility)

?