### PR TITLE
Fix jetpunk.com detection again (4)

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -290,11 +290,12 @@ m-hentai.net##div[class^="landingpageadcontainer_iframe"]
 jetpunk.com##+js(no-xhr-if, prebid)
 jetpunk.com##+js(cookie-remover, PageCount)
 jetpunk.com##+js(set-local-storage-item, PageCount, $remove$)
-jetpunk.com##+js(set, asc, 2)
 ! https://github.com/uBlockOrigin/uAssets/issues/25387
+jetpunk.com##+js(set, asc, {})
 jetpunk.com##+js(trusted-set, google_tag_manager, '{ "value": { "G-Z8CH48V654": { "_spx": false, "bootstrap": 1704067200000, "dataLayer": { "name": "dataLayer" } }, "SANDBOXED_JS_SEMAPHORE": 0, "dataLayer": { "gtmDom": true, "gtmLoad": true, "subscribers": 1 }, "sequence": 1 } }')
 @@||jetpunk.com^$script,1p
 @@||jetpunk.com^$ghide
+||www.jetpunk.com/resources/asc.js$script,domain=www.jetpunk.com,important
 jetpunk.com##.banner-ad-outer
 jetpunk.com##.box-ad-inner
 jetpunk.com##.box-ad-outer


### PR DESCRIPTION
Jetpunk changed its detection yet again:

- It checks that `asc` isn't a number, so make it an object
- Block the ad prebid script that populates this object

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.jetpunk.com/user-quizzes/1298084/cities-that-beat-new-york`

### Describe the issue

Regression: https://github.com/uBlockOrigin/uAssets/issues/25387 is back yet again.

To reproduce: While logged in, attempt to rate or comment on any quiz. A popup modal asking the user to disable their adblocker appears.

### Screenshot(s)

See linked issue

### Versions

- Browser/version: Firefox 133.0.3
- uBlock Origin version: 1.61.2

### Settings

- Default

### Notes

Relevant jetpunk.com code:

```javascript
          isAdblocker() {
            return !(
              this.user &&
              (
                this.user.isPremium ||
                u.isQuizmaster(this) ||
                1 == this.user.isjetpunk
              ) ||
              'none' != this.testContainer.css('display') &&
              'number' != typeof window.asc
            )
          }
```

The test container element already has display: block, no change needed here.