### PR TITLE
Address revancedapps[.]com and other similar websites

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3457,6 +3457,7 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ! https://github.com/uBlockOrigin/uAssets/pull/17469
 ! https://github.com/uBlockOrigin/uAssets/issues/18857
 ! https://github.com/uBlockOrigin/uAssets/pull/19580
+! https://github.com/hagezi/dns-blocklists/issues/2288
 ||revanced.*^$all,from=~revanced.app,to=~revanced.app
 ||revancedapk.*^$all,domain=~revanced.app
 ||revancedapp.*^$all,domain=~revanced.app
@@ -3479,8 +3480,7 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||vanced-official.com^$all,domain=~revanced.app
 ||vanced.pro^$all,domain=~revanced.app
 ||vancedmanager.*^$all,domain=~revanced.app
-! https://github.com/hagezi/dns-blocklists/issues/2288
-||revancedapps.$all,domain=~revanced.app
+||revancedapps.*^$all,domain=~revanced.app
 ! LuckyPatcher - Official site: luckypatchers.com
 ! https://old.reddit.com/r/luckypatcher/comments/rawq9f/what_is_the_official_website/
 ! https://old.reddit.com/r/luckypatcher/comments/aln5tj/official_download_for_lucky_patcher/

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3479,6 +3479,8 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||vanced-official.com^$all,domain=~revanced.app
 ||vanced.pro^$all,domain=~revanced.app
 ||vancedmanager.*^$all,domain=~revanced.app
+! https://github.com/hagezi/dns-blocklists/issues/2288
+||revancedapps.$all,domain=~revanced.app
 ! LuckyPatcher - Official site: luckypatchers.com
 ! https://old.reddit.com/r/luckypatcher/comments/rawq9f/what_is_the_official_website/
 ! https://old.reddit.com/r/luckypatcher/comments/aln5tj/official_download_for_lucky_patcher/


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://revancedapps.com/` (malicious)
`revancedapps.example` ([safe way to test rule coverage](https://en.wikipedia.org/wiki/.example))

### Describe the issue

While revancedapp.[TLD] is covered by existing rules, revancedapp**s**.[TLD] is not.
[As this pattern is being used in the wild](https://github.com/hagezi/dns-blocklists/issues/2288), I thought it pertinent to add a rule for it.
Thank you

### Screenshot(s)



### Versions

- Browser/version: Firefox 123.0 (64-bit)
- uBlock Origin version: 1.56.1b11

### Settings

Irrelevant, issue can be confirmed by rule examination.

### Notes

Full credit to @damianir750 for finding the original malicious website.
