### PR TITLE
Fix jetpunk.com detection again (2)

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -304,6 +304,7 @@ jetpunk.com##+js(set, asc, 2)
 ! https://github.com/uBlockOrigin/uAssets/issues/25387
 jetpunk.com##+js(set, google_tag_manager, {})
 jetpunk.com##+js(set, google_tag_manager.G-Z8CH48V654, {})
+jetpunk.com##+js(set, google_tag_manager.G-Z8CH48V654.dataLayer, {})
 @@||jetpunk.com^$script,1p
 @@||jetpunk.com^$ghide
 jetpunk.com##.banner-ad-outer


### PR DESCRIPTION
Continuing the cat-and-mouse game with jetpunk.com: they now check whether the data layer is defined.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.jetpunk.com/quizzes/obfuscations-of-movie-titles-3`

### Describe the issue

Regression: https://github.com/uBlockOrigin/uAssets/issues/25387 is back yet again.

To reproduce: While logged in, attempt to rate or comment on any quiz. A popup modal asking the user to disable their adblocker appears.

### Screenshot(s)

See linked issue

### Versions

- Browser/version: Firefox 131.0
- uBlock Origin version: 1.60.0

### Settings

- Default

### Notes

Relevant jetpunk.com code:

```js
          isAdblocker() {
            var e;
            return !(
              this.user &&
              (
                this.user.isPremium ||
                f.isQuizmaster(this) ||
                1 == this.user.isjetpunk
              ) ||
              document.getElementById('CxkDwmaFMXvB') &&
              'object' == typeof (
                null === (e = window.google_tag_manager) ||
                void 0 === e ||
                null === (e = e['G-Z8CH48V654']) ||
                void 0 === e ? void 0 : e.dataLayer // ← new
              )
            )
          }
```
