### PR TITLE
Fix filecrypt clicknload localhost

### DIFF
--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -140,5 +140,8 @@
 !
 ! https://github.com/uBlockOrigin/uAssets/pull/24488
 @@||localhost^$websocket,domain=www.faceit.com
+
+! Clicknload https://community.brave.com/t/filecrypt-co-functionality-is-broken-when-shields-are-up/597698/
+@@||127.0.0.1^$domain=filecrypt.co
 !
 ! ——— END


### PR DESCRIPTION
Address "Click N Load" on filecrypt.co

Ref: https://community.brave.com/t/filecrypt-co-functionality-is-broken-when-shields-are-up/597698/