### PR TITLE
cleanup old filters for chat.deepseek.com

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1616,10 +1616,6 @@ discord.com##+js(no-xhr-if, discord.com/api/v9/science)
 ! https://github.com/uBlockOrigin/uAssets/pull/27339
 ||apmplus.volces.com/monitor_web/collect$xhr,method=post
 ||gator.volces.com/list$xhr,method=post
-! https://github.com/uBlockOrigin/uAssets/pull/26935
-||chat.deepseek.com/api/v0/events$xhr,method=post
-chat.deepseek.com##.ds-theme.ds-modal-wrapper:has-text(uBlock)
-chat.deepseek.com##.ds-modal-overlay
 
 ! https://github.com/uBlockOrigin/uAssets/issues/26946
 ||sex-empire.org/templates/*/js/metrika.js


### PR DESCRIPTION
Removes old filters that are not relevant anymore, the new ones have been added in https://github.com/uBlockOrigin/uAssets/pull/27339
