### PR TITLE
Adding phishing URL

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -984,7 +984,7 @@ tech4yougadgets.com##+js(aopr, Notification)
 ||adblock-pro-download.com^$all
 ||reepratic.com^$all
 ||5vcjzwb1tsnd82g.caflu87p1d.ru^$all
-||existingacountporbkun.italianaconserve.it^all
+||existingacountporbkun.italianaconserve.it^$all
 
 
 ! phishing /scam /malware

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -984,6 +984,7 @@ tech4yougadgets.com##+js(aopr, Notification)
 ||adblock-pro-download.com^$all
 ||reepratic.com^$all
 ||5vcjzwb1tsnd82g.caflu87p1d.ru^$all
+||existingacountporbkun.italianaconserve.it^all
 
 
 ! phishing /scam /malware


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://existingacountporbkun.italianaconserve.it/?46525SU=4TI90K00D`

### Describe the issue

URL is being used as part of a phishing scam being sent to Porkbun customers. Screenshot of the email below.

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/63184938/e1c22313-b6f7-4d52-bf85-bad3b7399216)


### Versions

- Browser/version: Firefox 124.0.2
- uBlock Origin version: 1.57.0

### Settings

- No changes

### Notes

Have not only received this phishing email myself, but also analysed with VirusTotal. Have also reported to Google Safe Browsing and Microsoft.
