### PR TITLE
Update privacy.txt

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1000,3 +1000,6 @@ dev.to##+js(cookie-remover, ahoy_visit)
 
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt
+
+! https://docs.wiris.com/api/integrations/jsdoc/telemetry.js.html
+||data.wiris.cloud/telemetry*


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://data.wiris.cloud/telemetry`

### Describe the issue

Added data.wiris.cloud/telemetry* endpoint to the privacy.txt list.
This endpoint is used to send telemetry data about Wiris Math plugin