### PR TITLE
Block LAN exception for Folding@Home

### DIFF
--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -98,7 +98,7 @@
 ! https://github.com/uBlockOrigin/uAssets/pull/20768
 @@||127.0.0.1^$3p,domain=musicbrainz.org
 !
-! 
+! https://github.com/uBlockOrigin/uAssets/pull/22475
 @@||127.0.0.1^$domain=client.foldingathome.org
 !
 ! ——— END

--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -98,4 +98,7 @@
 ! https://github.com/uBlockOrigin/uAssets/pull/20768
 @@||127.0.0.1^$3p,domain=musicbrainz.org
 !
+! 
+@@||127.0.0.1^$domain=client.foldingathome.org
+!
 ! ——— END


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://client.foldingathome.org/`

### Describe the issue

`client.foldingathome.org` is the official web UI for the Folding@Home distributed computing project. The "Block Outsider Intrusion into LAN" filter prevents it from connecting to the client daemon running on `localhost:7396`.

### Screenshot(s)

![image](https://github.com/kouwei32/uAssets/assets/29967594/93b6fd07-f5fd-403b-829f-d5a58d54c303)

### Versions

- Browser/version: Firefox 115.7.0esr
- uBlock Origin version: 1.55.0

### Settings

N/A

### Notes

Simple exception filter: `@@||127.0.0.1^$domain=client.foldingathome.org`
Tested to work with this added, and stop working when removed.
