### PR TITLE
Hide unclosable register banner on https://realpython.com/

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7112,3 +7112,8 @@ news.17173.com##+js(aeld, copy)
 ! https://github.com/uBlockOrigin/uAssets/issues/21319
 ||videos-cloudfront.jwpsrv.com^$media,domain=app.simpleclub.com
 ||cdn.jwplayer.com^$media,domain=app.simpleclub.com
+
+! 2023-12-11 https://realpython.com - hide unclosable register banner
+realpython.com##.show.fade.modal
+realpython.com##.show.fade.modal-backdrop
+realpython.com##body:remove-class(modal-open)


### PR DESCRIPTION
Banner appears after 5 visited pages/reloads

![Screenshot 2023-12-11 at 16 32 20](https://github.com/uBlockOrigin/uAssets/assets/99194003/8e451884-9bce-4113-8f01-cbd1f08a5893)

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://realpython.com/`
