### PR TITLE
Dead site: seositespeed.com

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -341,9 +341,6 @@ watchporn.to##[href^="https://go.gkrtmc.com/"]
 dotabuff.com##+js(no-fetch-if, ads)
 dotabuff.com##.retaliate.mana-void
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/106120
-seositespeed.com##+js(acs, eval, replace)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/11245
 social-unlock.com##+js(set, ad_link,  '')
 


### PR DESCRIPTION
https://urlfilter.adtidy.org/v2/checkDomain?domain=seositespeed.com