### PR TITLE
Update consents

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -1401,7 +1401,7 @@ fruugo.de##+js(set-cookie, consents, essential)
 ! https://github.com/uBlockOrigin/uAssets/issues/22896
 ! https://github.com/uBlockOrigin/uAssets/issues/22911
 ! https://github.com/easylist/easylist/issues/19970
-cmp-sp.tagesspiegel.de,cmp.bz-berlin.de,cmp.techbook.de,cmp.stylebook.de,cmp2.bild.de,sourcepoint.wetter.de,consent.finanzen.at,sourcepoint.n-tv.de,sourcepoint.kochbar.de,cdn.privacy-mgmt.com,cmp.computerbild.de,cmp.petbook.de,cmp-sp.siegener-zeitung.de,cmp-sp.sportbuzzer.de,klarmobil.de##+js(trusted-click-element, button[title^="Alle akzeptieren"])
+cmp-sp.tagesspiegel.de,cmp.bz-berlin.de,cmp.techbook.de,cmp.stylebook.de,cmp2.bild.de,sourcepoint.wetter.de,consent.finanzen.at,sourcepoint.n-tv.de,sourcepoint.kochbar.de,sourcepoint.rtl.de,cdn.privacy-mgmt.com,cmp.computerbild.de,cmp.petbook.de,cmp-sp.siegener-zeitung.de,cmp-sp.sportbuzzer.de,klarmobil.de##+js(trusted-click-element, button[title^="Alle akzeptieren"])
 
 ! necessary = true/ stats = false
 seen.es##+js(trusted-set-cookie, aceptarCookiesSeen, '{"necesarias":true,"estadisticas":false}', , , reload, 1)
@@ -1629,7 +1629,7 @@ ilgazzettino.it,ilmessaggero.it,ilsecoloxix.it##+js(trusted-click-element, butto
 weather.com##+js(trusted-set-local-storage-item, userConsents, {"functional-technology":true})
 
 ! accept / impulse.de
-privacy.motorradonline.de,cdn.privacy-mgmt.com##+js(trusted-click-element, button[title="Akzeptieren und weiter"], , 1000)
+privacy.motorradonline.de,cdn.privacy-mgmt.com,consent.watson.de##+js(trusted-click-element, button[title="Akzeptieren und weiter"], , 1000)
 
 ! just necessary
 tedbaker.com##+js(trusted-set-cookie, CONSENTMGR, c1:0|c6:0|c9:0|ts:1718751098255|consent:false|id:01902d7e715a00551abb1b4878180206f003606700fb9, , , domain, .tedbaker.com)
@@ -1664,7 +1664,7 @@ redbull.com##+js(trusted-set-cookie, OptanonAlertBoxClosed, $currentDate$, , , d
 ! https://kurier.at/video/aktuelle-videos/israel-bombardiert-weiter-hisbollah-ziele-im-libanon/402951598
 jeuxvideo.com##+js(trusted-click-element, button[onclick="Didomi.setUserAgreeToAll();"], , 1000)
 idnes.cz##+js(trusted-click-element, a[href="javascript:Didomi.setUserAgreeToAll();"], , 1000)
