### PR TITLE
Add new Polyfill domain

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -4190,7 +4190,7 @@ oltacidergisi.com##+js(acs, atob, minimalDrainValue)
 ! https://www.bleepingcomputer.com/news/security/polyfillio-javascript-supply-chain-attack-impacts-over-100k-sites/
 ||polyfill.io^$all
 ||googie-anaiytics.com^$all
-! https://github.com/uBlockOrigin/uAssets/pull/242633
+! https://github.com/uBlockOrigin/uAssets/pull/24272
 ! https://www.bleepingcomputer.com/news/security/polyfill-claims-it-has-been-defamed-returns-after-domain-shut-down/
 ||polyfill.com^$all
 

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -4190,6 +4190,9 @@ oltacidergisi.com##+js(acs, atob, minimalDrainValue)
 ! https://www.bleepingcomputer.com/news/security/polyfillio-javascript-supply-chain-attack-impacts-over-100k-sites/
 ||polyfill.io^$all
 ||googie-anaiytics.com^$all
+! https://github.com/uBlockOrigin/uAssets/pull/242633
+! https://www.bleepingcomputer.com/news/security/polyfill-claims-it-has-been-defamed-returns-after-domain-shut-down/
+||polyfill.com^$all
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24248
 ||veilcurtin.world^$doc


### PR DESCRIPTION


<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`polyfill.com`

### Describe the issue

Unblocked malicious domain.

### Screenshot(s)

N/A

### Versions

- Browser/version: N/A
- uBlock Origin version: N/A

### Settings

- N/A

### Notes

This was first reported by @pojunen
[Polyfill[.]io has moved to polyfill[.]com after their domain was taken down](https://www.bleepingcomputer.com/news/security/polyfill-claims-it-has-been-defamed-returns-after-domain-shut-down/). Thanks
