### PR TITLE
privacy: add unlocky

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -481,6 +481,11 @@ zhihu.com##+js(no-xhr-if, log-sdk.ksapisrv.com/rest/wd/common/log/collect method
 ||smartaccess.biz^
 ||adonsonlyd.xyz^
 
+! Unlocky
+||unlocky.xyz
+||unlocky.org
+||rockingfolders.com
+
 ! https://github.com/uBlockOrigin/uAssets/issues/17786
 ! https://github.com/uBlockOrigin/uAssets/issues/20569
 ||adthrive.com^$removeparam,from=~mediaite.com|~a-z-animals.com

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -482,9 +482,9 @@ zhihu.com##+js(no-xhr-if, log-sdk.ksapisrv.com/rest/wd/common/log/collect method
 ||adonsonlyd.xyz^
 
 ! Unlocky
-||unlocky.xyz
-||unlocky.org
-||rockingfolders.com
+||unlocky.xyz^
+||unlocky.org^
+||rockingfolders.com^
 
 ! https://github.com/uBlockOrigin/uAssets/issues/17786
 ! https://github.com/uBlockOrigin/uAssets/issues/20569


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
unlocky.org
unlocky.xyz
```

### Describe the issue

This website claims to provide unlock codes for Android phone but it tricks people to finish various "offers" which involves providing personal information. The actual information needed for unlock was never sent. For example, you can bypass the animation of `unlocky.xyz` with the following code in console.

```js
xfContentLocker.completedLeads = ["a"] * 100
xfContentLocker.completedPoints = 100
xfContentLocker.checkComplete()
```

After this it will jump to `https://unlocky.org/get-code` and continue similar flow.

### Screenshot(s)

<img width="617" alt="image" src="https://github.com/user-attachments/assets/613b5079-bd6c-4a10-859b-673e179711be">


### Versions

N/A

### Settings

N/A

### Notes

Not entirely sure if it fits privacy filter.