### PR TITLE
extend-fix-#20059 to `www.howtogeek.com`

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -6944,8 +6944,8 @@ bluesnews.com##+js(nostif, nn_mpu1, 5000)
 broncoshq.com##+js(rmnt, script, XF)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/20059#issuecomment-1806089143
-androidpolice.com,makeuseof.com,movieweb.com,xda-developers.com,thegamer.com,cbr.com,gamerant.com,screenrant.com##+js(remove-cookie, articlesRead, when, scroll keydown)
-androidpolice.com,makeuseof.com,movieweb.com,xda-developers.com,thegamer.com,cbr.com,gamerant.com,screenrant.com##+js(set, maxUnauthenicatedArticleViews, null)
+androidpolice.com,makeuseof.com,movieweb.com,xda-developers.com,thegamer.com,cbr.com,gamerant.com,screenrant.com,howtogeek.com##+js(remove-cookie, articlesRead, when, scroll keydown)
+androidpolice.com,makeuseof.com,movieweb.com,xda-developers.com,thegamer.com,cbr.com,gamerant.com,screenrant.com,howtogeek.com##+js(set, maxUnauthenicatedArticleViews, null)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/20606
 groundies.com##.cms-popup


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.howtogeek.com/reduce-windows-malware-threat/`

### Describe the issue

Related to
https://github.com/uBlockOrigin/uAssets/issues/20059#issuecomment-1806089143

Popup subscription appears after you scroll 5/6 articles.
Currently, AG hides the popup, I think it's better adopt the other solution.

### Screenshot(s)

<img width="1069" alt="df" src="https://github.com/uBlockOrigin/uAssets/assets/1375223/27b21648-0412-421c-9eca-4e6032829586">

### Versions

- Browser/version: Firefox 121
- uBlock Origin version: 1.54

### Settings

- enabled AdGuard Ads
- enabled AdGuard Tracking Protection
- enabled uBlock filters – Cookie Notices
- enabled uBlock filters – Annoyances