### PR TITLE
softonic.pl: nuisance

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -197,6 +197,8 @@ fplstatistics.co.uk##+js(trusted-set-cookie, FCCDCF, %5Bnull%2Cnull%2Cnull%2C%5B
 kirjasto.vaasa.fi##+js(trusted-set-cookie, Arena Cookie Consent, '{"categories":["necessary"],"level":["necessary"],"revision":0,"data":null,"rfc_cookie":false,"consent_date":"1970-00-00T00:00:00.000Z","consent_uuid":"00000000-0000-0000-0000-000000000000","last_consent_update":"1970-01-01T00:00:00.000Z"}', 1year)
 ! softonic.com, endless loading for dl button - https://winning-eleven-2012-apk-download-v101.en.softonic.com/chrome/extension
 softonic.com##+js(trusted-set-cookie, euconsent-v2, CP2KIMAP2KIMAAHABBENAcEgAAAAAAAAAAiQAAAAAAEEoAMAARBqDQAYAAiDUKgAwABEGopABgACINQ6ADAAEQaiEAGAAIg1BIAMAARBqGQAYAAiDUAA.YAAAAAAAAAAA, 1year, , domain, softonic.com)
+! https://github.com/uBlockOrigin/uAssets/pull/25191
+softonic.pl##+js(trusted-set-cookie, euconsent-v2, CP2KIMAP2KIMAAHABBENAcEgAAAAAAAAAAiQAAAAAAEEoAMAARBqDQAYAAiDUKgAwABEGopABgACINQ6ADAAEQaiEAGAAIg1BIAMAARBqGQAYAAiDUAA.YAAAAAAAAAAA, 1year, , domain, softonic.pl)
 ! https://attend.informatechevents.virtual.informatech.com/event/the-ai-summit-new-york-2023
 informatech.com##+js(trusted-set-cookie, swapcard-cookie-consent, %7B%22accepted%22%3Afalse%7D)
 ! https://www.spv.no/


### PR DESCRIPTION
endless loading for dl button - `https://chrome.softonic.pl/` and `https://winning-eleven-2012-apk-download-v101.softonic.pl/chrome/extension`

works fine with modified English scriptlet.

willing can check rest in future:

```adb
! https://www.softonic-ar.com
! https://www.softonic-id.com
! https://www.softonic.jp
! https://www.softonic.kr
! https://www.softonic.nl
! https://www.softonic.ru
! https://www.softonic.se
! https://www.softonic-th.com
! https://www.softonic.cn
```