### PR TITLE
Fixes spankvideo playback

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1380,7 +1380,7 @@ vpnmentor.com##+js(cookie-remover, /_alooma/)
 ||spankbang.com/static/dist/desktop/js/analytics$script
 ! https://github.com/uBlockOrigin/uAssets/issues/25974
 spankbang.com##+js(set, send_gravity_event, noopFunc)
-spankbang.com##+js(set, send_recommendation_event, noopFunc)
+! spankbang.com##+js(set, send_recommendation_event, noopFunc)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/25180
 perplexity.ai##+js(aost, window.screen.height, setTimeout)


### PR DESCRIPTION
Disabled rule, causes issues on no playback (reported). Stop user from clicking on video.

NSFW: `https://spankbang.com/39btk/video/fucking+hot+asian+anally+fucked`