### PR TITLE
Revert: modrinth.com: ads

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2112,10 +2112,6 @@ rock.porn##a[href^="https://wittered-mainging.com/"]
 ! https://github.com/uBlockOrigin/uAssets/issues/23348
 www.tiktok.com##+js(json-prune-fetch-response, itemList.[-].ad_info.ad_id, , propsToMatch, url:api/recommend/item_list/)
 
-! https://github.com/uBlockOrigin/uAssets/issues/24130
-modrinth.com##.markdown-body > p:last-of-type > a > img
-||wsrv.nl/?url=https%3A%2F%2Ftr7zw.dev%2Fimg%2Fshockbyte_black.png$domain=modrinth.com
-
 ! https://github.com/uBlockOrigin/uAssets/issues/24142
 ||video-ads-module.ad-tech.nbcuni.com^
 


### PR DESCRIPTION
### URL(s) where the issue occurs

https://modrinth.com/mod/not-enough-animations
https://modrinth.com/mod/entitytexturefeatures
https://modrinth.com/mod/modernfix
https://modrinth.com/mod/moreculling < bypass example

### Describe the issue

In the commit 088808a from issue #24130
Please read through the attached issue.

It blocks user generated content, and pretty stupidly I might add. Not only is it using a `last-of-type` which can really easily be blocked [[example]](https://modrinth.com/mod/moreculling) but it also has a very targeted check towards @tr7zw domain.  Obviously no real thought or effort got put into these checks.

UBlock doesn't block user generated content, until now. Which means we should now be fearful that they will block a lot more. Such as: Youtube descriptions, user forum footers, personal websites, github descriptions, etc...
The fact that UBlock isn't making sure to check the kind of blocks they are adding, says a lot.

### Screenshot(s)

Example of the obviously lazy implementation.
With UBlock:
![image](https://github.com/uBlockOrigin/uAssets/assets/28154542/82c3461b-2439-4c58-a7d7-0c2a8bc76b4e)
Without UBlock:
![image](https://github.com/uBlockOrigin/uAssets/assets/28154542/032fae3e-aea3-4d19-ae43-38c38bd070bd)
Thanks @hypherionmc for the images.

### Notes
