### PR TITLE
strip GitHub `notification_referrer_id` query param

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -873,7 +873,7 @@ www.lenovo.com##+js(aost, history.replaceState, injectedScript)
 ||upera.shop/ref/$doc,uritransform=/^\/ref\/[^\/]+//
 
 ! https://www.makeuseof.com/best-vs-code-chatgpt-extensions/ - Tracking cookies
-androidpolice.com,makeuseof.com,movieweb.com,xda-developers.com##+js(cookie-remover, /articlesRead|previousPage/) 
+androidpolice.com,makeuseof.com,movieweb.com,xda-developers.com##+js(cookie-remover, /articlesRead|previousPage/)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/20440
 /^https?:\/\/chat\.openai\.com\/ces\/v1\/[a-z]$/$xhr,1p,domain=chat.openai.com,method=post
@@ -997,6 +997,9 @@ vpnmentor.com##+js(cookie-remover, /_alooma/)
 
 ! onlyfans click tracking
 ||onlyfans.com/api2/v2/users/clicks-stats^
+
+! https://github.com/notifications tracking query param
+$removeparam=notification_referrer_id,domain=github.com
 
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://github.com/notifications`

### Describe the issue

For some reason this query param can cause a near infinite redirect, as well as the base64 encoded click tracking. Removing it doesn't effect notifications being marked as read or not.

It does seem that the param being set's required for the following shelf to show up on notifications, so I could see this being an unwanted change: ![](https://user-images.githubusercontent.com/1362750/103318947-67512e00-4a73-11eb-876e-67c701a8afac.png)

### Versions

- Browser/version: Firefox 129
- uBlock Origin version: 1.59.0