### PR TITLE
stalkforx.ru, stalktoolss.ru, stalkanalysis.ru: badware

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3654,3 +3654,4 @@ cambe.pr.gov.br,paranhos.ms.gov.br##^script[language][type]:has-text(window.loca
 
 ||stalkforx.ru^$all
 ||stalktoolss.ru^$all
+||stalkanalysis.ru^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3652,6 +3652,7 @@ cambe.pr.gov.br,paranhos.ms.gov.br##^script[language][type]:has-text(window.loca
 ||blast-drops.com^$all
 ||starkfond.net^$all
 
+! https://github.com/uBlockOrigin/uAssets/pull/21539
 ||stalkforx.ru^$all
 ||stalktoolss.ru^$all
 ||stalkanalysis.ru^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3651,3 +3651,6 @@ cambe.pr.gov.br,paranhos.ms.gov.br##^script[language][type]:has-text(window.loca
 ||nitroshiba.com^$all
 ||blast-drops.com^$all
 ||starkfond.net^$all
+
+||stalkforx.ru^$all
+||stalktoolss.ru^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://stalkforx.ru/#1683899100922511378|5lY42eHs|X`
`https://stalktools.ru/#1683899100922511378|5lY42eHs|X`
`https://stalkanalysis.ru/web/?type=2&id=X`

### Describe the issue

When the user presses the "Log in with Twitter account" button, they will be redirected to a fake Twitter login page. After entering their username and password, that account will be used to send this website through DMs to all following/follower(s).

> ![Screenshot kslash/status/1728023492548043098](https://github.com/uBlockOrigin/uAssets/assets/133132480/b69a80e1-a68b-4314-a79d-817fba50ddf6)
https://twitter.com/kslash/status/1728023492548043098

### Notes

https://www.virustotal.com/gui/domain/stalkforx.ru
https://www.virustotal.com/gui/domain/stalktoolss.ru