### PR TITLE
Annoyances: fix(breakage): stocktwits.com

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -1228,9 +1228,6 @@ kpopjjang.com##*::selection:style(background-color:#338FFF !important;)
 fantricks.com##+js(acs, jQuery, contextmenu)
 fantricks.com##body:style(-webkit-touch-callout: default !important;-webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
 
-! https://adblockplus.org/forum/viewtopic.php?f=1&t=64879&start=0
-stocktwits.com##+js(aopr, Date.prototype.toUTCString)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/5175
 steelersdepot.com##.modal, .modal-backdrop
 


### PR DESCRIPTION
### URL(s) where the issue occurs

```
stocktwits.com
```

### Describe the issue

Website doesn't load due to scriptlet.

refs https://github.com/ghostery/broken-page-reports/issues/381

### Versions

- Browser/version: Version 118.0.5993.117 (Official Build, ungoogled-chromium) (arm64)
- uBlock Origin version: 1.54.0

### Settings

```
uBlock Origin: 1.54.0
Chromium: 118
filterset (summary):
 network: 107681
 cosmetic: 90758
 scriptlet: 27331
 html: 0
listset (total-discarded, last-updated):
 added:
  http://localhost:3000/1p-filters.txt: 197-0, 1d.3h.52m
  http://localhost:3000/autoconsent.txt: 470-1, 1d.3h.48m
  http://localhost:3000/custom.txt: 352-41, 1d.3h.52m
  http://localhost:3000/whotracksme.txt: 346-1, 1d.3h.52m
  fanboy-cookiemonster: 49211-161, 4d.5h.1m
  ublock-annoyances: 6445-58, 16m
 default:
  user-filters: 13-0, never
  easylist: 76477-15, 16m
  easyprivacy: 33168-65, 6m
  plowe-0: 3781-1152, 11d.5h.36m
  ublock-badware: 7555-137, 16m
  ublock-filters: 36361-223, 16m
  ublock-privacy: 952-12, 16m
  ublock-quick-fixes: 128-4, 16m
  ublock-unbreak: 2176-34, 16m
  urlhaus-1: 10190-0, 16m
filterset (user): [array of 13 redacted]
userSettings: [none]
hiddenSettings: [none]
supportStats:
 allReadyAfter: 287 ms
 maxAssetCacheWait: 174 ms
```

### Notes
