### PR TITLE
Privacy: add compute-pressure permission policy

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -574,6 +574,7 @@ bikesales.com.au##^html > head > :is([name="canonical"], [rel="canonical"]):not(
 ! https://github.com/uBlockOrigin/uAssets/issues/21516
 !#if env_chromium
 *$permissions=browsing-topics=(),from=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
+*$permissions=compute-pressure=(),from=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 *$permissions=idle-detection=(),from=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 *$permissions=join-ad-interest-group=(),from=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 *$permissions=run-ad-auction=(),from=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local


### PR DESCRIPTION
### Describe the issue

Google Chrome (Chromium) [125](https://groups.google.com/a/chromium.org/g/blink-dev/c/7leKysvPZWk/m/6Jh9ZZHTAgAJ) will ship with [Compute Pressure API](https://www.w3.org/TR/compute-pressure/) enabled by default. This API had been in development since March 2021 and at the time faced [criticism from Apple](https://lists.webkit.org/pipermail/webkit-dev/2021-May/031853.html). Apple expressed privacy concerns (cross-domain message passing, device fingerprinting) and claimed that it would be difficult to express the system load as a single value since modern systems are multi-core, support multiple threads per core, dynamic boost and even may be heterogeneous (performance and efficiency cores), support simultaniously on-die GPUs and dedicated GPUs. In 2022, [Zoom claimed to need](https://github.com/w3c/compute-pressure/issues/14) such an API for determining appropriate video feed resolutions and some more advanced features (like background blur). Unfortunately, apparently Zoom never followed up demonstrating how this API would actually help.

### Versions

- Browser/version: Google Chrome Canary 124.0.6367.0
- uBlock Origin version: 1.56.0

### Settings

- None

### Notes

I believe that Compute Pressure API will go the way of Battery Status API. Both APIs basically answer the question how wasteful the website should be. In both cases the website could obtain better information by asking the user directly or just measuring its own performance (e.g., dropped frames). Both APIs are impractical for legitimate use, but will **not** actually expose much fingerprinting resolution to be a real privacy concern. Still, why not block something potentially harmful and completely useless?