-20minutes.fr,20minutos.es,24sata.hr,abc.es,actu.fr,antena3.com,antena3internacional.com,atresmedia.com,atresmediapublicidad.com,atresmediastudios.com,atresplayer.com,autopista.es,belfasttelegraph.co.uk,bonduelle.it,bonniernews.se,cadenaser.com,ciclismoafondo.es,cnews.fr,cope.es,correryfitness.com,decathlon.nl,decathlon.pl,di.se,diepresse.com,dn.se,dnevnik.hr,dumpert.nl,ebuyclub.com,edreams.de,edreams.net,elcomercio.es,elconfidencial.com,eldesmarque.com,elespanol.com,elpais.com,elpais.es,engadget.com,euronews.com,europafm.com,expressen.se,flooxernow.com,france.tv,france24.com,ghacks.net,gva.be,hbvl.be,krone.at,kurier.at,ladepeche.fr,lalibre.be,lasexta.com,lasprovincias.es,ledauphine.com,lejdd.fr,leparisien.fr,lexpress.fr,libremercado.com,marmiton.org,melodia-fm.com,metronieuws.nl,mundodeportivo.com,nicematin.com,nieuwsblad.be,numerama.com,ondacero.es,profil.at,radiofrance.fr,rankia.com,rfi.fr,rossmann.pl,rtbf.be,rtl.lu,science-et-vie.com,sensacine.com,sfgame.net,shure.com,silicon.es,sncf-connect.com,sport.es,techcrunch.com,telegraaf.nl,telequebec.tv,trailrun.es,video-streaming.orange.fr##+js(trusted-click-element, #didomi-notice-agree-button, , 1000)
+20minutes.fr,20minutos.es,24sata.hr,abc.es,actu.fr,antena3.com,antena3internacional.com,atresmedia.com,atresmediapublicidad.com,atresmediastudios.com,atresplayer.com,autopista.es,belfasttelegraph.co.uk,bonduelle.it,bonniernews.se,cadenaser.com,ciclismoafondo.es,cnews.fr,cope.es,correryfitness.com,decathlon.nl,decathlon.pl,di.se,diepresse.com,dn.se,dnevnik.hr,dumpert.nl,ebuyclub.com,edreams.de,edreams.net,elcomercio.es,elconfidencial.com,eldesmarque.com,elespanol.com,elpais.com,elpais.es,engadget.com,euronews.com,europafm.com,expressen.se,flooxernow.com,france.tv,france24.com,fussballtransfers.com,ghacks.net,gva.be,hbvl.be,krone.at,kurier.at,ladepeche.fr,lalibre.be,lasexta.com,lasprovincias.es,ledauphine.com,lejdd.fr,leparisien.fr,lexpress.fr,libremercado.com,marmiton.org,melodia-fm.com,metronieuws.nl,mundodeportivo.com,nicematin.com,nieuwsblad.be,numerama.com,ondacero.es,profil.at,radiofrance.fr,rankia.com,rfi.fr,rossmann.pl,rtbf.be,rtl.lu,science-et-vie.com,sensacine.com,sfgame.net,shure.com,silicon.es,sncf-connect.com,sport.es,techcrunch.com,telegraaf.nl,telequebec.tv,trailrun.es,video-streaming.orange.fr##+js(trusted-click-element, #didomi-notice-agree-button, , 1000)
 20minutes.fr,20minutos.es,24sata.hr,abc.es,actu.fr,antena3.com,antena3internacional.com,atresmedia.com,atresmediapublicidad.com,atresmediastudios.com,atresplayer.com,autopista.es,belfasttelegraph.co.uk,bonduelle.it,bonniernews.se,cadenaser.com,ciclismoafondo.es,cnews.fr,cope.es,correryfitness.com,decathlon.nl,decathlon.pl,diepresse.com,dnevnik.hr,dumpert.nl,ebuyclub.com,edreams.de,edreams.net,elcomercio.es,elconfidencial.com,eldesmarque.com,elespanol.com,elpais.com,elpais.es,engadget.com,euronews.com,europafm.com,expressen.se,flooxernow.com,france24.com,ghacks.net,gva.be,hbvl.be,krone.at,kurier.at,ladepeche.fr,lalibre.be,lasexta.com,lasprovincias.es,ledauphine.com,lejdd.fr,leparisien.fr,lexpress.fr,libremercado.com,marmiton.org,melodia-fm.com,metronieuws.nl,mundodeportivo.com,nicematin.com,nieuwsblad.be,numerama.com,ondacero.es,profil.at,radiofrance.fr,rankia.com,rfi.fr,rossmann.pl,rtbf.be,rtl.lu,science-et-vie.com,sensacine.com,sfgame.net,shure.com,silicon.es,sncf-connect.com,sport.es,techcrunch.com,telegraaf.nl,telequebec.tv,trailrun.es,video-streaming.orange.fr###didomi-host:style(visibility: hidden !important;)
 20minutes.fr,20minutos.es,24sata.hr,abc.es,actu.fr,antena3.com,antena3internacional.com,atresmedia.com,atresmediapublicidad.com,atresmediastudios.com,atresplayer.com,autopista.es,belfasttelegraph.co.uk,bonduelle.it,bonniernews.se,cadenaser.com,ciclismoafondo.es,cnews.fr,cope.es,correryfitness.com,decathlon.nl,decathlon.pl,diepresse.com,dnevnik.hr,dumpert.nl,ebuyclub.com,edreams.de,edreams.net,elcomercio.es,elconfidencial.com,eldesmarque.com,elespanol.com,elpais.com,elpais.es,engadget.com,euronews.com,europafm.com,expressen.se,flooxernow.com,france24.com,ghacks.net,gva.be,hbvl.be,krone.at,kurier.at,ladepeche.fr,lalibre.be,lasexta.com,lasprovincias.es,ledauphine.com,lejdd.fr,leparisien.fr,lexpress.fr,libremercado.com,marmiton.org,melodia-fm.com,metronieuws.nl,mundodeportivo.com,nicematin.com,nieuwsblad.be,numerama.com,ondacero.es,profil.at,radiofrance.fr,rankia.com,rfi.fr,rossmann.pl,rtbf.be,rtl.lu,science-et-vie.com,sensacine.com,sfgame.net,shure.com,silicon.es,sncf-connect.com,sport.es,techcrunch.com,telegraaf.nl,telequebec.tv,trailrun.es,video-streaming.orange.fr##body.didomi-popup-open:style(overflow: auto !important;)
 @@||sdk.privacy-center.org^$script,domain=actu.fr|ledauphine.com
