### PR TITLE
Cleanup theguardian.com consents

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -79,12 +79,13 @@ cmpv2.independent.co.uk##+js(trusted-click-element, [title="Reject All"], , 500)
 cmpv2.independent.co.uk##+js(trusted-click-element, button[title="READ FOR FREE"], , 1000)
 independent.co.uk##[id^="sp_message_container"]
 independent.co.uk##html.sp-message-open:style(width: initial !important)
-! https://www.theguardian.com/sport/video/2023/jun/25/carlos-alcaraz-beats-alex-de-minaur-to-win-first-grass-court-trophy-at-queens-video
-sourcepoint.theguardian.com##+js(trusted-click-element, .sp_choice_type_12[title="Manage or reject cookies"])
-sourcepoint.theguardian.com##+js(trusted-click-element, [title="Reject all"], , 500)
-theguardian.com##+js(trusted-set-cookie, consentUUID, 5ffc4740-d276-4a4b-8ed0-4b68feeed1ba_34, , , domain, theguardian.com)
-theguardian.com##[title="SP Consent Message"]
-www.theguardian.com##+js(trusted-set-local-storage-item, gu.prefs.engagementBannerLastClosedAt, {"value": "$currentISODate$"})
+! reject consent/emdded yt. (UK IP) https://www.theguardian.com/sport/video/2023/jun/25/carlos-alcaraz-beats-alex-de-minaur-to-win-first-grass-court-trophy-at-queens-video
+! https://www.theguardian.com/society/ng-interactive/2024/jul/17/frozen-in-time-the-motherhood-dilemma-for-single-women-in-china
+theguardian.com##+js(trusted-set-cookie, consentUUID, e3fd021c-e23a-4a83-81b8-88fda69b94f0_34, , , domain, theguardian.com)
+! https://www.theguardian.com/ (US IP - CPPA) Do not sell my personal infomation
+! https://www.theguardian.com/news/audio/2024/aug/09/best-of-2024-so-far-hippy-capitalist-guru-grocer-the-forgotten-genius-who-changed-british-food-podcast
+theguardian.com##+js(trusted-set-cookie,  consentStatus, rejectedAll)
+theguardian.com##+js(trusted-set-cookie,  ccpaUUID, 9df52f38-6763-409e-96d5-3ece9565aa68)
 ! https://video.lefigaro.fr/figaro/video/les-gestes-damour-prennent-plusieurs-formes-dans-une-video-humoristique-lukraine-demande-plus-de-caesar-a-la-france/
 lefigaro.fr##+js(trusted-set-cookie, fig_save_consent, iTTPgpSWqAGGcd3vV88zNDbHsABxE1hB, 1year)
 ! https://www.filmweb.pl/video/Zwiastun/Indiana+Jones+i+artefakt+przeznaczenia+Zwiastun+nr+2+polskie+napisy-64884


### PR DESCRIPTION
Simplify the consents on theguardian.com for US and UK. Both set to Reject. Embedded videos play.

- Cookie: `consentUUID` (EU/UK)

- Cookie: `ccpaUUID` (US) CPPA 