### PR TITLE
Fixed Trakt.tv #26812

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -3843,6 +3843,8 @@ trakt.tv##:xpath("//*[(text()='Advertisement')]"):upward(1)
 trakt.tv##+js(set, art3m1sItemNames.affiliate-wrapper, '""')
 trakt.tv##.snigel
 trakt.tv##a[target="_blank"][style]:has(img[src])
+! https://github.com/uBlockOrigin/uAssets/issues/26812
+trakt.tv##div[id*="-wrapper"]:has(a[href="/vip/advertising"])
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/15tco62/adblock_detected_at/
 deletedspeedstreams.blogspot.com##+js(nostif, adblock)


### PR DESCRIPTION
Closes #26812

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://trakt.tv/dashboard
https://trakt.tv/users/<username>/history
(and similar sites)

### Describe the issue

A full width, or near-full width banner that shows advertisements, and a link to the VIP page

### Screenshot(s)

### Versions

- Browser/version: Opera GX 115.0.5322.124
- uBlock Origin version: 1.60.0

### Settings

- Added a few built-in filters, nothing relevant to the issue.

### Notes

I have tested  on uBlock Origin, AdGuard and AdGuard for Samsung Internet. The latest AdGuard Base filter already has a filter that fixes this issue on the dashboard, but fails to fix it on personal pages, like https://trakt.tv/users/<username>/history. This filter fixes the issue everywhere, without any noticable issues, as far as I could check.