### PR TITLE
`nyaa.land` ads and timer

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -234,3 +234,7 @@ bailiwickexpress.com##+js(acs, $, load_banner)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/171126
 twitchmetrics.net##+js(set-cookie, npabp, 1)
+
+! nyaa.land ads and timer
+nyaa.land##html > body > div:has(>a[href="https://privateiptvaccess.com"])
+nyaa.land##+js(aeld, DOMContentLoaded)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
`nyaa.land` 

### Describe the issue

Timer on DOM load, in `script` tag:
```js
document.addEventListener("DOMContentLoaded", function() { setTimeout(function() { window.open("https://privateiptvaccess.com", "_blank"); }, 6000); });
```

### Screenshot(s)

Banner ad:
![](https://github.com/uBlockOrigin/uAssets/assets/18603393/7ddba718-51bd-4a8a-abb1-082e1b966016)

### Versions

- Browser/version: Firefox 121.0

- uBlock Origin version: 1.55.0

## Not relevant


### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]