### PR TITLE
address `gojo2.com` anti-adb

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -2700,7 +2700,7 @@ nopay.info##+js(aopw, AaDetector)
 
 ! ai_adb sites
 ! https://github.com/uBlockOrigin/uAssets/issues/17528
-avitter.net,bi-girl.net,carryflix.icu,dark5k.com,fairyhorn.cc,javhdvideo.org,nakiny.com,nemumemo.com,phodoi.vn,savingsomegreen.com,tutsnode.com##+js(aopr, b2a)
+avitter.net,bi-girl.net,carryflix.icu,dark5k.com,fairyhorn.cc,gojo2.com,javhdvideo.org,nakiny.com,nemumemo.com,phodoi.vn,savingsomegreen.com,tutsnode.com##+js(aopr, b2a)
 freewebcart.com##+js(nostif, ai_adb)
 freewebcart.com##.pum-open-overlay:style(overflow: auto !important;)
 freewebcart.com##.pum-overlay


### PR DESCRIPTION
`https://gojo2.com/jujutsu-kaisen-season-2-reaction/`

I can trigger the anti-adb message if  I click on a link on the page and then use the browser's back button. It only happens on chrome for me.

### Screenshot(s)
<img width="1440" src="https://github.com/uBlockOrigin/uAssets/assets/46979193/577b6d91-7db1-4901-bac0-30da634e2c79">
