### PR TITLE
`nyaa.land` update ads

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -235,9 +235,9 @@ bailiwickexpress.com##+js(acs, $, load_banner)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/171126
 twitchmetrics.net##+js(set-cookie, npabp, 1)
 
-! https://github.com/uBlockOrigin/uAssets/pull/22099
-nyaa.land##+js(aeld, DOMContentLoaded, open)
-nyaa.land##[href="https://privateiptvaccess.com"]
+! https://github.com/uBlockOrigin/uAssets/pull/22112
+nyaa.land##^script:has-text(privateiptvaccess.com)
+nyaa.land##[href*="privateiptvaccess.com"]
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/19bfu0c/anti_ad_blocker_issue_on_a_website/
 ||go4kora.tv/assets/js/script_antiAdBlock_*.js$script,1p


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`nyaa.land`

### Describe the issue

#22099
New `script` tag:
```js
setTimeout(() => { window.open("https://privateiptvaccess.com/?random-32-char-hex-string", "_blank"); }, 5000);
```

### Screenshot(s)

same as linked issue

### Versions

- Browser/version: same as linked issue
- uBlock Origin version: same as linked issue

## Not relevant

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
