### PR TITLE
Privacy: Add missing LogRocket session replay intake domain

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -914,5 +914,9 @@ coomer.su,kemono.su##+js(set, plausible, noopFunc)
 ! https://baomoi.com/ - Tracking pixels
 ||api.baomoi.com/*/n/images/su$xhr,1p
 
+! https://logrocket.com - Session Replay intake
+||lr-intake.com^
+||intake-lr.com^
+
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt


### PR DESCRIPTION
### Describe the issue

This PR adds [LogRocket](https://logrocket.com/)'s session replay intake domain to the privacy blocklist.
Written in [their documentation](https://docs.logrocket.com/docs/proxying-traffic-through-your-own-domain#proxy-server), LogRocket will hit the `lr-intake.com` endpoint to ingest their session replay.

Though, through manual research using a proxy, I was able to confirm that LogRocket also ingests their endpoint through an alternate domain: `intake-lr.com`

<details>
<summary>Screenshot of proxy</summary>

![CleanShot 2024-01-13 at 05 25 29](https://github.com/uBlockOrigin/uAssets/assets/2129163/61db5990-5e51-4a2c-9ec1-1e62a3af57b5)
</details>

### Versions

- Browser/version: Arc Browser Version 1.25.1 (45028), Chromium Engine Version 120.0.6099.216
- uBlock Origin version: uBlock Origin 1.54.0