@@ -1771,9 +1771,9 @@ tvsyd.dk##+js(trusted-set-cookie, tv2reg_cookie_consent, '{"revision":1,"consent
 ! required/comfort=true
 suedtirolerjobs.it,kaerntnerjobs.at,tirolerjobs.at,salzburgerjobs.at,wienerjobs.at##+js(trusted-set-cookie, cookieConsents, '{%22required%22:true%2C%22statistics%22:null%2C%22comfort%22:true%2C%22personalization%22:null}')
 
-bunte.de,chip.de##[id^="sp_message_container"]
-bunte.de,chip.de##html.sp-message-open > body:style(position: unset !important; overflow: unset !important)
-cmp.bunte.de,cmp.chip.de##+js(trusted-click-element, button[title="Akzeptieren"], , 1000)
+bunte.de,chip.de,focus.de##[id^="sp_message_container"]
+bunte.de,chip.de,focus.de##html.sp-message-open > body:style(position: unset !important; overflow: unset !important)
+cmp.bunte.de,cmp.chip.de,cmp.focus.de##+js(trusted-click-element, button[title="Akzeptieren"], , 1000)
 
 ! Mandatory + Functional - for customer service chat
 posti.fi##+js(trusted-set-cookie, OptanonAlertBoxClosed, $currentDate$, 1year, , domain, posti.fi)
@@ -2126,7 +2126,7 @@ elisa.ee##+js(trusted-click-element, cds-button[id="cookie-allow-necessary-et"],
 
 ! accept (consent wall) 
 ! cdn.privacy-mgmt.com / rockhard.de 
-baseendpoint.brigitte.de,baseendpoint.gala.de,baseendpoint.haeuser.de,baseendpoint.urbia.de,cmp.tag24.de,golem.de,cdn.privacy-mgmt.com##+js(trusted-click-element, button[title*="Zustimmen"], ,  1000)
+baseendpoint.brigitte.de,baseendpoint.gala.de,baseendpoint.haeuser.de,baseendpoint.urbia.de,cmp.tag24.de,mpv2.berliner-zeitung.de,golem.de,cdn.privacy-mgmt.com##+js(trusted-click-element, button[title*="Zustimmen"], ,  1000)
 
 ! accept (including forms)
 regjeringen.no##+js(trusted-click-element, button[id="userSelectAll"], ,  1000)
@@ -2208,6 +2208,9 @@ thomann.de##+js(trusted-click-element, button.js-decline-all-cookies, , 1000)
 
 ! essential only
 landkreis-kronach.de##+js(trusted-click-element, button.cookieselection-confirm-selection, , 1000)
