### PR TITLE
Fix jetpunk.com detection again (5)

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -291,7 +291,7 @@ jetpunk.com##+js(no-xhr-if, prebid)
 jetpunk.com##+js(cookie-remover, PageCount)
 jetpunk.com##+js(set-local-storage-item, PageCount, $remove$)
 ! https://github.com/uBlockOrigin/uAssets/issues/25387
-jetpunk.com##+js(set, asc, {})
+jetpunk.com##+js(trusted-set, asc, '{ "value": {"cmd": [null], "que": [null], "wrapperVersion": "6.19.0", "refreshQue": {"waitDelay": 3000, "que": []}, "isLoaded": true, "bidderSettings": {}, "libLoaded": true, "version": "v9.20.0", "installedModules": [], "adUnits": [], "aliasRegistry": {}, "medianetGlobals": {}} }')
 jetpunk.com##+js(trusted-set, google_tag_manager, '{ "value": { "G-Z8CH48V654": { "_spx": false, "bootstrap": 1704067200000, "dataLayer": { "name": "dataLayer" } }, "SANDBOXED_JS_SEMAPHORE": 0, "dataLayer": { "gtmDom": true, "gtmLoad": true, "subscribers": 1 }, "sequence": 1 } }')
 @@||jetpunk.com^$script,1p
 @@||jetpunk.com^$ghide


### PR DESCRIPTION
Jetpunk changed its detection yet again, faster than usual this time. It now checks that `asc` isn't an empty object. Mimic the non-adblocked object structure.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.jetpunk.com/user-quizzes/1488626/us-presidents-sudden-death`

### Describe the issue

Regression: https://github.com/uBlockOrigin/uAssets/issues/25387 is back yet again.

To reproduce: While logged in, attempt to rate or comment on any quiz. A popup modal asking the user to disable their adblocker appears.

### Screenshot(s)

See linked issue

### Versions

- Browser/version: Firefox 133.0.3
- uBlock Origin version: 1.61.2

### Settings

- Default

### Notes

Relevant jetpunk.com code:

```javascript
          isAdblocker() {
            return !(
              this.user &&
              (
                this.user.isPremium ||
                u.isQuizmaster(this) ||
                1 == this.user.isjetpunk
              ) ||
              'none' != this.testContainer.css('display') &&
              '{}' != JSON.stringify(window.asc)
            )
          }
```