### PR TITLE
Privacy: Block deepseek analytics

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1558,3 +1558,6 @@ discord.com##+js(no-xhr-if, discord.com/api/v9/science)
 
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt
+
+! chat.deepseek.com analytics
+||chat.deepseek.com/api/v0/events$xhr,method=post

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1556,10 +1556,10 @@ discord.com##+js(no-xhr-if, discord.com/api/v9/science)
 ! https://github.com/easylist/easylist/issues/21077
 ||internal-api.prolific.com/api/v1/statistics/
 
-! Merge in resource-abuse.txt
-!#include resource-abuse.txt
-
 ! chat.deepseek.com analytics
 ||chat.deepseek.com/api/v0/events$xhr,method=post
 chat.deepseek.com##.ds-theme.ds-modal-wrapper:has(.ds-modal-content__title:has-text(/Ad/))
 chat.deepseek.com##.ds-modal-overlay
+
+! Merge in resource-abuse.txt
+!#include resource-abuse.txt

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1561,3 +1561,5 @@ discord.com##+js(no-xhr-if, discord.com/api/v9/science)
 
 ! chat.deepseek.com analytics
 ||chat.deepseek.com/api/v0/events$xhr,method=post
+chat.deepseek.com##.ds-theme.ds-modal-wrapper:has(.ds-modal-content__title:has-text(/Ad/))
+chat.deepseek.com##.ds-modal-overlay


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://chat.deepseek.com`

### Describe the issue

Block `/api/v0/events` POST request that sends analytics to their API including ip address, region, user agent, etc..
Also removes the adblocker modal

### Screenshot(s)

Sample of the kind of data that is being sent:

![obfuscated](https://github.com/user-attachments/assets/10b863d6-47bd-492d-bf97-c4b366549eb3)

AdBlocker modal:

![image](https://github.com/user-attachments/assets/9967f32e-ef96-42bb-8f2e-176e6243fafb)

### Versions

- Browser/version: Firefox/134.0.1
- uBlock Origin version: 1.62.0

