### PR TITLE
Update filters.txt

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -5776,10 +5776,6 @@ venstrike.jimdofree.com##+js(aeld, load, nextFunction)
 @@||programasve.blogspot.com^$ghide
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3208
-||maxcheaters.com/*.gif$image
-@@||maxcheaters.com/uploads2/country/*.gif$image
-maxcheaters.com##.ipsContained.ipsImage
-maxcheaters.com##+js(nostif, adblock)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3206
 mivo.com##.ads


### PR DESCRIPTION
remove maxcheaters.com domain from the list. these banners are used for website income. it is not spam.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.maxcheaters.com`


### Describe the issue

Please remove "maxcheaters.com" domain. Banners are not used for spam , its the main income for website. 

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Chrome/Any
- uBlock Origin version: Latest

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
