### PR TITLE
extend-fix-#20059

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -6956,8 +6956,8 @@ bluesnews.com##+js(nostif, nn_mpu1, 5000)
 broncoshq.com##+js(rmnt, script, XF)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/20059#issuecomment-1806089143
-androidpolice.com##+js(remove-cookie, articlesRead, when, scroll keydown)
-androidpolice.com,makeuseof.com,movieweb.com,xda-developers.com##+js(set, maxUnauthenicatedArticleViews, null)
+androidpolice.com,makeuseof.com,movieweb.com,xda-developers.com,thegamer.com,cbr.com##+js(remove-cookie, articlesRead, when, scroll keydown)
+androidpolice.com,makeuseof.com,movieweb.com,xda-developers.com,thegamer.com,cbr.com##+js(set, maxUnauthenicatedArticleViews, null)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/20606
 groundies.com##.cms-popup


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
`https://www.thegamer.com/thegamer-game-of-the-year-2023/`
`https://www.cbr.com/fantasy-tropes-lord-of-the-rings/`

### Describe the issue

Related to
https://github.com/uBlockOrigin/uAssets/issues/20059#issuecomment-1806089143

Popup subscription appears after you scroll 5/6 articles.

So,
- added `thegamer.com` and `cbr.com` to both rules;
- added `makeuseof.com` , `movieweb.com` , `xda-developers.com` to the first rule: with only the second one the popup doesn't appear but you aren't able to read the full article.

### Screenshot(s)

<img width="1124" alt="dd" src="https://github.com/uBlockOrigin/uAssets/assets/1375223/87cc1400-b266-4e32-bb13-2df0b746e19a">

### Versions

- Browser/version: Firefox 121
- uBlock Origin version: 1.54

### Settings

- enabled AdGuard Ads
- enabled AdGuard Tracking Protection
- enabled uBlock filters – Cookie Notices
- enabled uBlock filters – Annoyances