### PR TITLE
Banner ads in body text on Modrinth and Curseforge

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2674,8 +2674,10 @@ modrinth.com##section.normal-page__content a[href*="/redirect/"] img
 ! https://github.com/uBlockOrigin/uAssets/issues/24130
 modrinth.com##section.normal-page__content [href^="https://bisecthosting.com/"][href*="?r="] img
 modrinth.com##section.normal-page__content :is([href^="https://ModdersAgainstBlockers.github.io"],[href*="/kinetic/"],[href*="/creeperhost"],[href^="https://fxco.ca/assets/"],[href^="https://rb.gy/"]) > img
+modrinth.com##section.normal-page__content p > img[alt^="Use code"]
 curseforge.com##:is(.project-description,div.project-detail__content) [href^="/linkout?remoteUrl=http"]:is([href*="fxco.ca"]) > img
 ||i.imgur.com/h4556XW.gif$image,3p
+curseforge.com##:is(.project-description,div.project-detail__content) p > img[alt^="Use code"]
 
 ! https://arenascan.com/ anti-adb
 arenascan.com##+js(aost, document.getElementById, adsBlocked)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

More specific filters are needed as sometimes the banner ads don't include a link and need to be filtered differently. This filter uses the `alt` text but other approaches may also be viable (such as using the text of the preceding `h2`, or both).

### URL(s) where the issue occurs

- `https://modrinth.com/mod/embeddium`
- `https://www.curseforge.com/minecraft/mc-mods/embeddium`

### Describe the issue

Banner ads in body text

### Screenshot(s)

![curseforge](https://github.com/user-attachments/assets/689d4f9c-1962-4461-b8cd-4d5418ae9c7c)
![modrinth](https://github.com/user-attachments/assets/dde11fbc-b329-4323-aa3e-fa406cc2b211)


### Versions

- Browser/version: Firefox 134.0.2 (64-bit)
- uBlock Origin version: uBlock Origin 1.62.0

### Settings

-

### Notes

The `h2` text preceding each of these ads is also technically part of the ad but I haven't found an easy way to include it in the filter without being overly broad. I'm open to suggestions and/or changes by maintainers to incorporate this.