+
+! accept (consent wall)
+consent.t-online.de##+js(trusted-click-element, button[title="ZUSTIMMEN"], , 1000)
 
 ! https://ir.ung.edu/ - essential only
 ir.ung.edu##+js(trusted-set-cookie, cookie_preferences, '{"allow_all":0,"google_analytics":0,"accepted":1}', , , reload, 1)

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -2126,7 +2126,7 @@ elisa.ee##+js(trusted-click-element, cds-button[id="cookie-allow-necessary-et"],
 
 ! accept (consent wall) 
 ! cdn.privacy-mgmt.com / rockhard.de 
-baseendpoint.brigitte.de,baseendpoint.gala.de,baseendpoint.haeuser.de,baseendpoint.urbia.de,cmp.tag24.de,mpv2.berliner-zeitung.de,golem.de,cdn.privacy-mgmt.com##+js(trusted-click-element, button[title*="Zustimmen"], ,  1000)
+baseendpoint.brigitte.de,baseendpoint.gala.de,baseendpoint.haeuser.de,baseendpoint.urbia.de,cmp.tag24.de,mpv2.berliner-zeitung.de,golem.de,cdn.privacy-mgmt.com,consent.t-online.de,cmp-sp.handelsblatt.com##+js(trusted-click-element, button[title*="Zustimmen" i], ,  1000)
 
 ! accept (including forms)
 regjeringen.no##+js(trusted-click-element, button[id="userSelectAll"], ,  1000)
@@ -2208,9 +2208,6 @@ thomann.de##+js(trusted-click-element, button.js-decline-all-cookies, , 1000)
 
 ! essential only
 landkreis-kronach.de##+js(trusted-click-element, button.cookieselection-confirm-selection, , 1000)
-
-! accept (consent wall)
-consent.t-online.de##+js(trusted-click-element, button[title="ZUSTIMMEN"], , 1000)
 
 ! https://ir.ung.edu/ - essential only
 ir.ung.edu##+js(trusted-set-cookie, cookie_preferences, '{"allow_all":0,"google_analytics":0,"accepted":1}', , , reload, 1)

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -1401,7 +1401,7 @@ fruugo.de##+js(set-cookie, consents, essential)
 ! https://github.com/uBlockOrigin/uAssets/issues/22896
 ! https://github.com/uBlockOrigin/uAssets/issues/22911
 ! https://github.com/easylist/easylist/issues/19970
-cmp-sp.tagesspiegel.de,cmp.bz-berlin.de,cmp.techbook.de,cmp.stylebook.de,sourcepoint.wetter.de,consent.finanzen.at,sourcepoint.n-tv.de,sourcepoint.kochbar.de,cdn.privacy-mgmt.com,cmp.computerbild.de,cmp.petbook.de,cmp-sp.siegener-zeitung.de,cmp-sp.sportbuzzer.de,klarmobil.de##+js(trusted-click-element, button[title^="Alle akzeptieren"])
+cmp-sp.tagesspiegel.de,cmp.bz-berlin.de,cmp.techbook.de,cmp.stylebook.de,cmp2.bild.de,sourcepoint.wetter.de,consent.finanzen.at,sourcepoint.n-tv.de,sourcepoint.kochbar.de,cdn.privacy-mgmt.com,cmp.computerbild.de,cmp.petbook.de,cmp-sp.siegener-zeitung.de,cmp-sp.sportbuzzer.de,klarmobil.de##+js(trusted-click-element, button[title^="Alle akzeptieren"])
 
 ! necessary = true/ stats = false
 seen.es##+js(trusted-set-cookie, aceptarCookiesSeen, '{"necesarias":true,"estadisticas":false}', , , reload, 1)
@@ -1896,7 +1896,7 @@ webuildgroup.com##+js(trusted-set-cookie, general_cookie_consent, "")
 atlasformen.*##+js(trusted-click-element, button[data-reject-all], , 1000)
 
 ! consent and agree (consentwall)
