### PR TITLE
infinitytweet.com: badware

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -3981,6 +3981,7 @@ oltacidergisi.com##+js(acs, atob, minimalDrainValue)
 ||anyplacehere.store^$all
 ||infinitytweet.me^$all
 ||infinitweet.com^$all
+||infinitytweet.com^$all
 
 ! https://www.bitdefender.com/blog/labs/ai-meets-next-gen-info-stealers-in-social-media-malvertising-campaigns/
 /^https:\/\/(?:ai|art|get)?-?midjourney(?:s|ai)[^\/]+\//$doc,domain=~midjourney.com|~edu|~gov


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://infinitytweet.com`
`https://anyplacehere.store`
`https://infinitytweet.me`
`https://infinitweet.com`

### Describe the issue

infinitytweet.com is a variant of roundyearfun.org (#18388).

1. Both domain resolve to `67.205.42.35` ([list of domains hosted on this IP](https://www.virustotal.com/gui/ip-address/67.205.42.35/relations))
2. Use the same API, `anyplacehere.store`

### Notes

- #18388
- #20090
- #23183