### PR TITLE
Fixed issue with raenonx.cc in quick-fixes.txt

### DIFF
--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -92,7 +92,7 @@ download.megaup.net##+js(rpnt, script, /\[("|'|`)name("|'|`)]\s*!=/, ['name']!= 
 ! https://github.com/uBlockOrigin/uAssets/issues/21353
 raenonx.cc##body > div[class] > style:first-child + .w-full:has(> .button-clickable-bg-opaque > .transform-smooth > svg)
 raenonx.cc##.w-full:has(> style + div > style + div .adsbygoogle)
-raenonx.cc##[id^="headlessui-"] [role="dialog"]:has(a[href="https://pks.raenonx.cc/en/docs/view/help/disable-adblock"])
+raenonx.cc##[id^="headlessui-"] [role="dialog"]:has(.w-full > .w-full > .markdown > p > a[href="https://pks.raenonx.cc/en/docs/view/help/disable-adblock"])
 raenonx.cc##.w-full > div[class*="min-h-"]:has(> style + div > .markdown > p > a[href*="adblock"])
 raenonx.cc##.size-full > .w-full > .flex-col > style + div:has-text(blocker)
 raenonx.cc##html[style*="hidden"]:style(overflow: visible !important;)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://pks.raenonx.cc`

### Describe the issue

The previous line broke the "Add Pokémon"-button after the element was loaded once.

### Versions

- Browser/version: Firefox 126.0
- uBlock Origin version: 1.57.2

### Notes

Since the "Add Pokémon"-button interface and the popup shares common elements a more thorough filter is needed.
This change fixes the issue with the "Add Pokémon"-button interface but keeps the popup gone.
