### PR TITLE
address `dualshockers.com` anti-adb

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -4092,7 +4092,7 @@ sanfoundry.com##.sf-desktop-ads
 ! https://github.com/uBlockOrigin/uAssets/issues/21552
 ! https://github.com/uBlockOrigin/uAssets/issues/20059#issuecomment-1879665761
 ! https://github.com/uBlockOrigin/uAssets/issues/19707#issuecomment-1888064204
-androidpolice.com,cbr.com,gamerant.com,thegamer.com##+js(aeld, error, blocker)
+androidpolice.com,cbr.com,dualshockers.com,gamerant.com,thegamer.com##+js(aeld, error, blocker)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/19468
 yt2conv.com##+js(ra, onclick, a#downloadbtn[onclick^="window.open"], stay)


### PR DESCRIPTION
`https://www.dualshockers.com/`

"Something went wrong. Please disable your blocker on DualShockers.com" detection message only on chrome and not on firefox after clicking through a few articles.