### PR TITLE
Add www.easistent.com filters

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -3241,3 +3241,8 @@ javplayer.me##+js(nowoif)
 
 ! https://www.scoreland.* popup
 scoreland.biz,scoreland.name##+js(nowoif)
+
+! https://www.easistent.com ads & annoyances
+https://www.easistent.com/images/banners/*
+www.easistent.com##.banner-wrapper
+www.easistent.com###banner-sl-24


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.easistent.com/`
`https://www.easistent.com/webapp#/calendar` (requires login)

### Describe the issue

eAsistent, a proprietary school system in Slovenia, is promoting their paid plan and their mobile app even on desktops on every visit of the page. Ad that shows whilst logged in is especially annoying, because it pops up about 3 seconds after page load and therefore disrupts any possible clicks.

### Screenshot(s)

`https://www.easistent.com/` before changes
![image](https://github.com/user-attachments/assets/a5b5f448-e5c9-4ca8-a0d5-e2653bf4bc46)

`https://www.easistent.com/` after changes
![image](https://github.com/user-attachments/assets/86116821-39c1-471f-befc-11d52913d376)

`https://www.easistent.com/webapp#/calendar` before changes
![image](https://github.com/user-attachments/assets/274d4d5d-a991-485d-b330-b79f78835d7e)

`https://www.easistent.com/webapp#/calendar` after changes
![image](https://github.com/user-attachments/assets/28ef1410-2c01-4726-bdb9-1083e7b03749)

### Versions

- Browser/version: Firefox 129.0.2 on Fedora Linux
- uBlock Origin version: 1.59.0

### Settings

- Blocking ad-related images in order to save bandwidth
- Blocking all distracting divs

### Notes

It seems as if eAsistent serves all image ads through ` https://www.easistent.com/images/banners/*`. In future they could add (but are unlikely to add) important content there. I've opted into a wildcard, because these image ads relatively frequently change (each start of the month).
