### PR TITLE
Extend fix #21412 / clean-quotidiano.net-rules

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -736,8 +736,8 @@ manta.net##+js(trusted-set-local-storage-item, cookie_setting, '{"analytical_coo
 chip.de##+js(trusted-set-cookie, consentUUID, 5b13fb0e-6264-4bfa-bd0c-20f35140a634_26)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/21412
-@@||cmp.pubtech.ai/*/pubtech-cmp-v2.js$script,from=ilrestodelcarlino.it
-ilrestodelcarlino.it##+js(trusted-click-element, #pubtech-cmp #pt-close)
+@@||cmp.pubtech.ai/*/pubtech-cmp-v2.js$script,from=ilrestodelcarlino.it|quotidiano.net|lanazione.it|ilgiorno.it|iltelegrafolivorno.it
+ilrestodelcarlino.it,quotidiano.net,lanazione.it,ilgiorno.it,iltelegrafolivorno.it##+js(trusted-click-element, #pubtech-cmp #pt-close)
 
 ! https://www.lekarnaave.cz/ - Preference
 lekarnaave.cz##+js(trusted-set-cookie, cookiesSettings, %7B%22necessary%22%3Atrue%2C%22preferential%22%3Atrue%7D, , , reload, 1)

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -687,12 +687,6 @@ ab.gr##+js(trusted-set-cookie, CookieConsent, 1.0.0.0.0)
 tameteo.com,tempo.pt,yourweather.co.uk,meteored.cl,meteored.mx,tempo.com,ilmeteo.net,meteored.com.ar,daswetter.com##+js(trusted-set-cookie, euconsent-v2, CP2APYAP2APYADtACBDEAcEgAAAAAAAAACiQAAAAAAAA)
 tameteo.com,tempo.pt,yourweather.co.uk,meteored.cl,meteored.mx,tempo.com,ilmeteo.net,meteored.com.ar,daswetter.com##+js(set-cookie, euconsent-v2-addtl, 0)
 
-! quotidiano. net cookies + (FA / AA unbreaking videos https://www.quotidiano.net/video/parigi-arrestato-guru-di-atman-yoga-federation-e-altre-41-persone-jgbapomp)
-quotidiano.net##+js(trusted-click-element, button#pt-accept-all)
-@@||cmp-assets.pubtech.ai/*.json$xhr
-@@||cmp.pubtech.ai/*/pubtech-cmp-v2.js$script,domain=quotidiano.net
-quotidiano.net#@##pubtech-cmp
-
 ! https://www.glamour.com/story/cher-alexander-edwards-relationship-timeline ---- Functional for embeds
 glamour.com##+js(trusted-set-cookie, OptanonConsent, groups=C0003%3A0%2CC0002%3A0%2CC0004%3A1%2CC0001%3A1%2CC0009%3A0, 1year)
 
@@ -736,6 +730,7 @@ manta.net##+js(trusted-set-local-storage-item, cookie_setting, '{"analytical_coo
 chip.de##+js(trusted-set-cookie, consentUUID, 5b13fb0e-6264-4bfa-bd0c-20f35140a634_26)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/21412
+! quotidiano. net cookies + (FA / AA unbreaking videos https://www.quotidiano.net/video/parigi-arrestato-guru-di-atman-yoga-federation-e-altre-41-persone-jgbapomp)
 @@||cmp.pubtech.ai/*/pubtech-cmp-v2.js$script,from=ilrestodelcarlino.it|quotidiano.net|lanazione.it|ilgiorno.it|iltelegrafolivorno.it
 ilrestodelcarlino.it,quotidiano.net,lanazione.it,ilgiorno.it,iltelegrafolivorno.it##+js(trusted-click-element, #pubtech-cmp #pt-close)
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.ilrestodelcarlino.it/video/aeroporto-bologna-piano-di-investimenti-da-216-milioni-in-5-anni-hr8muxqm`
(already fixed)
`https://www.quotidiano.net/video/parigi-arrestato-guru-di-atman-yoga-federation-e-altre-41-persone-jgbapomp`
(already fixed)
`https://www.lanazione.it/firenze/cronaca/allarme-bomba-casa-pound-94924538`
`https://www.ilgiorno.it/pavia/cronaca/milano-belgioioso-pullman-incidente-48bc51e1`
`https://www.iltelegrafolivorno.it/cronaca/inaugurato-a-livorno-il-nuovo-ponte-in-via-di-salviano-bd16c8f6`


### Describe the issue
All `quotidiano.net` group (`ilrestodelcarlino.it`, `quotidiano.net`, `lanazione.it`, `ilgiorno.it`, `iltelegrafolivorno.it`) has the same issue #21412 (video doesn't load), so this pull request extends the same solution.


### Screenshot(s)

<img width="310" alt="d" src="https://github.com/uBlockOrigin/uAssets/assets/1375223/f97e014b-2bee-42e1-8459-add27b72583d">


### Versions

- Browser/version: Firefox 120
- uBlock Origin version: 1.54

### Settings
- enabled AdGuard Ads
- enabled AdGuard Tracking Protection
- enabled uBlock filters – Cookie Notices
- enabled uBlock filters – Annoyances


### Notes

- `quotidiano.net` was already fixed accepting all cookies, reject them is enough now.
- 
```
@@||cmp-assets.pubtech.ai/*.json$xhr
quotidiano.net#@##pubtech-cmp

```
looks like not more needed.