-cmp-sp.goettinger-tageblatt.de##+js(trusted-click-element, button[title="Einwilligen und weiter"], , 1000)
+cmp-sp.goettinger-tageblatt.de,cmp-sp.saechsische.de##+js(trusted-click-element, button[title="Einwilligen und weiter"], , 1000)
 
 ! refuse
 klm.*##+js(trusted-set-cookie, bw_cookie_banner, '{"1":true,"2":false,"3":false}')
@@ -2202,6 +2202,12 @@ sailgp.com##+js(set-cookie, sgp-cp-acceptance, true)
 
 ! accept
 wells.pt##+js(trusted-click-element, button.CybotCookiebotDialogBodyButton, , 1000)
+
+! reject
+thomann.de##+js(trusted-click-element, button.js-decline-all-cookies, , 1000)
+
+! essential only
+landkreis-kronach.de##+js(trusted-click-element, button.cookieselection-confirm-selection, , 1000)
 
 ! https://ir.ung.edu/ - essential only
 ir.ung.edu##+js(trusted-set-cookie, cookie_preferences, '{"allow_all":0,"google_analytics":0,"accepted":1}', , , reload, 1)

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -1664,7 +1664,7 @@ redbull.com##+js(trusted-set-cookie, OptanonAlertBoxClosed, $currentDate$, , , d
 ! https://kurier.at/video/aktuelle-videos/israel-bombardiert-weiter-hisbollah-ziele-im-libanon/402951598
 jeuxvideo.com##+js(trusted-click-element, button[onclick="Didomi.setUserAgreeToAll();"], , 1000)
 idnes.cz##+js(trusted-click-element, a[href="javascript:Didomi.setUserAgreeToAll();"], , 1000)
