### PR TITLE
Address consents on telenet.be/royalmail.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -1985,7 +1985,7 @@ salzburg.info##+js(set-attr, img.js-lazy-img[src^="data:image/"], src, [data-src
 verksamt.se##+js(trusted-click-element, [data-testid="consent-necessary"])
 
 ! decline (reported, allow search to work)
-booking.com,dhl.de,khanacademy.org,konami.com,groceries.asda.com,pluto.tv,samsonite.*,questdiagnostics.com##+js(trusted-click-element, button[id="onetrust-reject-all-handler"], , 1000)
+booking.com,dhl.de,khanacademy.org,konami.com,groceries.asda.com,pluto.tv,samsonite.*,telenet.be,questdiagnostics.com##+js(trusted-click-element, button[id="onetrust-reject-all-handler"], , 1000)
 
 ! non-essential
 here.com##+js(trusted-click-element, div[class="t_cm_ec_reject_button"], , 1000)
@@ -2148,6 +2148,9 @@ mobile.de##+js(trusted-click-element, button.mde-consent-accept-btn, , 1000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/26797
 cookist.it,fanpage.it,geopop.it,lexplain.it##+js(trusted-click-element, '.gdpr-modal .gdpr-btn--secondary, .gdpr-modal .gdpr-modal__box-bottom-dx > button.gdpr-btn--br:first-child')
+
+! decline
+royalmail.com##+js(trusted-click-element, button#consent_prompt_decline, , 1000)
 
 ! gmx.net/gmx.ch consent-wall (agree)
 gmx.net##+js(trusted-click-element, button[id="save-all-pur"], , 1000)


### PR DESCRIPTION
Had a couple of reports on 2 sites, `telenet.be` and `royalmail.com`

Removed selected rules; to move to trusted instead.
https://github.com/easylist/easylist/commit/60d46753
https://github.com/easylist/easylist/commit/5336421