### PR TITLE
address fdownloader.net leftover modal ad

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -550,3 +550,6 @@ skyve.io##.wrapper:style(min-height:inherit! important;)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/22543
 ||pubfuture-ad.com^$script,3p,redirect-rule=noopjs,domain=faqwiki.us
+
+! https://fdownloader.net/ leftover modal ad
+fdownloader.net##+js(rmnt, script, showAd)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://fdownloader.net/`

### Describe the issue

Go to `https://fdownloader.net/` paste `https://www.facebook.com/NASA/videos/this-week-nasa/711678027593724/`& click download twice.

### Screenshot(s)

<details>
<summary>Screen</summary>

![2024-02-18_171107](https://github.com/uBlockOrigin/uAssets/assets/111344219/f6f5ffec-85db-4ffb-842d-e0b6235bf6db)
</details>

### Versions

- Browser/version: Google Chrome 121.0.6167.185, Firefox 122.0.1
- uBlock Origin version: 1.55.0

### Settings

uBO's default
