### PR TITLE
Add exemption for bloxstrap.pizzaboxer.xyz on bloxstrap.*

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -4237,7 +4237,7 @@ oltacidergisi.com##+js(acs, atob, minimalDrainValue)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24123
 ! https://github.com/pizzaboxer/bloxstrap/blob/main/README.md
-||bloxstrap.*^$doc
+||bloxstrap.*^$doc,domain=~bloxstrap.pizzaboxer.xyz,to=~bloxstrap.pizzaboxer.xyz
 ||bloxstrapmenu.com^$doc
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24323


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://bloxstrap.pizzaboxer.xyz

### Describe the issue

I'm the creator and owner of the Bloxstrap project ([pizzaboxer/bloxstrap](https://github.com/pizzaboxer/bloxstrap/)). It's popular enough that there have been about a dozen people making unofficial websites for it of which I have real concerns about, and I'm glad to see that an effort has been made to block them (#24123 - thank you very much @the9655a)

The only problem is that now I actually do have my own official website at https://bloxstrap.pizzaboxer.xyz/, which too is subject to the filter, so I need it exempted first before I can fully put it into use.

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/41478239/537cbb95-b958-41c6-9781-a93ed8aa4b83)

### Versions

- Browser/version: Firefox 127.0.2
- uBlock Origin version: 1.58.0

### Settings

- No changes
