### PR TITLE
Fixes #22676

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -948,7 +948,7 @@ coursera.org##+js(no-fetch-if, eventing)
 ! ||mngusr.com^
 
 ! https://github.com/uBlockOrigin/uAssets/issues/22676
-||analytics.strapi.io/api/v2/track^
+||analytics.strapi.io^
 
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -947,5 +947,8 @@ coursera.org##+js(no-fetch-if, eventing)
 ! https://github.com/uBlockOrigin/uAssets/issues/22631#issuecomment-1962238669
 ! ||mngusr.com^
 
+! https://github.com/uBlockOrigin/uAssets/issues/22676
+||analytics.strapi.io/api/v2/track^
+
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
This happens on a locally hosted version of the Strapi CMS.

The API URL it's trying to access:
`https://analytics.strapi.io/api/v2/track`

### Describe the issue
Self hosted version of Strapi accesses an analytics URL.

While the server administrator can disable this by setting the STRAPI_TELEMETRY_DISABLED environment variable, I still think UBlock should filter this.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: 123.0
- uBlock Origin version: 1.56.0

### Settings

- Just Defaults

### Notes

I have not tested this on the Strapi Cloud version of Strapi.