### PR TITLE
Update badware.txt (orcaslicer.co)

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6200,3 +6200,5 @@ uploadfox.net###ad-gs-05
 ! https://github.com/uBlockOrigin/uAssets/issues/26708
 ||fiheos.co.in^$all
 /^https?:\/\/[a-z0-9]{18}\.[a-z]{6}\.co\.in\//$all,to=co.in
+! https://github.com/uBlockOrigin/uAssets/issues/26052#issuecomment-2571459915
+||orcaslicer.co^$doc


### PR DESCRIPTION

### URL(s) where the issue occurs

`orcaslicer.co`

### Describe the issue

This website is not an official website of OrcaSlicer and may cause harm to users.

I also asked in their discord channel, and it was confirmed that it's NOT an official site.

This happened before with the sites `orcaslicer.net` and `orcaslicer.info` which were also a fake/non-official site.

Here is a statement from the original repository:

```
🚨🚨🚨Important Security Alert🚨🚨🚨
Please be aware that "orcaslicer.net" or "orcaslicer.info" are NOT an official website for OrcaSlicer and may be potentially malicious. This site appears to use AI-generated content, lacking genuine context, and seems to exist solely to profit from advertisements. Worse, it may redirect download links to harmful sources. For your safety, avoid downloading OrcaSlicer from this site as the links may be compromised.

The only official platforms for OrcaSlicer are our GitHub project page and the [official Discord channel](https://discord.gg/P4VE9UY9gJ) .

We deeply value our OrcaSlicer community and appreciate all the social groups that support us. However, it is crucial to address the risk posed by any group that falsely claims to be official or misleads its members. If you encounter such a group or are part of one, please assist by encouraging the group owner to add a clear disclaimer or by alerting its members.

Thank you for your vigilance and support in keeping our community safe!
```
- https://github.com/SoftFever/OrcaSlicer?tab=readme-ov-file#important-security-alert


### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Chromium: 130 (Arc)
- uBlock Origin version: 1.61.0

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

Thank you to https://github.com/zshzebra (https://github.com/uBlockOrigin/uAssets/pull/26053#issuecomment-2571448976) for pointing this out
