### PR TITLE
Add polyfill for supplychain attack

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -4154,3 +4154,6 @@ oltacidergisi.com##+js(acs, atob, minimalDrainValue)
 ||infinityweet.me^$all
 ||infinityweet.com^$all
 ||anyplacehere.online^$all
+
+! https://sansec.io/research/polyfill-supply-chain-attack
+||polyfill.io^$all


### PR DESCRIPTION


### URL(s) where the issue occurs

`polyfill.io` / `cdn.polyfill.io`

### Describe the issue

This patch adds `polyfill.io` to badware.txt due to an ongoing supplychain attack using the domain and its subdomains.

Reference: 
https://sansec.io/research/polyfill-supply-chain-attack
