### PR TITLE
Fix embedded video ads on abcnews.go.com

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -3057,7 +3057,7 @@ gamesrepacks.com##+js(noeval-if, show)
 @@||firenzetoday.it^$ghide
 
 ! SSAI Video ads on ABC Owned TV station sites https://github.com/uBlockOrigin/uBlock-issues/issues/760#issuecomment-715702997
-||content.uplynk.com/api/*&ad=$xhr,removeparam=/^ad/,domain=abc7ny.com|abc7.com|abc7chicago.com|6abc.com|abc7news.com|abc13.com|abc11.com|abc30.com
+||content.uplynk.com/api/*&ad=$xhr,removeparam=/^ad/,domain=abc7ny.com|abc7.com|abc7chicago.com|6abc.com|abc7news.com|abc13.com|abc11.com|abc30.com|abcnews.go.com
 ! https://github.com/uBlockOrigin/uAssets/issues/25756
 6abc.com,abc11.com,abc13.com,abc30.com,abc7.com,abc7chicago.com,abc7news.com,abc7ny.com,abcotvs.net##.nav.sticky:style(top: 0px !important;)
 


### PR DESCRIPTION
User reported video ads on https://abcnews.go.com/538/live-updates/election-results-2024/?id=115468646

Indicated this fix the issue, and combine with the rest of the abc rules.
