### PR TITLE
Add z-library clone sites in badware

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3071,6 +3071,9 @@ torrdroidforpc.com##[href^="http://slugmefilehos.xyz/"]
 ||t-haihukikaku.online^$doc
 ||t-present.online^$doc
 ||rich-cash.site^$doc
+||z-lib.io^$all
+||z-lib.id^$all
+||zlibrary.to^$all
 
 ! https://twitter.com/1ZRR4H/status/1623067548781539339
 ||soft-pro.site^$all


### PR DESCRIPTION
### URL(s) where the issue occurs
https://z-lib.id

### Describe the issue

These website clone the UI of the popular Z-library project, Doesn't do anything (probably collect user/password from their fake login page) and marked as scam in official Z-lib website.