### PR TITLE
address `cartometro.com` anti-adb

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -5788,6 +5788,6 @@ crazyvidup.com##.footerStickyBox
 get-coin.click##+js(acs, Swal.fire)
 get-coin.click##+js(acs, document.createElement, atob)
 
-! cartometro .com anti-adb
+! https://github.com/easylist/easylist/issues/17968
 @@||cartometro.com^$ghide
 cartometro.com##[class^="cmad"]

--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -5787,3 +5787,7 @@ crazyvidup.com##.footerStickyBox
 ! https://github.com/uBlockOrigin/uAssets/issues/21339
 get-coin.click##+js(acs, Swal.fire)
 get-coin.click##+js(acs, document.createElement, atob)
+
+! cartometro .com anti-adb
+@@||cartometro.com^$ghide
+cartometro.com##[class^="cmad"]


### PR DESCRIPTION
`https://cartometro.com/cartes/metro-london/`

Fixes and addresses https://github.com/easylist/easylist/issues/17968