### PR TITLE
Fix jetpunk.com detection again

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -303,6 +303,7 @@ jetpunk.com##+js(set-local-storage-item, PageCount, $remove$)
 jetpunk.com##+js(set, asc, 2)
 ! https://github.com/uBlockOrigin/uAssets/issues/25387
 jetpunk.com##+js(set, google_tag_manager, {})
+jetpunk.com##+js(set, google_tag_manager.G-Z8CH48V654, {})
 @@||jetpunk.com^$script,1p
 @@||jetpunk.com^$ghide
 jetpunk.com##.banner-ad-outer


### PR DESCRIPTION
jetpunk.com used to detect adblockers by checking whether `google_tag_manager` exists, but now they also check an attribute of the object. Add a filter to provide this attribute as well.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.jetpunk.com/user-quizzes/117765/country-by-emojis`

### Describe the issue

Regression: #25387 is back, itself a regression of #21314.

To reproduce: While logged in, attempt to rate or comment on any quiz. A popup modal asking the user to disable their adblocker appears.

### Screenshot(s)

See linked issues

### Versions

- Browser/version: Firefox 131.0
- uBlock Origin version: 1.60.0

### Settings

- Default

### Notes

The relevant jetpunk.com code is:

```javascript
      isAdblocker() {
        return !(
          this.user &&
          (
            this.user.isPremium ||
            l.isQuizmaster(this) ||
            1 == this.user.isjetpunk
          ) ||
          'object' == typeof window.google_tag_manager &&
          'object' == typeof window.google_tag_manager['G-Z8CH48V654'] && // <- this causes the regression
          document.getElementById('CxkDwmaFMXvB')
        )
      }
```

This could be a bit of a cat-and-mouse game… happy to work on a more general solution if you can think of one.