### PR TITLE
nitroshiba.com: badware

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3641,3 +3641,4 @@ cambe.pr.gov.br,paranhos.ms.gov.br##^script[language][type]:has-text(window.loca
 ||mevnow.com^$all
 ||mevtime.com^$all
 ||eth-mev.com^$all
+||nitroshiba.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://nitroshiba.com/`
`https://get.nitroshiba.com/`

### Describe the issue

Cryptocurrency Scams

Fake NitroShiba Website

### Notes

NitroShiba Official Website: https://nitroshiba.xyz

Source:
- https://coinmarketcap.com/currencies/nitroshiba/
- https://crypto.com/price/nitroshiba
- https://arbiscan.io/token/0x4DAD357726b41bb8932764340ee9108cC5AD33a0