### PR TITLE
 Add curseforge and additional ad domains for fix of #24130 

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2149,6 +2149,5 @@ game8.co##.js-side-ads-movie-container:remove()
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24130
 modrinth.com##section.normal-page__content :is([href^="https://shockbyte.com/partner/"],[href^="https://billing.kinetichosting.net/"],[href^="https://bisecthosting.com/"],[href^="https://meloncube.net/"],[href^="https://scalacube.com/"],[href^="https://billing.ember.host/"],[href^="https://nodecraft.com/"]) > img
-curseforge.com##section.project-description :is([href*="shockbyte.com"],[href*="billing.kinetichosting.net"],[href*="bisecthosting.com"],[href*="meloncube.net"],[href*="scalacube.com"],[href*="billing.ember.host"],[href*="nodecraft.com"]) > img
-
+curseforge.com##section.project-description [href^="/linkout?remoteUrl=http"]:is([href*="shockbyte.com"],[href*="billing.kinetichosting.net"],[href*="bisecthosting.com"],[href*="meloncube.net"],[href*="scalacube.com"],[href*="billing.ember.host"],[href*="nodecraft.com"]) > img
 

--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2149,4 +2149,4 @@ game8.co##.js-side-ads-movie-container:remove()
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24130
 modrinth.com##section.normal-page__content :is([href^="https://shockbyte.com/partner/"],[href^="https://billing.kinetichosting.net/"],[href^="https://bisecthosting.com/"],[href^="https://meloncube.net/"],[href^="https://scalacube.com/"],[href^="https://billing.ember.host/"],[href^="https://nodecraft.com/"]) > img
-legacy.curseforge.com,curseforge.com##:is(section.project-description,div.project-detail__content) [href^="/linkout?remoteUrl=http"]:is([href*="shockbyte.com"],[href*="billing.kinetichosting.net"],[href*="bisecthosting.com"],[href*="meloncube.net"],[href*="scalacube.com"],[href*="billing.ember.host"],[href*="nodecraft.com"]) > img
+curseforge.com##:is(section.project-description,div.project-detail__content) [href^="/linkout?remoteUrl=http"]:is([href*="shockbyte.com"],[href*="billing.kinetichosting.net"],[href*="bisecthosting.com"],[href*="meloncube.net"],[href*="scalacube.com"],[href*="billing.ember.host"],[href*="nodecraft.com"]) > img

--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2149,5 +2149,4 @@ game8.co##.js-side-ads-movie-container:remove()
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24130
 modrinth.com##section.normal-page__content :is([href^="https://shockbyte.com/partner/"],[href^="https://billing.kinetichosting.net/"],[href^="https://bisecthosting.com/"],[href^="https://meloncube.net/"],[href^="https://scalacube.com/"],[href^="https://billing.ember.host/"],[href^="https://nodecraft.com/"]) > img
-curseforge.com##section.project-description [href^="/linkout?remoteUrl=http"]:is([href*="shockbyte.com"],[href*="billing.kinetichosting.net"],[href*="bisecthosting.com"],[href*="meloncube.net"],[href*="scalacube.com"],[href*="billing.ember.host"],[href*="nodecraft.com"]) > img
-
+legacy.curseforge.com,curseforge.com##:is(section.project-description,div.project-detail__content) [href^="/linkout?remoteUrl=http"]:is([href*="shockbyte.com"],[href*="billing.kinetichosting.net"],[href*="bisecthosting.com"],[href*="meloncube.net"],[href*="scalacube.com"],[href*="billing.ember.host"],[href*="nodecraft.com"]) > img

--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2153,3 +2153,6 @@ modrinth.com,curseforge.com##section.normal-page__content [href^="https://billin
 modrinth.com,curseforge.com##section.normal-page__content [href^="https://bisecthosting.com/"] > img
 modrinth.com,curseforge.com##section.normal-page__content [href^="https://meloncube.net/"] > img
 modrinth.com,curseforge.com##section.normal-page__content [href^="https://scalacube.com/"] > img
+modrinth.com,curseforge.com##section.normal-page__content [href^="https://billing.ember.host/"] > img
+modrinth.com,curseforge.com##section.normal-page__content [href^="https://nodecraft.com/"] > img
+

