### PR TITLE
address `basketballbuzz.ca` anti-adb

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -5739,3 +5739,6 @@ schooltravelorganiser.com##+js(nostif, adblock)
 
 ! sonixgvn .net anti-adb
 sonixgvn.net##+js(aost, setTimeout, ads)
+
+! basketballbuzz .ca anti-adb
+basketballbuzz.ca##+js(rmnt, script, mdp)


### PR DESCRIPTION
`https://basketballbuzz.ca/ncaa/fardaws-aimaq-canadas-all-time-ncaa-rebounding-leader/`