### PR TITLE
Fixes cdn.privacy-mgmt.com (German, agree)

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -1677,6 +1677,9 @@ cdn.privacy-mgmt.com##+js(trusted-click-element, button[title*="Accept"], , 1000
 ! bloodyelbow.com (accept)
 cdn.privacy-mgmt.com##+js(trusted-click-element, button[title*="AGREE"], , 1000)
 
+! rockhard.de (accept)
+cdn.privacy-mgmt.com##+js(trusted-click-element, button[title*="Zustimmen"], , 1000)
+
 ! just Use necessary cookies only
 degiro.*##+js(trusted-click-element, #CybotCookiebotDialogBodyButtonDecline)
 


### PR DESCRIPTION
Accept german "Zustimmen" on cdn.privacy-mgmt.com 

From `https://www.rockhard.de/`