### PR TITLE
Maxroll.gg - hide Ad-block warning

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -274,3 +274,6 @@ krx18.com##center > [src*="/ads/"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/22126
 playerwatch.xyz##+js(nowoif, , 10)
+
+! maxroll.gg
+maxroll.gg##.z-\[100000\]


### PR DESCRIPTION
### URL(s) where the issue occurs

https://maxroll.gg/poe/category/build-guides

### Describe the issue

After you browse Maxroll.gg with uBlock, they'll display a warning that you're using Ad-blocker.

### Screenshot(s)

https://i.imgur.com/B9VajAP.png

### Versions

- Browser/version: Chrome Version 120.0.6099.225 (Official Build) (64-bit)
- uBlock Origin version: 1.55.0
