### PR TITLE
starkfond.net: badware

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3643,3 +3643,4 @@ cambe.pr.gov.br,paranhos.ms.gov.br##^script[language][type]:has-text(window.loca
 ||eth-mev.com^$all
 ||nitroshiba.com^$all
 ||blast-drops.com^$all
+||starkfond.net^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://starkfond.net/`

### Describe the issue

Cryptocurrency Scams

Fake Starknet Website

### Notes

X (Twitter): https://twitter.com/Starknet
Website: https://www.starknet.io/en

They seem to have blocked some VPN IPs, so I saved a webpage snapshot using the Wayback Machine:
https://web.archive.org/web/20231220110755/https://starkfond.net/