### PR TITLE
Fix #22425

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -1866,3 +1866,6 @@ porno-baguette.com##+js(set-cookie, ppndr, 1)
 soccerinhd.com##+js(set, checkAdsStatus, noopFunc)
 soccerinhd.com##+js(no-fetch-if, googlesyndication)
 soccerinhd.com##+js(acs, document.documentElement, break;case $.)
+
+! https://github.com/uBlockOrigin/uAssets/issues/22425
+ytlarge.com##.adsbygoogle


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://ytlarge.com/`

### Describe the issue

There are large gaps on the website as described in #22425.

### Screenshot(s)

Before adding this filter:

![image](https://github.com/uBlockOrigin/uAssets/assets/31394614/b6231fd5-0bbe-44b8-8618-35b044432c1e)

After adding this filter:

![image](https://github.com/uBlockOrigin/uAssets/assets/31394614/19080dbf-5e0a-409e-93dc-ef8580dc6f85)

### Versions

- Browser/version: Chrome 125.0.6422.78
- uBlock Origin version: 1.58.0

### Settings

Added `ytlarge.com##.adsbygoogle` to filters.

### Notes

Not much else to say. I added a filter and it seemed to fix it.
