### PR TITLE
domain taken down: `mangahosted.com`

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -3573,8 +3573,6 @@ idevicecentral.com##+js(nostif, ()=>)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/125763
 lib.hatenablog.com##+js(acs, document.addEventListener, google_ad_client)
 
-! https://www.reddit.com/r/uBlockOrigin/comments/wb0duu/
-
 ! https://github.com/uBlockOrigin/uAssets/issues/14198
 komputerswiat.pl##+js(acs, $onet, adblock)
 

--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -3573,12 +3573,6 @@ idevicecentral.com##+js(nostif, ()=>)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/125763
 lib.hatenablog.com##+js(acs, document.addEventListener, google_ad_client)
 
-! https://www.reddit.com/r/uBlockOrigin/comments/wclff9/
-@@||mangahosted.com^$1p,xhr
-*$3p,xhr,redirect-rule=noop.txt,domain=mangahosted.com
-mangahosted.com##+js(acs, setTimeout, adsbygoogle)
-mangahosted.com##.slot
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/wb0duu/
 
 ! https://github.com/uBlockOrigin/uAssets/issues/14198


### PR DESCRIPTION
`https://mangahosted.com/`

Domain redirects to a site that says the domain is no longer in service due to copyright infringement. Also removed a comment that doesn't seem to be connected with any filter.