### PR TITLE
update cookie consents

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -2068,7 +2068,7 @@ taxscouts.com##+js(trusted-click-element, button[data-js="cookieConsentReject"],
 cdn.privacy-mgmt.com##+js(trusted-click-element, button[title*="Jetzt"], , 1000)
 
 ! decline 
-online.no##+js(trusted-click-element, a[id="consent_prompt_decline"], , 1000)
+online.no,telenor.no##+js(trusted-click-element, a[id="consent_prompt_decline"], , 1000)
 
 ! Necessary
 redcare.it##+js(trusted-set-cookie, usercentrics_consent, '{"ad_storage":0,"analytics_storage":0,"functional":0}')
@@ -2103,3 +2103,21 @@ bruendl.at##+js(trusted-click-element, button.cookie-notice__button--dismiss, , 
 
 ! required+3p
 sbk.org##+js(trusted-set-cookie, cookie-optIn, '{"required":true,"statistics":false,"thirdParty":true}')
+
+! reject/allow technical
+latamairlines.com##+js(trusted-click-element, button[data-testid="cookies-politics-reject-button--button"], , 1000)
+
+! allow necessary
+elisa.ee##+js(trusted-click-element, cds-button[id="cookie-allow-necessary-et"], , 1000)
+
+! accept (consent wall)
+baseendpoint.brigitte.de##+js(trusted-click-element, button[title="Zustimmen"], ,  1000)
+
+! accept (including forms)
+regjeringen.no##+js(trusted-click-element, button[id="userSelectAll"], ,  1000)
+
+! agree (consent wall)
+cmp-sp.tagesspiegel.de##+js(trusted-click-element, button[title="Alle akzeptieren"], , 1000)
+
+! karlsruhe-insider.de, accept&close
+cdn.privacy-mgmt.com##+js(trusted-click-element, button[title="Akzeptieren & Schließen"], , 1000)


### PR DESCRIPTION
- Add `telenor.no` -> `online.no##+js(trusted-click-element, a[id="consent_prompt_decline"], , 1000)`
- Add latamairlines.com  (reject/allow technical)
- Add elisa.ee (necessary)
- baseendpoint.brigitte.de (Accept)
- regjeringen.no (Accept)
- tagesspiegel.de (Agree)
- karlsruhe-insider.de (Accept)