### PR TITLE
LAN: Add filter for some ISP routers issued by Vodafone Germany

### DIFF
--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -72,6 +72,7 @@
 ||hitronhub.home^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||homerouter.cpe^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||huaweimobilewifi.com^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
+||kabel.box^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||localbattle.net^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||my.keenetic.net^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||my.router^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local


### PR DESCRIPTION
Added `kabel.box` to lan-block.txt

### URL(s) where the issue occurs

`kabel.box`

### Describe the issue

The web interface URL for some ISP routers issued by Vodafone Germany

### Screenshot(s)

n/a

### Versions

- Browser/version: Firefox 128.0.3
- uBlock Origin version: 1.58.0

### Settings

n/a

### Notes

Added some missing devices for lan-block.txt
