### PR TITLE
Fix unescaped comma in replace modifier

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -27,7 +27,7 @@ alliptvlinks.com###arlinablock
 alliptvlinks.com##body:style(overflow: auto !important)
 ! https://github.com/uBlockOrigin/uAssets/issues/22620
 alliptvlinks.com##+js(no-xhr-if, /doubleclick|googlesyndication/, length:10)
-||alliptvlinks.com/tktk-content/plugins/$script,1p,replace=/\bconst now.+?, 100/clearInterval(timer);resolve();}, 100/gms
+||alliptvlinks.com/tktk-content/plugins/$script,1p,replace=/\bconst now.+?\, 100/clearInterval(timer);resolve();}\, 100/gms
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11102
 apkmirror.com#@#.gooWidget


### PR DESCRIPTION
I was just looking at the files trying to understand the rules format and I'm pretty sure that commas need to be escaped since they're used as separators for modifiers?

Maybe uBlock handles this just fine, but it is wrong according to adguard's docs (which uBlock references).

If this is not an issue or if this is something that is more widespread and should be fixed for all incorrect replace regexes, feel free to just close this issue.