-20minutes.fr,20minutos.es,24sata.hr,abc.es,actu.fr,antena3.com,antena3internacional.com,atresmedia.com,atresmediapublicidad.com,atresmediastudios.com,atresplayer.com,autopista.es,belfasttelegraph.co.uk,bonduelle.it,bonniernews.se,cadenaser.com,ciclismoafondo.es,cnews.fr,cope.es,correryfitness.com,decathlon.nl,decathlon.pl,di.se,diepresse.com,dn.se,dnevnik.hr,dumpert.nl,ebuyclub.com,edreams.de,edreams.net,elcomercio.es,elconfidencial.com,eldesmarque.com,elespanol.com,elpais.com,elpais.es,engadget.com,euronews.com,europafm.com,expressen.se,flooxernow.com,france.tv,france24.com,fussballtransfers.com,ghacks.net,gva.be,hbvl.be,krone.at,kurier.at,ladepeche.fr,lalibre.be,lasexta.com,lasprovincias.es,ledauphine.com,lejdd.fr,leparisien.fr,lexpress.fr,libremercado.com,marmiton.org,melodia-fm.com,metronieuws.nl,mundodeportivo.com,nicematin.com,nieuwsblad.be,numerama.com,ondacero.es,profil.at,radiofrance.fr,rankia.com,rfi.fr,rossmann.pl,rtbf.be,rtl.lu,science-et-vie.com,sensacine.com,sfgame.net,shure.com,silicon.es,sncf-connect.com,sport.es,techcrunch.com,telegraaf.nl,telequebec.tv,trailrun.es,video-streaming.orange.fr##+js(trusted-click-element, #didomi-notice-agree-button, , 1000)
+20minutes.fr,20minutos.es,24sata.hr,abc.es,actu.fr,antena3.com,antena3internacional.com,atresmedia.com,atresmediapublicidad.com,atresmediastudios.com,atresplayer.com,autopista.es,belfasttelegraph.co.uk,bonduelle.it,bonniernews.se,cadenaser.com,ciclismoafondo.es,cnews.fr,cope.es,correryfitness.com,decathlon.nl,decathlon.pl,di.se,diepresse.com,dn.se,dnevnik.hr,dumpert.nl,ebuyclub.com,edreams.de,edreams.net,elcomercio.es,elconfidencial.com,eldesmarque.com,elespanol.com,elpais.com,elpais.es,engadget.com,euronews.com,europafm.com,expressen.se,flooxernow.com,france.tv,france24.com,fussballtransfers.com,ghacks.net,gva.be,hbvl.be,krone.at,kurier.at,ladepeche.fr,lalibre.be,lasexta.com,lasprovincias.es,ledauphine.com,lejdd.fr,leparisien.fr,lexpress.fr,libremercado.com,marmiton.org,melodia-fm.com,m6.fr,metronieuws.nl,mundodeportivo.com,nicematin.com,nieuwsblad.be,numerama.com,ondacero.es,profil.at,radiofrance.fr,rankia.com,rfi.fr,rossmann.pl,rtbf.be,rtl.lu,science-et-vie.com,sensacine.com,sfgame.net,shure.com,silicon.es,sncf-connect.com,sport.es,techcrunch.com,telegraaf.nl,telequebec.tv,trailrun.es,video-streaming.orange.fr##+js(trusted-click-element, #didomi-notice-agree-button, , 1000)
 20minutes.fr,20minutos.es,24sata.hr,abc.es,actu.fr,antena3.com,antena3internacional.com,atresmedia.com,atresmediapublicidad.com,atresmediastudios.com,atresplayer.com,autopista.es,belfasttelegraph.co.uk,bonduelle.it,bonniernews.se,cadenaser.com,ciclismoafondo.es,cnews.fr,cope.es,correryfitness.com,decathlon.nl,decathlon.pl,diepresse.com,dnevnik.hr,dumpert.nl,ebuyclub.com,edreams.de,edreams.net,elcomercio.es,elconfidencial.com,eldesmarque.com,elespanol.com,elpais.com,elpais.es,engadget.com,euronews.com,europafm.com,expressen.se,flooxernow.com,france24.com,ghacks.net,gva.be,hbvl.be,krone.at,kurier.at,ladepeche.fr,lalibre.be,lasexta.com,lasprovincias.es,ledauphine.com,lejdd.fr,leparisien.fr,lexpress.fr,libremercado.com,marmiton.org,melodia-fm.com,metronieuws.nl,mundodeportivo.com,nicematin.com,nieuwsblad.be,numerama.com,ondacero.es,profil.at,radiofrance.fr,rankia.com,rfi.fr,rossmann.pl,rtbf.be,rtl.lu,science-et-vie.com,sensacine.com,sfgame.net,shure.com,silicon.es,sncf-connect.com,sport.es,techcrunch.com,telegraaf.nl,telequebec.tv,trailrun.es,video-streaming.orange.fr###didomi-host:style(visibility: hidden !important;)
 20minutes.fr,20minutos.es,24sata.hr,abc.es,actu.fr,antena3.com,antena3internacional.com,atresmedia.com,atresmediapublicidad.com,atresmediastudios.com,atresplayer.com,autopista.es,belfasttelegraph.co.uk,bonduelle.it,bonniernews.se,cadenaser.com,ciclismoafondo.es,cnews.fr,cope.es,correryfitness.com,decathlon.nl,decathlon.pl,diepresse.com,dnevnik.hr,dumpert.nl,ebuyclub.com,edreams.de,edreams.net,elcomercio.es,elconfidencial.com,eldesmarque.com,elespanol.com,elpais.com,elpais.es,engadget.com,euronews.com,europafm.com,expressen.se,flooxernow.com,france24.com,ghacks.net,gva.be,hbvl.be,krone.at,kurier.at,ladepeche.fr,lalibre.be,lasexta.com,lasprovincias.es,ledauphine.com,lejdd.fr,leparisien.fr,lexpress.fr,libremercado.com,marmiton.org,melodia-fm.com,metronieuws.nl,mundodeportivo.com,nicematin.com,nieuwsblad.be,numerama.com,ondacero.es,profil.at,radiofrance.fr,rankia.com,rfi.fr,rossmann.pl,rtbf.be,rtl.lu,science-et-vie.com,sensacine.com,sfgame.net,shure.com,silicon.es,sncf-connect.com,sport.es,techcrunch.com,telegraaf.nl,telequebec.tv,trailrun.es,video-streaming.orange.fr##body.didomi-popup-open:style(overflow: auto !important;)
 @@||sdk.privacy-center.org^$script,domain=actu.fr|ledauphine.com
