### PR TITLE
Update consents

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -1122,9 +1122,9 @@ mafu.de##+js(trusted-set-cookie, wmm-visitor_token, 4cb8860d-4194-4ab5-be04-10f9
 ! essential only
 paf.com##+js(trusted-set-cookie, cookieConsent, {%22essential%22:true%2C%22tracking%22:false%2C%22marketing%22:false})
 ! Continue without agreeing, hide consent flash (.didomi-continue-without-agreeing)
-auto.it,boursobank.com,canalplus.com,frandroid.com,jobijoba.*,meteofrance.com,mondialtissus.fr,oscaro.com,publicsenat.fr,rmcbfmplay.com,suzuki.fr###didomi-host
-auto.it,boursobank.com,canalplus.com,frandroid.com,jobijoba.*,meteofrance.com,mondialtissus.fr,oscaro.com,publicsenat.fr,rmcbfmplay.com,suzuki.fr##+js(trusted-click-element, .didomi-continue-without-agreeing, , 1000)
-auto.it,boursobank.com,canalplus.com,frandroid.com,jobijoba.*,meteofrance.com,mondialtissus.fr,oscaro.com,publicsenat.fr,rmcbfmplay.com,suzuki.fr##body.didomi-popup-open:style(overflow: auto !important;)
+auto.it,boursobank.com,canalplus.com,frandroid.com,jobijoba.*,intersport.*,meteofrance.com,mondialtissus.fr,oscaro.com,publicsenat.fr,rmcbfmplay.com,suzuki.fr###didomi-host
+auto.it,boursobank.com,canalplus.com,frandroid.com,jobijoba.*,intersport.*,meteofrance.com,mondialtissus.fr,oscaro.com,publicsenat.fr,rmcbfmplay.com,suzuki.fr##+js(trusted-click-element, .didomi-continue-without-agreeing, , 1000)
+auto.it,boursobank.com,canalplus.com,frandroid.com,jobijoba.*,intersport.*,meteofrance.com,mondialtissus.fr,oscaro.com,publicsenat.fr,rmcbfmplay.com,suzuki.fr##body.didomi-popup-open:style(overflow: auto !important;)
 ! functional only, ad/analytics denied
 flip.gr##+js(trusted-set-cookie, consts, '{%22ad_storage%22:%22denied%22%2C%22analytics_storage%22:%22denied%22%2C%22functionality_storage%22:%22granted%22}')
 ! necessarry
@@ -2004,7 +2004,7 @@ salzburg.info##+js(set-attr, img.js-lazy-img[src^="data:image/"], src, [data-src
 verksamt.se##+js(trusted-click-element, [data-testid="consent-necessary"])
 
 ! decline (reported, allow search to work)
-booking.com,de.vanguard,dhl.de,khanacademy.org,konami.com,jll.*,groceries.asda.com,n26.com,nintendo.com,panasonic.com,pluto.tv,samsonite.*,telenet.be,toujeo.com,questdiagnostics.com##+js(trusted-click-element, button[id="onetrust-reject-all-handler"], , 1000)
+booking.com,de.vanguard,dhl.de,khanacademy.org,konami.com,jll.*,intersport.*,groceries.asda.com,n26.com,nintendo.com,panasonic.com,pluto.tv,samsonite.*,telenet.be,toujeo.com,questdiagnostics.com##+js(trusted-click-element, button[id="onetrust-reject-all-handler"], , 1000)
 
 ! non-essential
 here.com##+js(trusted-click-element, div[class="t_cm_ec_reject_button"], , 1000)
@@ -2507,7 +2507,7 @@ stiwa.com##+js(trusted-set-cookie, siwa-cb, 'media=true,essentials=true')
 transparency.meta.com##+js(trusted-click-element, button[data-cookiebanner="accept_button"], , 1000)
 
 ! reject
-safran-group.com##+js(trusted-click-element, button.cky-btn-reject, , 1000)
+safran-group.com,sr-ramenendeuren.be##+js(trusted-click-element, button.cky-btn-reject, , 1000)
 
 ! essential
 naturesfinest.pt##+js(trusted-set-cookie, cookie_consent, agree_none, , , reload, 1)
@@ -2920,14 +2920,17 @@ deichmann.com##+js(trusted-click-element, a[onclick="consentLayer.buttonAcceptMa
 nmhh.hu##+js(trusted-set-cookie, gdpr2, base)
 
 ! reject
