### PR TITLE
Add modrinth banner ad domains

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2366,7 +2366,7 @@ game8.co##.js-side-ads-movie-container:remove()
 ! https://github.com/uBlockOrigin/uAssets/discussions/24177#discussioncomment-9821526
 modrinth.com##section.normal-page__content a[href*="/redirect/"] img
 ! https://github.com/uBlockOrigin/uAssets/issues/24130
-modrinth.com##section.normal-page__content :is([href^="https://ModdersAgainstBlockers.github.io"],[href^="https://billing.bloom.host/"],[href^="https://minefort.com/"],[href^="https://www.ocean-hosting.top/"],[href^="https://billing.apexminecrafthosting.com/"],[href^="https://mcph.info/"], [href*="/kinetic/"], [href*="/creeperhost"], [href^="https://www.akliz.net/"], [href^="http://bloom.amymialee.xyz"]) > img
+modrinth.com##section.normal-page__content :is([href^="https://ModdersAgainstBlockers.github.io"],[href^="https://billing.bloom.host/"],[href^="https://minefort.com/"],[href^="https://www.ocean-hosting.top/"],[href^="https://billing.apexminecrafthosting.com/"],[href^="https://mcph.info/"], [href*="/kinetic/"], [href*="/creeperhost"], [href^="https://www.akliz.net/"], [href^="http://bloom.amymialee.xyz"], [href^="https://fxco.ca/assets/"], [href*="kinetichosting.net"]) > img
 curseforge.com##:is(.project-description,div.project-detail__content) [href^="/linkout?remoteUrl=http"]:is([href*="fxco.ca"],[href*="billing.bloom.host"],[href*="minefort.com"],[href*="www.ocean-hosting.top"],[href*="billing.apexminecrafthosting.com"],[href*="mcph.info"]) > img
 ||i.imgur.com/h4556XW.gif$image,3p
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://modrinth.com/mod/moreculling`
`https://modrinth.com/mod/carpet-fixes`

### Describe the issue

Banner ads in descriptions.

### Screenshot(s)

![a](https://github.com/user-attachments/assets/90c296c9-c625-48c3-bb23-6d377ba626d7)
![b](https://github.com/user-attachments/assets/261892ef-1da9-4f70-80ae-fa16e578f016)

### Versions

- Browser/version: Firefox 129.0.1 (64-bit)
- uBlock Origin version: 1.59.0

### Settings

none

### Notes

The `fxco.ca/assets` path seems to always redirect to the ad domain. I don't think there's breakage.
