### PR TITLE
Block fitgirlrepackz[.]com and sites like it

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3451,7 +3451,7 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||fitgirlrepacksite.com^$all,domain=~fitgirl-repacks.site
 ! https://github.com/uBlockOrigin/uAssets/issues/18206
 ||fitgirl.cc^$all,domain=~fitgirl-repacks.site
-! [replace with link to PR]
+! https://github.com/uBlockOrigin/uAssets/issues/21658
 ||fitgirlrepackz.*^$all,domain=~fitgirl-repacks.site
 ! Magisk manager - Official site: https://github.com/topjohnwu/Magisk
 ! https://xda-developers.com/psa-magiskmanager-com-not-official-website-magisk/

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3451,6 +3451,8 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||fitgirlrepacksite.com^$all,domain=~fitgirl-repacks.site
 ! https://github.com/uBlockOrigin/uAssets/issues/18206
 ||fitgirl.cc^$all,domain=~fitgirl-repacks.site
+! [replace with link to PR]
+||fitgirlrepackz.*^$all,domain=~fitgirl-repacks.site
 ! Magisk manager - Official site: https://github.com/topjohnwu/Magisk
 ! https://xda-developers.com/psa-magiskmanager-com-not-official-website-magisk/
 ! https://forum.xda-developers.com/t/downloaded-a-fake-magisk.4581461/


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://fitgirlrepackz.com/`

### Describe the issue

This is a [fake FitGirl website](https://tria.ge/231229-v2aeksedam/behavioral1) which does not appear to be blocked by uBlock Origin. I have added a rule to block all websites starting with `fitgirlrepackz`, copied from the existing rules.
Thank you

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/84232764/42865ce5-50b9-4098-b2ea-40d0ed44f7b1)
![image](https://github.com/uBlockOrigin/uAssets/assets/84232764/4f0682b3-2dd3-472c-b608-be338b0e3bcb)


### Versions

N/A

### Settings

N/A

### Notes


