### PR TITLE
[nsfw] address uflash.tv breakage

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -7783,10 +7783,12 @@ topflix.*##+js(aopr, console.clear)
 @@||uflash.tv^$ghide
 uflash.tv#@#.ad
 @@||exosrv.com/popunder1000.js$script,domain=uflash.tv
-uflash.tv##+js(aopr, open)
 uflash.tv##+js(aopw, ads_priv)
 uflash.tv##.advertisement
 uflash.tv##[id^="ad-float"]
+! https://github.com/uBlockOrigin/uAssets/issues/24103
+uflash.tv##+js(nowoif, adblock, 1, obj)
+uflash.tv##+js(no-fetch-if, ujsmediatags method:HEAD)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4776
 jizzbunker.com,xxxdan.com##+js(aopw, spot)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

NSFW `http://www.uflash.tv/video/96753/0001-luodong-spiritual-massage-applecounty305`

### Describe the issue

Video won't load (video tag is not inserted into the DOM).
fixes #24103

### Versions

- Browser/version: Firefox 127.0
- uBlock Origin version: 1.58.0

### Notes

Here is the (deobfuscated) script that handles loading the video into the page:
```
(function () {
    let isPopupBlocked = false;
    $("#flash").css({
        'width': "100%",
        'height': "600px"
    });
    function tryOpenPopup() {
        var adblockPopup = window.open("adblock", '', "width=1,height=1");
        try {
            adblockPopup.close();
            return false;
        } catch (ex) {
            isPopupBlocked = true;
            $("#flash").html("<video id=\"videoplayer\" width=\"100%\" height=\"600\"  controls=\"controls\" ><source src=\"/media/videos/popblock.mp4\" type=\"video/mp4\"></video>");
        }
    }
    setTimeout(function () {
        tryOpenPopup();
        if (!isPopupBlocked) {
            fetch("https://www.xadsmart.com/ctle/ujsmediatags.min.js", {
                'method': "HEAD",
                'mode': "no-cors",
                'cache': "no-store"
            }).then(() => {
                $.post("/ajax/getvideo", {
                    'vid': window.location.pathname.split('/')[2]
                }, function (response) {
                    if (response.error) {
                        $("#flash").html("<div style=\"width:100%;height:600px;text-align:center;color:#f00;font-size:20px\">" + response.error + "</div>");
                    } else {
                        $("#flash").html("<video id=\"videoplayer\" width=\"100%\" height=\"600\"  controls=\"controls\" ><source src=\"" + response.video_src + "\" type=\"video/mp4\"></video>");
                    }
                }, "json");
            }).catch(() => {
                isPopupBlocked = true;
                $("#flash").html("<video id=\"videoplayer\" width=\"100%\" height=\"600\"  controls=\"controls\" ><source src=\"/media/videos/adblock.mp4\" type=\"video/mp4\"></video>");
            });
        }
    }, 0);
})();
```

We can see that it won't load the video (the POST request to `/ajax/getvideo`) if:
- it is unable to open (and close) a popup.
- it is unable to fetch a script from `https://www.xadsmart.com/ctle/ujsmediatags.min.js`.

The solution I propose (confirmed to work on my side) is:
- remove the filter `uflash.tv##+js(aopr, open)` as this will prevent the script from running to completion.
- add the filter `uflash.tv##+js(nowoif, adblock, 1, obj)` to defuse the opening of the popup and return a fake window object.
- add the filter `uflash.tv##+js(no-fetch-if, ujsmediatags method:HEAD)` to defuse the call to `https://www.xadsmart.com/ctle/ujsmediatags.min.js` and still return a valid empty response.