### PR TITLE
webtoons.com breakage fix

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -356,10 +356,6 @@ endbasic.dev,jmmv.dev##+js(no-xhr-if, method:POST)
 /?v=eyI*sImgiOiJodHRwczovL$image,1p
 !/^https?:\/\/[-.0-9a-z]+\/script\.js$/$script,1p,strict3p,match-case
 
-! https://www.reddit.com//r/uBlockOrigin/comments/u4ef87/webtoons_redirects_to_loginfracom_and_back_to/
-webtoons.com##+js(set, ccsrv, '')
-webtoons.com##+js(set, lcs_SerName, '')
-
 ! https://github.com/uBlockOrigin/uAssets/issues/13059
 ||hdslb.com/bfs/cm/cm-sdk/static/js/bili-collect.js$script,redirect=noop.js,domain=bilibili.com,important
 


### PR DESCRIPTION
### URL(s) where the issue occurs

`webtoons.com`

### Describe the issue

Logging in from the pop-up is impossible with uBlock-Privacy filter enabled.

**Steps to reproduce:**
Enable uBlock-Privacy filter. When on an episode page, click any button that requires to be logged-in (like, subscribe, upvote comment etc.). A popup appears with options to log in (e-mail, Line account, Google account etc.). Clicking any button doesn't do anything. Uncaught error in console "Cannot read properties of undefined ('serviceZone')".

**Cause:**
The uBlock monitoring feature displays `+js(set-constant, lcs_SerName, )` and `+js(set-constant, ccsrv, )` as blocked by uBlock-Privacy filter, however those two calls seem to be vital for login-in pop up to work properly.
This is also the only non-third-party script that is blocked on the site.
Removing the two `webtoons.com##+js` entries from uBlock-Privacy filter list also fixes the issue.
The issue persists when either of those two is still enabled, both need to be removed.

### Versions

- Browser/version: Chromium 122
- uBlock Origin version: 1.56.0

### Settings

Other default filters don't impact this breakage, only the ublock-Privacy one.

### Notes

From the comment attached to these two filters I assume they were added over a year ago due to another breakage regarding logging-in page.
Webtoons changed their login page less than a month ago, those two filters not only seem unnecessary anymore, but also break the current version of the site.