### PR TITLE
Two changes to badlists

### DIFF
--- a/filters/badlists.txt
+++ b/filters/badlists.txt
@@ -25,9 +25,9 @@ https://www.joinhoney.com/whitelist/honey-smart-shopping.txt
 https://slickdeals.net/attachment/extension/allowlist.txt
 https://easylist-downloads.adblockplus.org/exceptionrules.txt
 https://letyshops.com/adblock.txt
-https://work.ink/adblock-whitelist.txt
 https://www.aadvantageeshopping.com/adBlockWhitelist.php
 https://multiup.org/list_adblock.txt
+https://multiup.io/list_adblock.txt
 https://downloads.zohocdn.com/ulaa-browser/release/adb/stable/ulaa-filters.txt
 
 # https://www.reddit.com/r/uBlockOrigin/comments/143k8lm/


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://work.ink/adblock-whitelist.txt`

This URL returns a 404

`https://multiup.org/list_adblock.txt`
Redirects to `https://multiup.io/list_adblock.txt`

### Describe the issue

This PR removes the work.ink list as it no longer exists.
Additionally, it adds a new URL for the MultiUp list. I have not seen any cases of users subscribing to that new URL.
Thanks

### Screenshot(s)

work.ink returning a 404 for /adblock-whitelist.txt
![image](https://github.com/uBlockOrigin/uAssets/assets/84232764/2ac744e0-cb55-4916-a20f-c1597457f4bd)


### Versions

N/A

### Settings

N/A

### Notes

Sorry for not following the PR template.
