### PR TITLE
fix `crazyvidup.com` video player

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -5787,3 +5787,7 @@ yourupload.com##+js(acs, atob, /h=decodeURIComponent|_pop/)
 
 ! thebullspen .com anti-adb
 thebullspen.com##+js(rmnt, script, fetch)
+
+! crazyvidup .com video player
+crazyvidup.com##+js(ra, srcdoc, iframe)
+crazyvidup.com##.footerStickyBox


### PR DESCRIPTION
`https://nvcplayer.crazyvidup.com/player/html/Jvtnx94ramevj` from `https://hufoot.com/Fulham-vs-West-Ham-United/20494`

Makes video player normal-sized and hides `.footerStickyBox`