### PR TITLE
snapinst.app

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -4629,10 +4629,7 @@ planhub.ca##.h-banner
 ! https://github.com/uBlockOrigin/uAssets/issues/15803
 ! https://github.com/uBlockOrigin/uAssets/issues/17583
 ! https://github.com/uBlockOrigin/uAssets/issues/17714
-snapinsta.app###dlModal
-snapinsta.app##body:style(overflow: auto !important;)
-snapinsta.app###adOverlay
-snapinsta.app##+js(set, app.showModalAd, noopFunc)
+snapinst.app##+js(set, app.showModalAd, noopFunc)
 snaptik.app##[onclick^="showAd"]:remove-attr(onclick)
 snaptik.app##+js(aost, $, openAdsModal)
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://snapinst.app/

### Describe the issue

1. Open https://snapinst.app/
1. Paste some link, e.g. https://www.instagram.com/p/DFyBQ4MRPvB (this post contains a lot of pictures)
1. Click on download button
1. Ad appears on the download page and blocks scrolling

### Notes

the https://snapinsta.app/ domain used to redirect to https://snapinst.app/ for a while, but recently https://snapinsta.app/ is active again. However, as i can see, the old rules no longer apply there, so this PR removes them (`#adOverlay` still alive, but just block scrolling without the scriptlet)
