### PR TITLE
Add McGraw Hill copy-paste prevention

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7456,3 +7456,8 @@ helldivers.io###gwvideo
 ! https://bongdaplus.vn/ - anti right click, select
 bongdaplus.vn##+js(aeld, mousedown, undefined, elements, body)
 bongdaplus.vn##+js(set, document.oncontextmenu, trueFunc)
+
+! McGraw Hill e-textbooks - copy paste
+prod.reader-ui.prod.mheducation.com##+js(aeld, mouseup)
+prod.reader-ui.prod.mheducation.com##*:remove-attr(oncopy)
+prod.reader-ui.prod.mheducation.com##*:remove-attr(oncut)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://prod.reader-ui.prod.mheducation.com/epub/epub-id`

### Describe the issue

Attempts to highlight text and copy on a McGraw Hill e-textbook results in a popup. The first rule disables the popup completely. However, the site still prevents copy-pasting. The second and third rules remove the `oncut` and `oncopy` attributes from all elements, which are set to `return false` in a desperate attempt to sabotage students from actually using the material they paid for.

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/13326074/ab4fbe5d-7080-496e-a62c-aa90f33d4442)

### Versions

- Browser/version: Firefox 123.0.1
- uBlock Origin version: 1.56.0


### Notes

I've tried removing the first rule in order to preserve the popup but also get copy-paste working. However, when the popup is dismissed, the text is unselected automatically, preventing copying.