### PR TITLE
Fix jetpunk.com detection again (3)

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -302,10 +302,7 @@ jetpunk.com##+js(cookie-remover, PageCount)
 jetpunk.com##+js(set-local-storage-item, PageCount, $remove$)
 jetpunk.com##+js(set, asc, 2)
 ! https://github.com/uBlockOrigin/uAssets/issues/25387
-jetpunk.com##+js(set, google_tag_manager, {})
-jetpunk.com##+js(set, google_tag_manager.G-Z8CH48V654, {})
-jetpunk.com##+js(set, google_tag_manager.G-Z8CH48V654.dataLayer, {})
-jetpunk.com##+js(set, google_tag_manager.G-Z8CH48V654.bootstrap, 1)
+jetpunk.com##+js(trusted-set, google_tag_manager, '{ "value": { "G-Z8CH48V654": { "_spx": false, "bootstrap": 1704067200000, "dataLayer": { "name": "dataLayer" } }, "SANDBOXED_JS_SEMAPHORE": 0, "dataLayer": { "gtmDom": true, "gtmLoad": true, "subscribers": 1 }, "sequence": 1 } }')
 @@||jetpunk.com^$script,1p
 @@||jetpunk.com^$ghide
 jetpunk.com##.banner-ad-outer


### PR DESCRIPTION
Once again jetpunk.com changed its detection.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.jetpunk.com/user-quizzes/1329777/correctly-spelled-or-not-click-quiz-1`

### Describe the issue

Regression: https://github.com/uBlockOrigin/uAssets/issues/25387 is back yet again.

To reproduce: While logged in, attempt to rate or comment on any quiz. A popup modal asking the user to disable their adblocker appears.

### Screenshot(s)

See linked issue

### Versions

- Browser/version: Firefox 131.0.3
- uBlock Origin version: 1.60.0

### Settings

- Default

### Notes

Relevant jetpunk.com code:

```javascript
          isAdblocker() {
            var e;
            return !(
              this.user &&
              (
                this.user.isPremium ||
                f.isQuizmaster(this) ||
                1 == this.user.isjetpunk
              ) ||
              document.getElementById('CxkDwmaFMXvB') &&
              'number' == typeof (
                null === (e = window.google_tag_manager) ||
                void 0 === e ||
                null === (e = e['G-Z8CH48V654']) ||
                void 0 === e ? void 0 : e.bootstrap // ← changed
              )
            )
          }
```

I could mock up the whole GTM object, but at this point I'm curious that they'll do next.