-guter-gerlach.de,zsgarwolin.pl##+js(trusted-set-cookie, cookieControlPrefs, '[]')
-guter-gerlach.de,zsgarwolin.pl##+js(set-cookie, cookieControl, true)
+guter-gerlach.de,zsgarwolin.pl,mobile-fueling.de##+js(trusted-set-cookie, cookieControlPrefs, '[]')
+guter-gerlach.de,zsgarwolin.pl,mobile-fueling.de##+js(set-cookie, cookieControl, true)
 
 ! reject
 carefully.be##+js(trusted-click-element, div#cookiescript_reject, , 1000)
 
 ! required
 kosta.at##+js(trusted-set-cookie, COOKIE_CONSENT, NECESSARY|NECESSARY.DSGVO_CONSENT|TECHNICAL|TECHNICAL.PHP_SESSION|TECHNICAL.SHOP_WARENKORB|TECHNICAL.SHOP_PAYMENT|TECHNICAL.NEWSLETTER)
+
+! accept
+rocket-league.com##+js(trusted-click-element, button#acceptPrivacyPolicy, , 1000)
 
 ! essential+external content
 germany.travel##+js(trusted-set-local-storage-item, consent, '{"version":1,"consent":{"essential":"1","analytics":0,"marketing":0,"external":"1"}}')
@@ -2949,6 +2952,40 @@ sparda.at##+js(trusted-set-cookie, cookie_info, all:0|req:1|track:1|marketing:0|
 
 ! https://github.com/uBlockOrigin/uAssets/issues/26900 - functional
 karkkainen.com##+js(trusted-set-cookie, CookieInformationConsent, '{"website_uuid":"0fabd588-2344-49cd-9abb-ce5ffad2757e","timestamp":"$currentDate$","consent_url":"https://www.karkkainen.com/","consent_website":"karkkainen.com","consent_domain":"www.karkkainen.com","user_uid":"","consents_approved":["cookie_cat_necessary","cookie_cat_functional"],"consents_denied":[],"user_agent":""}')
+
+! decline
+bosch-homecomfort.com,elmleblanc-optibox.fr,monservicechauffage.fr,boschrexroth.com##+js(trusted-click-element, dock-privacy-settings >>> bbg-button#decline-all-modal-dialog, , 1000)
+
+! deny
+gamersgate.com##+js(trusted-click-element, button.cookiebanner__buttons__deny, , 1000)
+
+! refuse
+home-connect.com##+js(trusted-click-element, button.js-deny, , 1000)
+
+! necessary
+internetlekarna.cz,lekarna-bella.cz,lekarnasvjosefa.cz,slimbee.cz##+js(trusted-set-cookie, cookiesSettings, '{"necessary":true}', , reload, 1)
+
+! basic
+lowrider.at##+js(trusted-click-element, a[role="button"][data-cookie-individual], , 3200)
+lowrider.at##+js(trusted-click-element, a[role="button"][data-cookie-accept], , 3500)
+
+! deny
+mesto.de##+js(trusted-click-element, button[title="Deny all cookies"], , 1000)
+
+! basic
+miethke.com,pin-freunde.de##+js(trusted-set-cookie, Consent_status, '!youtube=true!matomo=false!tarteaucitron=true')
+
+! deny
+icscards.nl,worldcard.nl##+js(trusted-set-cookie, COOKIE_OPT_IN, NO_OPT_IN)
+
+! necessary
+veiligverkeer.be,vsv.be##+js(trusted-click-element, button#cookieconsent-banner-accept-necessary-button, , 2000)
+
+! necessary
+rodekruis.be##+js(trusted-set-cookie, consents, '{"marketing":false,"marketing.marketing.marketing":false,"necessary":true,"necessary.necessary.necessary":true,"preferences":false,"preferences.preferences.preferences":false,"statistics":false,"statistics.statistics.statistics":false}')
+
+! intersport.gr
+intersport.gr,intersport.bg,intersport.com.cy,intersport.ro##+js(trusted-click-element, div[data-vtest="reject-all"], , 1000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/27019 - Accept all
 cmp.focus.de##+js(trusted-click-element, button.accept-all)

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -2987,6 +2987,9 @@ rodekruis.be##+js(trusted-set-cookie, consents, '{"marketing":false,"marketing.m
 ! intersport.gr
 intersport.gr,intersport.bg,intersport.com.cy,intersport.ro##+js(trusted-click-element, div[data-vtest="reject-all"], , 1000)
 
+! necessary 
+mega.io##+js(trusted-set-cookie, cookieConsent, '{"preferences":false,"analytics":false,"marketing":false}')
+
 ! https://github.com/uBlockOrigin/uAssets/issues/27019 - Accept all
 cmp.focus.de##+js(trusted-click-element, button.accept-all)
 


### PR DESCRIPTION
Update from https://github.com/easylist/easylist/commit/775d5c147a582db3b7285b1398f4b4c63b2af86c

Only select accept where needed to get past consents. rocket-league.com

Also intersport.* has different consents based on specific regions. I think most are covered