### PR TITLE
update #24714 - www.decompiler.com ad block detection support

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -3054,7 +3054,7 @@ chasingthedonkey.com##+js(nowoif)
 taste.com.au##.main-header:style(top: 0 !important)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24714
-@@||decompiler.com/javascripts/*$script,1p
+@@||/ads/prebid/ads/prebid/ads/prebid/ads-prebid/*$script,domain=decompiler.com
 
 ! ytlarge detection
 @@||ytlarge.com^$ghide


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.decompiler.com/jar/e361d8a9147d43fca5f31f9f257e4e51/SkyblockPlus-1.0.2.jar`

### Describe the issue

Allow the `https://www.codicibancari.it/javascripts/ads/prebid/ads/prebid/ads/prebid/ads-prebid/prebid-ads.b571be381f1f.js` script to load. Which is used for ad block detection.

### Screenshot(s)

N/A
