### PR TITLE
Fixes timeout.com and slashdot.org

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -1040,6 +1040,8 @@ snowandrock.com##+js(trusted-set-cookie, consent_setting, analytics%3A0%7Cfuncti
 ! New solution when the next stable version becomes widely used. https://github.com/uBlockOrigin/uBlock-issues/issues/2971
 ! All store information on device cookies
 dw.com,kinepolis.*,winfuture.de,lippu.fi,racingnews365.com##+js(trusted-click-element, #cmpwrapper >>> #cmpbntyestxt, , 1000)
+! I do not accept
+news.slashdot.org##+js(trusted-click-element, span#cmpbntnotxt, , 1000)
 
 ! https://www.zdf.de/ - Functional + social
 zdf.de##+js(trusted-set-cookie, zdf_cmp_client, '{%22version%22:%22v1%22%2C%22iteration%22:1%2C%22consents%22:[{%22id%22:%22personalisierung%22%2C%22value%22:false}%2C{%22id%22:%22socialMedia%22%2C%22value%22:true}%2C{%22id%22:%22instagram%22%2C%22value%22:true}%2C{%22id%22:%22twitter%22%2C%22value%22:true}%2C{%22id%22:%22facebook%22%2C%22value%22:true}%2C{%22id%22:%22drittsysteme%22%2C%22value%22:true}%2C{%22id%22:%22erforderlich%22%2C%22value%22:true}%2C{%22id%22:%22erfolgsmessung%22%2C%22value%22:true}]}')
@@ -2123,6 +2125,8 @@ sp-manager-magazin-de.manager-magazin.de##+js(trusted-click-element, button[titl
 
 ! agree timeout.com (EU IP)
 cdn.privacy-mgmt.com##+js(trusted-click-element, button[title="Accept all"], , 1000)
+! timeout.com (with GPC enabled browser) US IP
+cdn.privacy-mgmt.com##+js(trusted-click-element, button[title="Save & Exit"], , 1000)
 
 ! karlsruhe-insider.de, accept&close
 cdn.privacy-mgmt.com##+js(trusted-click-element, button[title="Akzeptieren & Schließen"], , 1000)


### PR DESCRIPTION
Fixes consents on news.slashdot.org (EU) and timeout.com (US + GPC)