### PR TITLE
Fix endless loading on ohra.nl

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -879,8 +879,8 @@ canva.com##+js(trusted-set-cookie, CTC, eyJBIjoxNzA4NTg5MjM3MTc1LCJCIjoxNzA4NTg5
 ! https://thegreencity.gr/ - Preferences
 thegreencity.gr##+js(trusted-set-cookie, the_green_city, [%22preference%22%2C%22technical%22])
 
-! https://www.ohra.nl/ - Social
-ohra.nl##+js(trusted-set-cookie, consentCookie, %7B%22id%22%3A%22d28cc3d1-22a4-4137-9477-3e82b6936e01%22%2C%22permissions%22%3A%7B%22social%22%3Atrue%2C%22personalization%22%3Afalse%2C%22tracking%22%3Afalse%7D%2C%22createdAt%22%3A%222023-10-13T02%3A54%3A20.54Z%22%7D, , , reload, 1)
+! https://www.ohra.nl/ - Accept
+ohra.nl##+js(trusted-click-element, kpcf-cookie-toestemming >>> button[class="ohgs-button-primary-green"], , 1000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/20065
 ||cdn.tinypass.com/api/piano.js$script,domain=corriere.it


### PR DESCRIPTION
Endless loading due to invalid cookie value.

Change to Accept, and work around shadow-root.