### PR TITLE
Update instagram,facebook consents

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -58,6 +58,8 @@ consent.youtube.com##body.bodyUIModernization:has([action="https://consent.youtu
 facebook.com##+js(trusted-click-element, div[aria-label="Decline optional cookies"], , 1000)
 ! decline
 instagram.com##+js(trusted-click-element, button._a9_1, , 1000)
+! remove old value (TEMP)
+instagram.com##+js(remove-cookie, ig_did)
 ! Sample page: https://www.bloomberg.com/live/europe || https://www.bloomberg.co.jp/live/asia
 sourcepointcmp.bloomberg.com,sourcepointcmp.bloomberg.co.jp##+js(trusted-click-element, [title="Manage Cookies"])
 sourcepointcmp.bloomberg.com,sourcepointcmp.bloomberg.co.jp##+js(trusted-click-element, [title="Reject All"], , 1000)

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -58,8 +58,6 @@ consent.youtube.com##body.bodyUIModernization:has([action="https://consent.youtu
 facebook.com##+js(trusted-click-element, div[aria-label="Decline optional cookies"], , 1000)
 ! decline
 instagram.com##+js(trusted-click-element, button._a9_1, , 1000)
-! decline (accept E98790B8-2AA3-4D25-AAE2-590E19511822)
-instagram.com##+js(trusted-set-cookie, ig_did, 5443AF77-1A68-4603-BF65-43BB5F664A80, 1year, , reload, 1, dontOverwrite, 1)
 ! Sample page: https://www.bloomberg.com/live/europe || https://www.bloomberg.co.jp/live/asia
 sourcepointcmp.bloomberg.com,sourcepointcmp.bloomberg.co.jp##+js(trusted-click-element, [title="Manage Cookies"])
 sourcepointcmp.bloomberg.com,sourcepointcmp.bloomberg.co.jp##+js(trusted-click-element, [title="Reject All"], , 1000)

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -54,8 +54,10 @@ consent.google.*##[data-p*="/consent.google."]:has(button[jsname="tWT92d"])
 ! https://github.com/uBlockOrigin/uAssets/discussions/18598#discussioncomment-8651332
 consent.youtube.com##+js(trusted-click-element, [action="https://consent.youtube.com/save"][style="display:inline;"] [name="set_eom"][value="true"] ~ .basebuttonUIModernization[value][aria-label])
 consent.youtube.com##body.bodyUIModernization:has([action="https://consent.youtube.com/save"] .saveButtonUIModernization[value][aria-label])
-! decline optional (allow R39uZ-5MEK4VY8yBikIiiv42)
-facebook.com##+js(trusted-set-cookie, datr, 835uZ-bIo1ECQru7AjqnhhRl, 1year, , reload, 1, dontOverwrite, 1)
+! decline
+facebook.com##+js(trusted-click-element, div[aria-label="Decline optional cookies"], , 1000)
+! decline
+instagram.com##+js(trusted-click-element, button._a9_1, , 1000)
 ! decline (accept E98790B8-2AA3-4D25-AAE2-590E19511822)
 instagram.com##+js(trusted-set-cookie, ig_did, 5443AF77-1A68-4603-BF65-43BB5F664A80, 1year, , reload, 1, dontOverwrite, 1)
 ! Sample page: https://www.bloomberg.com/live/europe || https://www.bloomberg.co.jp/live/asia


### PR DESCRIPTION
Instagram is using changing uuid's for declining consents. Causing issues for users logging in via email

Better option is to use a trusted click here;

ref: https://github.com/brave/brave-browser/issues/42993
