### PR TITLE
Add GeoFS annoyance to filter list

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7597,3 +7597,6 @@ pronews.gr##.wrap-banner
 twitter.com,x.com,~platform.twitter.com##+js(trusted-replace-xhr-response, '/,"expanded_url":"([^"]+)","url":"[^"]+"/g', ',"expanded_url":"$1","url":"$1"', /graphql)
 platform.twitter.com##+js(trusted-replace-xhr-response, '/,"expanded_url":"([^"]+)","indices":([^"]+)"url":"[^"]+"/g', ',"expanded_url":"$1","indices":$2"url":"$1"', /tweet-result)
 !#endif
+
+! https://www.geo-fs.com
+www.geo-fs.com##.geofs-adsense-container.geofs-adbanner


### PR DESCRIPTION
This removes the annoying sidebar at the right in GeoFS

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.geo-fs.com/geofs.php?v=3.7`

### Describe the issue

This removes the annoying sidebar(where ads are usually shown) at the right in GeoFS.

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/45824021/e7cb581c-0a6d-40d8-b660-3eaeda5e51be)

### Versions

- Browser/version: chrome 126.0.6478.55 
- uBlock Origin version: 1.58.0

### Settings

- Add "www.geo-fs.com##.geofs-adsense-container.geofs-adbanner" to the filter list
