### PR TITLE
P: (nsfw) https://gamcore.com/games/exiles

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -3343,7 +3343,6 @@ classic.gamcore.com##[id]:has(> .warningbox)
 classic.gamcore.com###center > .flashes > .wide:has(> a[href][rel])
 gamcore.com##.item:has([href^="/games/"][class=""])
 gamcore.com##.item:has(> a[href] > img[src*="//cdn.69games.xxx/"])
-gamcore.com##.menuArea [rel]
 gamcore.com##.row > .d-md-block
 gamcore.com##.row > .d-lg-block.d-none
 gamcore.com##.mycontainer > .d-lg-block.d-none > iframe
@@ -3358,6 +3357,10 @@ porcore.com##[style^="width:728px;height:90px"]
 porcore.com###videoitems.videoitems > .onevideothumb:has(> .clip-link > img[src^="/uploads/"][src$="gif"])
 porcore.com##[target="_blank"]:has([src*=".gif"])
 porcore.com##li > a[href*="/loader?"]
+gamcore.com##li.d-md-block
+gamcore.com##.menuArea a[href="https://www.porngames.tv/"]
+gamcore.com##.add_game.d-none
+gamcore.com##.item:has(> a[href^="/games/fuckyou/"])
 69games.xxx###footer
 69games.xxx###right
 69games.xxx###tvnotice
@@ -7216,7 +7219,7 @@ audiofanzine.com##+js(set, Math.pow, noopFunc)
 ! https://github.com/NanoMeow/QuickReports/issues/677
 hubzter.com##+js(aopr, adsanity_ad_block_vars)
 
-! sport stuff 
+! sport stuff
 /adu.php$frame,3p
 allfeeds.*,daddylive.*,sporting77.*,teleriumtv.*##+js(nowoif)
 allfeeds.*,teleriumtv.*###overlay
@@ -8677,7 +8680,7 @@ dreamdth.com##+js(aopw, wutimeBotPattern)
 ! https://www.reddit.com/r/uBlockOrigin/comments/8lmjam/please_help_me_bypass_the_adblock_detection_on/
 dreamdth.com##+js(set, adBlockDetected, false)
 dreamdth.com##+js(acs, $, show)
-		
+
 ! https://github.com/uBlockOrigin/uAssets/issues/5799
 ! https://github.com/uBlockOrigin/uAssets/issues/18375
 pornhub.*##+js(nostif, adsbytrafficjunkycontext)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://gamcore.com/games/exiles` (NSFW)

### Describe the issue

1. Incorrect blocking of links to sections of the site in the header, as well as non-blocking ad links.
2. Ad leftovers under the game.
3. Ad link in a card in the similar games section.

### Screenshot(s)

<details><summary>Screenshots of leftovers (NSFW):</summary>

![image](https://github.com/user-attachments/assets/8034c552-6905-450d-8dc9-8c2e6b653fa5)

</details>

### Versions

- Browser/version: Chrome 133
- uBlock Origin version: 1.62.0

### Settings

- Enable AdGuard URL Tracking Protection, EasyList/uBO - Cookie Notices, EasyList - Social Widgets, EasyList - Annoyances, uBlock filters - Annoyances, RU AdList filters.

### Notes

I have submitted a similar PR in the EL repo (https://github.com/easylist/easylist/pull/21287), but it has not been merged for over a week. Also, in a neighboring PR (https://github.com/easylist/easylist/pull/21289#discussion_r1976300897), one of the maintainers suggested that such rules would be more suitable for uAssets/AdGuard filters.