### PR TITLE
Apious filterlists have been taken down

### DIFF
--- a/filters/badlists.txt
+++ b/filters/badlists.txt
@@ -71,7 +71,3 @@ https://fuckfuckadblock.pages.dev/fuckfuckadblock.txt?_=3
 https://raw.githack.com/bogachenko/fuckfuckadblock/master/fuckfuckadblock.txt?_=3
 https://cdn.statically.io/gh/bogachenko/fuckfuckadblock/master/fuckfuckadblock.txt?_=3
 https://raw.githubusercontent.com/bogachenko/fuckfuckadblock/master/fuckfuckadblock.txt?_=3
-
-! https://github.com/uBlockOrigin/uAssets/discussions/20627
-https://raw.githubusercontent.com/Apious/Ads_Filter_Contents/1st/Ads_Block_Contents.txt
-https://raw.githubusercontent.com/Apious/Ads_Filter_DNS/1st/Ads_Block_DNS.txt


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
https://raw.githubusercontent.com/Apious/Ads_Filter_Contents/1st/Ads_Block_Contents.txt
https://raw.githubusercontent.com/Apious/Ads_Filter_DNS/1st/Ads_Block_DNS.txt
```

### Describe the issue

These URLs return 404, and their repositories have either been deleted or made private.

### Screenshot(s)

N/A

### Versions

N/A

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

This PR updates https://github.com/uBlockOrigin/uAssets/discussions/20627.
The original blog post has been taken down and I do not see a replacement. However, if the author has merely moved these filters elsewhere, I can update the links instead of removing them.