--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2148,11 +2148,19 @@ myp2p.*##a[rel="sponsored"]
 game8.co##.js-side-ads-movie-container:remove()
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24130
-modrinth.com,curseforge.com##section.normal-page__content [href^="https://shockbyte.com/partner/"] > img
-modrinth.com,curseforge.com##section.normal-page__content [href^="https://billing.kinetichosting.net/"] > img
-modrinth.com,curseforge.com##section.normal-page__content [href^="https://bisecthosting.com/"] > img
-modrinth.com,curseforge.com##section.normal-page__content [href^="https://meloncube.net/"] > img
-modrinth.com,curseforge.com##section.normal-page__content [href^="https://scalacube.com/"] > img
-modrinth.com,curseforge.com##section.normal-page__content [href^="https://billing.ember.host/"] > img
-modrinth.com,curseforge.com##section.normal-page__content [href^="https://nodecraft.com/"] > img
+modrinth.com##section.normal-page__content [href^="https://shockbyte.com/partner/"] > img
+modrinth.com##section.normal-page__content [href^="https://billing.kinetichosting.net/"] > img
+modrinth.com##section.normal-page__content [href^="https://bisecthosting.com/"] > img
+modrinth.com##section.normal-page__content [href^="https://meloncube.net/"] > img
+modrinth.com##section.normal-page__content [href^="https://scalacube.com/"] > img
+modrinth.com##section.normal-page__content [href^="https://billing.ember.host/"] > img
+modrinth.com##section.normal-page__content [href^="https://nodecraft.com/"] > img
+curseforge.com##section.project-description [href*="shockbyte.com"] > img
+curseforge.com##section.project-description [href*="billing.kinetichosting.net"] > img
+curseforge.com##section.project-description [href*="bisecthosting.com"] > img
+curseforge.com##section.project-description [href*="meloncube.net"] > img
+curseforge.com##section.project-description [href*="scalacube.com"] > img
+curseforge.com##section.project-description [href*="billing.ember.host"] > img
+curseforge.com##section.project-description [href*="nodecraft.com"] > img
+
 

--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2148,6 +2148,8 @@ myp2p.*##a[rel="sponsored"]
 game8.co##.js-side-ads-movie-container:remove()
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24130
-modrinth.com##section.normal-page__content [href^="https://shockbyte.com/partner/"] > img
-modrinth.com##section.normal-page__content [href^="https://billing.kinetichosting.net/"] > img
-modrinth.com##section.normal-page__content [href^="https://bisecthosting.com/"] > img
+modrinth.com,curseforge.com##section.normal-page__content [href^="https://shockbyte.com/partner/"] > img
+modrinth.com,curseforge.com##section.normal-page__content [href^="https://billing.kinetichosting.net/"] > img
+modrinth.com,curseforge.com##section.normal-page__content [href^="https://bisecthosting.com/"] > img
+modrinth.com,curseforge.com##section.normal-page__content [href^="https://meloncube.net/"] > img
+modrinth.com,curseforge.com##section.normal-page__content [href^="https://scalacube.com/"] > img

--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2148,19 +2148,7 @@ myp2p.*##a[rel="sponsored"]
 game8.co##.js-side-ads-movie-container:remove()
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24130
-modrinth.com##section.normal-page__content [href^="https://shockbyte.com/partner/"] > img
-modrinth.com##section.normal-page__content [href^="https://billing.kinetichosting.net/"] > img
-modrinth.com##section.normal-page__content [href^="https://bisecthosting.com/"] > img
-modrinth.com##section.normal-page__content [href^="https://meloncube.net/"] > img
-modrinth.com##section.normal-page__content [href^="https://scalacube.com/"] > img
-modrinth.com##section.normal-page__content [href^="https://billing.ember.host/"] > img
-modrinth.com##section.normal-page__content [href^="https://nodecraft.com/"] > img
-curseforge.com##section.project-description [href*="shockbyte.com"] > img
-curseforge.com##section.project-description [href*="billing.kinetichosting.net"] > img
-curseforge.com##section.project-description [href*="bisecthosting.com"] > img
-curseforge.com##section.project-description [href*="meloncube.net"] > img
-curseforge.com##section.project-description [href*="scalacube.com"] > img
-curseforge.com##section.project-description [href*="billing.ember.host"] > img
-curseforge.com##section.project-description [href*="nodecraft.com"] > img
+modrinth.com##section.normal-page__content :is([href^="https://shockbyte.com/partner/"],[href^="https://billing.kinetichosting.net/"],[href^="https://bisecthosting.com/"],[href^="https://meloncube.net/"],[href^="https://scalacube.com/"],[href^="https://billing.ember.host/"],[href^="https://nodecraft.com/"]) > img
+curseforge.com##section.project-description :is([href*="shockbyte.com"],[href*="billing.kinetichosting.net"],[href*="bisecthosting.com"],[href*="meloncube.net"],[href*="scalacube.com"],[href*="billing.ember.host"],[href*="nodecraft.com"]) > img
 
 


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://modrinth.com/resourcepack/dramatic-skys`
`https://modrinth.com/mod/tips`
`https://modrinth.com/mod/the-filler-update`
`https://modrinth.com/modpack/quantum-freedom`
`https://www.curseforge.com/minecraft/modpacks/technical-electrical`

### Describe the issue

Block additional domains that are used by modrinth and curseforge in-content banner ads. Added curseforge as an additional domain where this format of banner ad is common, but with a different element layout.

### Screenshot(s)

![Screenshot 2024-06-19 at 04 23 03](https://github.com/uBlockOrigin/uAssets/assets/173219075/983e0f73-8581-48fe-8c1e-26b94efc1578)
![Screenshot 2024-06-19 at 04 23 11](https://github.com/uBlockOrigin/uAssets/assets/173219075/ad48370d-3f80-4cae-a17d-161178c39c46)

### Versions

- Browser/version: Firefox 127
- uBlock Origin version: 1.58.0
- Basing my changes off of the latest commit related to these sites at the time.

### Settings

no changes

### Notes

none