@@ -1865,7 +1865,7 @@ dailypost.co.uk,the-express.com##+js(trusted-click-element, button[mode="primary
 dailypost.co.uk,the-express.com###qc-cmp2-container:style(visibility: hidden !important;)
 
 ! reject
-tarife.mediamarkt.de##+js(trusted-click-element, a.cmptxt_btn_no, , 1000)
+tarife.mediamarkt.de,gaggenau.com##+js(trusted-click-element, a.cmptxt_btn_no, , 1000)
 ! add to mediamarkt.be
 saturn.de##+js(trusted-click-element, button[data-test="pwa-consent-layer-save-settings"], , 1000])
 
@@ -2010,7 +2010,7 @@ salzburg.info##+js(set-attr, img.js-lazy-img[src^="data:image/"], src, [data-src
 verksamt.se##+js(trusted-click-element, [data-testid="consent-necessary"])
 
 ! decline (reported, allow search to work)
-booking.com,dhl.de,khanacademy.org,konami.com,groceries.asda.com,pluto.tv,samsonite.*,telenet.be,questdiagnostics.com##+js(trusted-click-element, button[id="onetrust-reject-all-handler"], , 1000)
+booking.com,de.vanguard,dhl.de,khanacademy.org,konami.com,groceries.asda.com,pluto.tv,samsonite.*,telenet.be,questdiagnostics.com##+js(trusted-click-element, button[id="onetrust-reject-all-handler"], , 1000)
 
 ! non-essential
 here.com##+js(trusted-click-element, div[class="t_cm_ec_reject_button"], , 1000)
@@ -2208,6 +2208,53 @@ thomann.de##+js(trusted-click-element, button.js-decline-all-cookies, , 1000)
 
 ! essential only
 landkreis-kronach.de##+js(trusted-click-element, button.cookieselection-confirm-selection, , 1000)
+
+! reject
+northcoast.com##+js(trusted-click-element, button#btn-reject-all, ,  1000)
+
+! required/functional only
+sogeti.*##+js(trusted-set-cookie, ConsentCookie, 'required:1,functional:1,analytic:0', , , reload, 1)
+
+! "Ok"
+bandenconcurrent.nl,bandenexpert.be##+js(trusted-click-element, button[data-consent-trigger="1"], , 1000)
+
+! reject/functional
+lisbonsaobentohotel.pt##+js(trusted-set-cookie, controlCookies, '{"functional":true,"analytics":false,"publicity":false}')
+
+! "OK"
+reserved.com##+js(trusted-set-cookie, button#cookiebotDialogOkButton, , 1000)
+
+! reject
+metro.*,makro.*,metro-tr.com##+js(trusted-click-element, button[field-reject-button-name], , 1000)
+
+! nessacry / uuid=1
+sj.se##+js(trusted-set-cookie, sj_consent_v1, %7B%22consent%22%3A%7B%22PERSONALIZATION%22%3Afalse%2C%22MARKETING%22%3Afalse%7D%2C%22uuid%22%3A%221%22%7D)
+
+! reject
+norwegian.com##+js(trusted-set-cookie, _nasStorageConsent, 'all=False&analysis=False&marketing=False&v=1')
+
+! stat=false
+klett.de##+js(trusted-set-cookie, klett_cookie_consent, '{%22statistiken%22:false}')
+
+! decline
+balay.es,constructa.com##+js(trusted-click-element, button.js-deny, , 1500)
+
+! decline
+ringside.ai##+js(trusted-set-cookie, rsdperms, %7B%22ringside%22%3Afalse%2C%22googleads%22%3Afalse%2C%22facebook%22%3Afalse%2C%22read%22%3Atrue%7D)
+
+! close without accepting
+dafy-moto.com##+js(trusted-click-element, a.jliqhtlu__close, , 1000)
+
+! reject
+airfrance.*##+js(trusted-set-cookie, bw_cookie_banner, '{"1":true,"2":false,"3":false}')
+
+! reject
+muziker.*##+js(trusted-set-cookie, muziker_consent, '%7B%22marketingCookie%22%3Afalse%2C%22analyticsCookie%22%3Afalse%7D', , , reload, 1)
+
+! functional
+akku-shop.nl,akkushop-austria.at,akkushop-b2b.de,akkushop.de,akkushop.dk,batterie-boutique.fr##+js(trusted-click-element, a.cookie-consent--reject-button, , 1000)
+! agree only option
+akkushop-schweiz.ch##+js(trusted-click-element, button[title="Alle Cookies akzeptieren"], , 1000)
 
 ! https://ir.ung.edu/ - essential only
 ir.ung.edu##+js(trusted-set-cookie, cookie_preferences, '{"allow_all":0,"google_analytics":0,"accepted":1}', , , reload, 1)


