### PR TITLE
add `polyfill-js.cn`

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -5106,6 +5106,8 @@ app##html > body[style]:not([class]):not([id]) > center#yangchen[style]:not([cla
 ! https://github.com/uBlockOrigin/uAssets/pull/24434
 ||polyfill.top^$all
 
+||polyfill-js.cn^$all
+
 ! https://github.com/uBlockOrigin/uAssets/issues/24248
 ||veilcurtin.world^$doc
 ||yikesgroto.com^$doc


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
https://polyfill-js.cn/v3/polyfill.min.js
```

### Describe the issue

The new domain of `polyfill.io`. It is also powered by the same Chinese CDN company Funnull.

### Screenshot(s)

<img width="732" alt="image" src="https://github.com/user-attachments/assets/c1e2c8fb-9458-4c1f-99e7-4524ada754bc">

Notice the CNAME is from the Chinese CDN company Funnull. It shares an almost same CNAME with `funnull.com`:

<img width="703" alt="image" src="https://github.com/user-attachments/assets/90258cbe-3494-4920-a8ab-9a7585973458">

### Versions

- Browser/version: 128.0.6613.84 (Official Build) (arm64) 
- uBlock Origin version: uBlock Origin development build 1.59.1b5
