### PR TITLE
fix #23456: 'Block Outsider Intrusion into LAN' filter list breaks Figma's 'Open in Desktop App' feature

### DIFF
--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -98,6 +98,8 @@
 !
 ! ——— EXCEPTIONS
 !
+! https://github.com/uBlockOrigin/uAssets/issues/23456
+@@||127.0.0.1^$xhr,domain=figma.com
 ! https://github.com/uBlockOrigin/uAssets/issues/19005
 @@||127.0.0.1^$xhr,domain=battlelog.battlefield.com
 !

--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -100,6 +100,7 @@
 !
 ! https://github.com/uBlockOrigin/uAssets/issues/23456
 @@||127.0.0.1^$xhr,domain=figma.com
+!
 ! https://github.com/uBlockOrigin/uAssets/issues/19005
 @@||127.0.0.1^$xhr,domain=battlelog.battlefield.com
 !


### PR DESCRIPTION
This fixes #23456 - see the issue for the full details. I can duplicate them here if necessary.

This fixes the issue by adding an exception for figma.com. I see similar exceptions in the same filter list, so I'm hoping this is a quick + simple fix.