### PR TITLE
Add modrinth and curseforge blocking domains

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2223,7 +2223,7 @@ game8.co##.js-side-ads-movie-container:remove()
 ! https://github.com/uBlockOrigin/uAssets/discussions/24177#discussioncomment-9821526
 modrinth.com##section.normal-page__content a[href*="/redirect/"] img
 ! https://github.com/uBlockOrigin/uAssets/issues/24130
-modrinth.com##section.normal-page__content :is([href^="https://billing.bloom.host/"],[href^="https://minefort.com/"],[href^="https://www.ocean-hosting.top/"],[href^="https://billing.apexminecrafthosting.com/"],[href^="https://mcph.info/"], [href*="/kinetic/"], [href*="/creeperhost"], [href^="https://www.akliz.net/"]) > img
+modrinth.com##section.normal-page__content :is([href^="https://ModdersAgainstBlockers.github.io"],[href^="https://billing.bloom.host/"],[href^="https://minefort.com/"],[href^="https://www.ocean-hosting.top/"],[href^="https://billing.apexminecrafthosting.com/"],[href^="https://mcph.info/"], [href*="/kinetic/"], [href*="/creeperhost"], [href^="https://www.akliz.net/"]) > img
 curseforge.com##:is(.project-description,div.project-detail__content) [href^="/linkout?remoteUrl=http"]:is([href*="billing.bloom.host"],[href*="minefort.com"],[href*="www.ocean-hosting.top"],[href*="billing.apexminecrafthosting.com"],[href*="mcph.info"]) > img
 
 ! https://arenascan.com/ anti-adb

--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2224,7 +2224,7 @@ game8.co##.js-side-ads-movie-container:remove()
 modrinth.com##section.normal-page__content a[href*="/redirect/"] img
 ! https://github.com/uBlockOrigin/uAssets/issues/24130
 modrinth.com##section.normal-page__content :is([href^="https://ModdersAgainstBlockers.github.io"],[href^="https://billing.bloom.host/"],[href^="https://minefort.com/"],[href^="https://www.ocean-hosting.top/"],[href^="https://billing.apexminecrafthosting.com/"],[href^="https://mcph.info/"], [href*="/kinetic/"], [href*="/creeperhost"], [href^="https://www.akliz.net/"]) > img
-curseforge.com##:is(.project-description,div.project-detail__content) [href^="/linkout?remoteUrl=http"]:is([href*="billing.bloom.host"],[href*="minefort.com"],[href*="www.ocean-hosting.top"],[href*="billing.apexminecrafthosting.com"],[href*="mcph.info"]) > img
+curseforge.com##:is(.project-description,div.project-detail__content) [href^="/linkout?remoteUrl=http"]:is([href*="fxco.ca"],[href*="billing.bloom.host"],[href*="minefort.com"],[href*="www.ocean-hosting.top"],[href*="billing.apexminecrafthosting.com"],[href*="mcph.info"]) > img
 
 ! https://arenascan.com/ anti-adb
 arenascan.com##+js(aost, document.getElementById, adsBlocked)


### PR DESCRIPTION
I haven't observed any breakage with this.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://modrinth.com/mod/memoryleakfix`
`https://www.curseforge.com/minecraft/mc-mods/carpet-fixes`

### Describe the issue

There are banner ads with undetected link domains.

### Screenshot(s)

![Screenshot a](https://github.com/uBlockOrigin/uAssets/assets/173219075/d9c7f9b6-5e37-45fe-88e4-0885b13bf6e9)
![Screenshot b](https://github.com/uBlockOrigin/uAssets/assets/173219075/c7b76dc5-3e04-4854-9ecb-906ae247793a)


Note that the broken image at the top is also broken when blocking is turned off.

### Versions

- Browser/version: Firefox 127.0.2
- uBlock Origin version: 1.58.0

### Settings

none

### Notes

none
