### PR TITLE
Add Keenetic domain to LAN block filter

### DIFF
--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -73,6 +73,7 @@
 ||homerouter.cpe^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||huaweimobilewifi.com^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||localbattle.net^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
+||my.keenetic.net^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||myfritz.box^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||mygateway^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||mobile.hotspot^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local


### PR DESCRIPTION
Keenetic has the domain `my.keenetic.net` available by default to access its [router configuration page](https://help.keenetic.com/hc/en-us/articles/360001923020-Web-interface).