### PR TITLE
Block survivopedia ads

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -1295,3 +1295,8 @@ lemino.docomo.ne.jp##+js(no-fetch-if, doubleclick.net)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/23292
 ||h.seznam.cz^$badfilter
+
+! https://github.com/uBlockOrigin/uAssets/issues/23329
+! https://github.com/easylist/easylist/pull/19008
+! changes width from 75% to 100% because the 25% was only removed to make space for ads
+www.survivopedia.com##.eltdf-column1:style(width: 100%!important)


### PR DESCRIPTION
This, along with https://github.com/easylist/easylist/pull/19008, fixes #23329

### URL(s) where the issue occurs

https://www.survivopedia.com/10-common-plants-you-can-turn-into-flour-part-ii/
https://www.survivopedia.com/edc-guidelines-for-the-responsible-gun-carrier/
etc

### Settings

None
