### PR TITLE
aha-music.com - hide Chromium extensions for Firefox users

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7608,3 +7608,8 @@ prompthero.com##body:style(overflow:initial!important)
 
 ! https://fancaps.net/anime/ adblock detection
 ||a.pub.network/fancaps-net/pubfig.min.js$script,redirect-rule=noopjs,domain=fancaps.net
+
+! extension buttons for other browsers
+!#if env_firefox
+aha-music.com##a[href*="/detail/"][target="_blank"]
+!#endif


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.aha-music.com/`

`https://www.aha-music.com/8bc80319a6da5d39a9647a1271552461`

### Describe the issue

Big buttons that add no value for Firefox users.

![buttons](https://github.com/uBlockOrigin/uAssets/assets/6733770/0ffa521d-9d41-4cd4-b974-35c233e1cc73)

![buttons 2](https://github.com/uBlockOrigin/uAssets/assets/6733770/05a9b6cf-dd30-4efe-a03c-737aaeedba92)

