### PR TITLE
Fix Thingiverse.com inline ad card

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -2314,8 +2314,9 @@ dl.3dmodelshare.org##+js(acs, document.addEventListener, google_ad_client)
 
 ! https://github.com/NanoMeow/QuickReports/issues/4598
 thingiverse.com##+js(nano-sib)
-thingiverse.com##[class^="CardGrid__cardGridItem"]:has(> [class^="AdCard"])
 thingiverse.com##[class*="ThingPage__topAd"]
+! https://github.com/uBlockOrigin/uAssets/issues/21961
+thingiverse.com##[class^="ItemCardContainer__itemCard"]:has(> [title="Advertisement"])
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/62686
 surf-trx.com##+js(nosiif, visibility, 1000)


### PR DESCRIPTION
Closes #21961

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

- `https://www.thingiverse.com/`
- `https://www.thingiverse.com/search?q=potato`

### Describe the issue

Inline advertisement cards are shown in search results and home page.

### Screenshot(s)

![thingiverse-ad](https://github.com/uBlockOrigin/uAssets/assets/1518323/be4ebcdc-8686-4b4d-8b3b-50fda06b598c)

### Versions

- Browser/version: Firefox: 121
- uBlock Origin version: 1.55.0

### Settings

- No changes from default

### Notes

Removing old `[class^="CardGrid__cardGridItem"]:has(> [class^="AdCard"])` selector as it appears Thingiverse has removed these classes.
