### PR TITLE
#22408

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -5217,3 +5217,8 @@ socket.pearsoned.com##+js(set, initializeNewRelic, noopFunc)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/18516
 ||click.discord.com^$badfilter
+
+! wunderground.com/wundermap gaps fix
+! https://github.com/uBlockOrigin/uAssets/issues/22408
+www.wunderground.com##.content-wrap #inner-wrap:style(height: 100vh !important;)
+www.wunderground.com##body wu-header:style(margin-top: 0px !important;)


### PR DESCRIPTION
Fixes #22408.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.wunderground.com/wundermap`

### Describe the issue

See #22408. Weather Underground's Wundermap shows gaps on the page top or bottom when ads are blocked.

### Screenshot(s)

Screenshots in #22408.

### Versions

- Browser/version: Firefox: 115
- uBlock Origin version: uBlock Origin: 1.55.0

### Settings

- Defaults across the board.

### Notes

See #22408 for further details, including culprit CSS rules.