### PR TITLE
chore(skk.moe): remove invalid filter

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -319,11 +319,7 @@ tacobell.com##+js(set, bmak.js_post, false)
 
 ! https://github.com/easylist/easylist/issues/6724#issuecomment-1003172754
 ! https://github.com/uBlockOrigin/uAssets/pull/15692#issuecomment-1321098072
-blog.skk.moe##+js(no-fetch-if, body:/[\w\W]{700}/)
-skk.moe##+js(no-fetch-if, method:/post|posT|poSt|poST|pOst|pOsT|pOSt|pOST|Post|PosT|PoSt|PoST|POst|POsT|POSt|POST/)
-blog.skk.moe##+js(no-fetch-if, /\/post\/.*\.json/)
 /cfga/jquery.js?$image
-/npm/sks@0.*/lazyload.js$script,3p
 
 ! jzzo.com,xxxvogue.net, etc.
 /s/js/ta-2.3.js?


### PR DESCRIPTION
### URL(s) where the issue occurs

blog.skk.moe

### Describe the issue

This PR removes invalid filter as this website now block access to object. (`no-fetch-if` will get nothing `{}`). It is possibly because the attributes of `enumerable: !1, writable: !1` set on the object, and there is no way to stop it (for now).

### Versions

- Browser/version: Firefox
- uBlock Origin version: 1.55.0

### Notes

I would suggest people w/ privacy concerns disable javascript when visiting this website, and maybe scriptlet could update and handle cases like this. However all current filters are no longer effective and could be removed. 

Still this PR serves as a notice, I am not sure the policy here would rather keep invalid filter. If so, simply close this PR.

> It is really easy for them(trackers) to just do a little but smart change and there is no easy way for us to block them. Good job @SukkaW, I learned a lot. Thanks for taking time doing this!

