### PR TITLE
Add dhl.de, questdiagnostics.com consents

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -1985,7 +1985,7 @@ salzburg.info##+js(set-attr, img.js-lazy-img[src^="data:image/"], src, [data-src
 verksamt.se##+js(trusted-click-element, [data-testid="consent-necessary"])
 
 ! decline (reported, allow search to work)
-booking.com,konami.com,groceries.asda.com,pluto.tv##+js(trusted-click-element, button[id="onetrust-reject-all-handler"], , 1000)
+booking.com,dhl.de,konami.com,groceries.asda.com,pluto.tv,questdiagnostics.com##+js(trusted-click-element, button[id="onetrust-reject-all-handler"], , 1000)
 
 ! non-essential
 here.com##+js(trusted-click-element, div[class="t_cm_ec_reject_button"], , 1000)


### PR DESCRIPTION
Address onetrust cookie consents; (only necessary) 

- Removed: https://github.com/easylist/easylist/commit/a50581f7
- Exception: https://github.com/easylist/easylist/commit/1e7d2766
