### PR TITLE
Fix "importgant" typo in a filter

### DIFF
--- a/filters/ubo-link-shorteners.txt
+++ b/filters/ubo-link-shorteners.txt
@@ -490,7 +490,7 @@ exego.app,cutlink.net,cutsy.net,cutyurls.com,cutty.app,cutnet.net##.steps-to-ear
 exego.app,cutlink.net,cutsy.net,cutyurls.com,cutty.app,cutnet.net##+js(aeld, click, handleClick)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/20776
-adcrypto.net,aduzz.com,bitcrypto.info,hbz.us,savego.org,owsafe.com###wpsafe-link:style(display: block !importgant;)
+adcrypto.net,aduzz.com,bitcrypto.info,hbz.us,savego.org,owsafe.com###wpsafe-link:style(display: block !important;)
 aduzz.com,bitcrypto.info,owsafe.com##+js(no-fetch-if, ads)
 !aduzz.com,bitcrypto.info##+js(set, wpsafelinkCount, 0)
 ! https://github.com/uBlockOrigin/uAssets/discussions/17361#discussioncomment-8529115


### PR DESCRIPTION
`display: block !importgant` is invalid CSS, so this filter has no effect at the moment.