### PR TITLE
whitelist "governikus.de" related to #23388

### DIFF
--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -134,7 +134,7 @@
 !
 ! https://github.com/uBlockOrigin/uAssets/issues/23388
 @@||localhost^$from=deutsche-rentenversicherung.de
-@@||127.0.0.1^$from=bund.de|organspende-register.de|bayernportal.de|mv-serviceportal.de
+@@||127.0.0.1^$from=bund.de|organspende-register.de|bayernportal.de|mv-serviceportal.de|governikus.de
 !
 ! https://github.com/uBlockOrigin/uAssets/pull/24488
 @@||localhost^$websocket,domain=www.faceit.com


### PR DESCRIPTION
### URL(s) where the issue occurs

https://pgp.governikus.de/wizard/requirements

### Describe the issue

https://www.ausweisapp.bund.de/home needs 127.0.0.1 to work, which is called by above URL.

### Screenshot(s)

### Versions

- Browser/version: up-to-date
- uBlock Origin version: up-to-date

### Settings

### Notes

related to #23388