### PR DESCRIPTION
- Fixes bild.de consent
- Address saechsische.de consent
- Reject thomann.de consent
- landkreis-kronach.de essential (only) consent 

Update; Add a few more .de consents

- Fixes rtl.de,watson.de,fussballtransfers.com,focus.de,berliner-zeitung.de,t-online.de consent

Update 2; Merge rules

- Merge consent.t-online.de `button[title*="Zustimmen" i]`
- Fixes handelsblatt.com consent

Update 3; Update various consents
```
! reject
northcoast.com##+js(trusted-click-element, button#btn-reject-all, ,  1000)
! required/functional only
sogeti.*##+js(trusted-set-cookie, ConsentCookie, 'required:1,functional:1,analytic:0', , , reload, 1)
! "Ok"
bandenconcurrent.nl,bandenexpert.be##+js(trusted-click-element, button[data-consent-trigger="1"], , 1000)
! reject/functional
lisbonsaobentohotel.pt##+js(trusted-set-cookie, controlCookies, '{"functional":true,"analytics":false,"publicity":false}')
! "OK"
reserved.com##+js(trusted-set-cookie, button#cookiebotDialogOkButton, , 1000)
! reject
metro.*,makro.*,metro-tr.com##+js(trusted-click-element, button[field-reject-button-name], , 1000)
! nessacry / uuid=1
sj.se##+js(trusted-set-cookie, sj_consent_v1, %7B%22consent%22%3A%7B%22PERSONALIZATION%22%3Afalse%2C%22MARKETING%22%3Afalse%7D%2C%22uuid%22%3A%221%22%7D)
! reject
norwegian.com##+js(trusted-set-cookie, _nasStorageConsent, 'all=False&analysis=False&marketing=False&v=1')
! reject
de.vanguard##+js(trusted-click-element, button[id="onetrust-reject-all-handler"], , 1000)
! stat=false
klett.de##+js(trusted-set-cookie, klett_cookie_consent, '{%22statistiken%22:false}')
! decline
balay.es,constructa.com##+js(trusted-click-element, button.js-deny, , 1400)
! deny
gaggenau.com##+js(trusted-click-element, a.cmptxt_btn_no, , 1000)
! didomi-notice-agree-button
m6.fr##+js(trusted-click-element, #didomi-notice-agree-button, , 1000)
! decline
ringside.ai##+js(trusted-set-cookie, rsdperms, %7B%22ringside%22%3Afalse%2C%22googleads%22%3Afalse%2C%22facebook%22%3Afalse%2C%22read%22%3Atrue%7D)
! close without accepting
dafy-moto.com##+js(trusted-click-element, a.jliqhtlu__close, , 1000)
! reject
airfrance.*##+js(trusted-set-cookie, bw_cookie_banner, '{"1":true,"2":false,"3":false}')
! reject
muziker.*##+js(trusted-set-cookie, muziker_consent, '%7B%22marketingCookie%22%3Afalse%2C%22analyticsCookie%22%3Afalse%7D', , , reload, 1)
! functional
akku-shop.nl,akkushop-austria.at,akkushop-b2b.de,akkushop.de,akkushop.dk,batterie-boutique.fr##+js(trusted-click-element, a.cookie-consent--reject-button, , 1000)
! agree, only option.
akkushop-schweiz.ch##+js(trusted-click-element, button[title="Alle Cookies akzeptieren"], , 1000)
```