### PR TITLE
address `9animes.ru` anti-adb

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -5887,3 +5887,6 @@ trannyteca.com##+js(rmnt, script, /h=decodeURIComponent|popundersPerIP/)
 
 ! shemale6 .com anti-adb
 *$image,domain=shemale6.com,redirect-rule=1x1.gif
+
+! 9animes .ru anti-adb
+9animes.ru##+js(no-xhr-if, googlesyndication)


### PR DESCRIPTION
`https://9animes.ru/watch/dr-stone-new-world-part-2-online-free-9anime`

Anti-adb only appears on chrome for me