### PR TITLE
Add polyfill[.]top

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -4251,6 +4251,8 @@ oltacidergisi.com##+js(acs, atob, minimalDrainValue)
 ! https://github.com/uBlockOrigin/uAssets/pull/24272
 ! https://www.bleepingcomputer.com/news/security/polyfill-claims-it-has-been-defamed-returns-after-domain-shut-down/
 ||polyfill.com^$all
+! https://x.com/Polyfill_Global/status/1809122842145141114
+||polyfill.top^$all
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24248
 ||veilcurtin.world^$doc

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -4252,6 +4252,7 @@ oltacidergisi.com##+js(acs, atob, minimalDrainValue)
 ! https://www.bleepingcomputer.com/news/security/polyfill-claims-it-has-been-defamed-returns-after-domain-shut-down/
 ||polyfill.com^$all
 ! https://x.com/Polyfill_Global/status/1809122842145141114
+! https://github.com/uBlockOrigin/uAssets/pull/24434
 ||polyfill.top^$all
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24248


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`polyfill.top`

### Describe the issue

New domain for polyfill.io: https://x.com/Polyfill_Global/status/1809122842145141114

### Screenshot(s)

![image](https://github.com/uBlockOrigin/uAssets/assets/84232764/c15e485f-f367-4920-837c-09682870f02a)
![image](https://github.com/uBlockOrigin/uAssets/assets/84232764/8d9c34c9-fc77-488e-aec3-4c32c6b94cc5)

### Versions
N/A

### Settings

N/A

### Notes

Seems to be using `fnvip100.com` to load the script. It is at present unclear if that domain is malicious and who owns it. I *suspect* it is owned by Polyfill.io (fn = Funnull, the new owners of polyfill), but my suspicion is not grounds for blocking.
