### PR TITLE
Remove old anti-adblock rules

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -87,41 +87,17 @@ pinterest.*##div[class="GrowthUnauthPinImage__imageDim"]
 pinterest.*##.GrowthUnauthPinImage > a > div[class^="Jea"]:has(button[class^="noButtonStyles "])
 pinterest.*##.Hsu.iyn.zI7:nth-of-type(2) > div > .FullPageModal__scroller
 
-! https://github.com/uBlockOrigin/uAssets/pull/2471
-flickr.com##.spaceball
-
-! https://github.com/jspenguin2017/uBlockProtector/issues/963
-phillymag.com##.gtp-ad
+! flickr.com "Upgrade to Flickr Pro to hide these ads" 
+flickr.com##.moola-search-view
 
 ! https://github.com/NanoAdblocker/NanoFilters/issues/120
-files.minecraftforge.net##.ad-container
 files.minecraftforge.net##.promo-container
-
-! https://github.com/NanoAdblocker/NanoFilters/issues/132
-||readthedocs.org/api/v2/sustainability/*$script,redirect=noopjs
 
 ! https://github.com/NanoAdblocker/NanoFilters/issues/134
 tv.mademyday.com##.blnotice
 
-! phys.org anti-adblock nag
-@@||phys.org^$ghide
-phys.org##.amp-unresolved
-phys.org##.adsbygoogle
-phys.org##.ads-336x280
-
-! https://github.com/NanoAdblocker/NanoFilters/issues/145
-minijuegos.com###adBlockDisclaimer
-
-! https://github.com/uBlockOrigin/uAssets/issues/2971
-||senmanga.com/img/block_*.png$image,1p
-
 ! https://github.com/uBlockOrigin/uAssets/issues/2972
-mimaletamusical.*##+js(aopw, document.oncontextmenu)
-mimaletamusical.*###cboxOverlay
-mimaletamusical.*###colorbox
-
-! https://github.com/uBlockOrigin/uAssets/issues/3006
-gardenista.com##+js(set, adsAreBlocked, false)
+mimaletamusical.blogspot.com##+js(aopw, document.oncontextmenu)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/2992
 fmhikayeleri.com##+js(acs, document.oncontextmenu)

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -88,7 +88,7 @@ pinterest.*##.GrowthUnauthPinImage > a > div[class^="Jea"]:has(button[class^="no
 pinterest.*##.Hsu.iyn.zI7:nth-of-type(2) > div > .FullPageModal__scroller
 
 ! flickr.com "Upgrade to Flickr Pro to hide these ads" 
-flickr.com##.moola-search-view
+flickr.com##.moola-search-view:has-text(hide these ads)
 
 ! https://github.com/NanoAdblocker/NanoFilters/issues/120
 files.minecraftforge.net##.promo-container


### PR DESCRIPTION
```
! https://github.com/uBlockOrigin/uAssets/pull/2471
flickr.com##.spaceball
```
No longer in use

```
! https://github.com/jspenguin2017/uBlockProtector/issues/963
phillymag.com##.gtp-ad
```
No longer in use

```
! flickr.com "Upgrade to Flickr Pro to hide these ads" 
flickr.com##.moola-search-view:has-text(hide these ads)
```
Changed too:

```
files.minecraftforge.net##.ad-container
```
No longer in use


```
! https://github.com/NanoAdblocker/NanoFilters/issues/132
||readthedocs.org/api/v2/sustainability/*$script,redirect=noopjs

! phys.org anti-adblock nag
@@||phys.org^$ghide
phys.org##.amp-unresolved
phys.org##.adsbygoogle
phys.org##.ads-336x280

! https://github.com/NanoAdblocker/NanoFilters/issues/145
minijuegos.com###adBlockDisclaimer

! https://github.com/uBlockOrigin/uAssets/issues/2971
||senmanga.com/img/block_*.png$image,1p

! https://github.com/uBlockOrigin/uAssets/issues/3006
gardenista.com##+js(set, adsAreBlocked, false)
```
No longer in use


```
! https://github.com/uBlockOrigin/uAssets/issues/2972
mimaletamusical.*##+js(aopw, document.oncontextmenu)
mimaletamusical.*###cboxOverlay
mimaletamusical.*###colorbox
```
Removed #colorbox, #cboxOverlay
Changed too:  blogspot.com (no longer regional domains). Still Current.
```
mimaletamusical.blogspot.com##+js(aopw, document.oncontextmenu)
```