### PR TITLE
Add polyfill-fastly.io CDN url

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -4217,6 +4217,10 @@ oltacidergisi.com##+js(acs, atob, minimalDrainValue)
 ! https://www.bleepingcomputer.com/news/security/polyfill-claims-it-has-been-defamed-returns-after-domain-shut-down/
 ||polyfill.com^$all
 
+! https://sansec.io/research/polyfill-supply-chain-attack
+! https://www.bleepingcomputer.com/news/security/polyfill-claims-it-has-been-defamed-returns-after-domain-shut-down/
+||polyfill-fastly.io^$all
+
 ! https://github.com/uBlockOrigin/uAssets/issues/24248
 ||veilcurtin.world^$doc
 ||yikesgroto.com^$doc


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.flaticon.com/`

### Describe the issue

Add Fastly's CDN URL for the Polyfill JS malware.

### Screenshot(s)

![firefox_ADUjB92jsP](https://github.com/uBlockOrigin/uAssets/assets/71477161/896cecae-6134-42be-aad8-1c913789d33d)

### Versions

- Browser/version: Firefox 127.0.2 (64-bit)
- uBlock Origin version: 1.58.0

### Settings

- N/A

### Notes

Adds Fastly's CDN URL for the latest Polyfill JS malware to the filter list.
Blocks the URL from downloading the malicious Javascript when visiting websites that still utilize it.
