### PR TITLE
editor.plantuml. com sidebar & empty bottom

### DIFF
--- a/filters/filters-2025.txt
+++ b/filters/filters-2025.txt
@@ -414,3 +414,6 @@ uns.bio###dynamic-overlay
 
 ! https://github.com/uBlockOrigin/uAssets/issues/26995
 pawastreams.pro##+js(rmnt, script, /adserverDomain|ai_cookie/)
+
+! editor.plantuml. com sidebar
+editor.plantuml.com##body:style(margin:0 !important)

--- a/filters/filters-2025.txt
+++ b/filters/filters-2025.txt
@@ -415,5 +415,6 @@ uns.bio###dynamic-overlay
 ! https://github.com/uBlockOrigin/uAssets/issues/26995
 pawastreams.pro##+js(rmnt, script, /adserverDomain|ai_cookie/)
 
-! editor.plantuml. com sidebar
+! editor.plantuml. com sidebar & empty bottom
 editor.plantuml.com##body:style(margin:0 !important)
+editor.plantuml.com##body>#external_container:style(height:100% !important)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://editor.plantuml.com`

### Describe the issue

The page displays a sidebar on the left, used to serve ads (already blocked by uBO)

### Screenshot(s)

![editor plantuml com](https://github.com/user-attachments/assets/83ab6ec4-98b6-4642-9a6a-2570722ae9b1)

### Versions

- Browser/version: Opera GX 115.0.5322.142
- uBlock Origin version: 1.60.0

### Settings

- Enabled built-in EasyList/uBO cookie notices, EasyList Social Widgets, EasyList/UBO Annoyances
- Added 5 manual filters for other, unrelated sites

### Notes

Tested on multiple machines (PC, Android), multiple adblockers (uBO, AdGuard). The page is very new, no blocks for it yet. The bottom space has absolutely no content currently, so removed it for improved usability. It's in a separate commit in case the maintainer does not want this change.