### PR TITLE
Add newly approved .internal TLD to lan blocking

### DIFF
--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -40,6 +40,11 @@
 ||0.0.0.0^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||[::]^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 !
+! ——— .internal TLD
+! https://en.wikipedia.org/wiki/.internal
+!
+||internal^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
+!
 ! ——— .local TLD
 ! https://en.wikipedia.org/wiki/.local
 !


### PR DESCRIPTION
.internal is now an ICANN approved TLD for lans

https://www.icann.org/en/board-activities-and-meetings/materials/approved-resolutions-special-meeting-of-the-icann-board-29-07-2024-en#section2.a

https://en.wikipedia.org/wiki/.internal
