### PR TITLE
Add robloxexecuter.framer.website due to spreading of malware.

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -800,7 +800,7 @@ tech4yougadgets.com##+js(aopr, Notification)
 ||gameplayer.click^$all
 ||ryosx.cc^$doc
 ||kingexploits.com^$doc
-||robloxexecuter.framer.website^&doc
+||robloxexecuter.framer.website^$doc
 ! http://92.118.151.48/6B6FGGWm
 ||92.118.151.48^$all
 ! https://cloud-folder.org/KRvjWueEcl/

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -800,6 +800,7 @@ tech4yougadgets.com##+js(aopr, Notification)
 ||gameplayer.click^$all
 ||ryosx.cc^$doc
 ||kingexploits.com^$doc
+||robloxexecuter.framer.website^&doc
 ! http://92.118.151.48/6B6FGGWm
 ||92.118.151.48^$all
 ! https://cloud-folder.org/KRvjWueEcl/


### PR DESCRIPTION
robloxexecuter.framer.website is spreading malware through advertising of a Roblox "executor".