### PR TITLE
Add fixes for apollographql.com & pcsupport.lenovo.com

### DIFF
--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -143,5 +143,11 @@
 
 ! Clicknload https://community.brave.com/t/filecrypt-co-functionality-is-broken-when-shields-are-up/597698/
 @@||127.0.0.1^$domain=filecrypt.co
+
+! Unable to scan for hardware due to localhost https://pcsupport.lenovo.com/ https://github.com/brave/brave-browser/issues/43050
+@@||127.0.0.1^$domain=pcsupport.lenovo.com
+
+! https://studio.apollographql.com/sandbox/explorer (fixed in https://github.com/brave/adblock-lists/pull/2320)
+@@||127.0.0.1^$domain=apollographql.com
 !
 ! ——— END


### PR DESCRIPTION
Sync with Brave localhost fixes.


- Hardware scan detection broken; https://pcsupport.lenovo.com/us/en/ (Fixed  in https://github.com/brave/brave-browser/issues/43050)

- Localhost requests being blocked; https://studio.apollographql.com/sandbox/explorer (Fixed in https://github.com/brave/adblock-lists/pull/2320) 