### PR TITLE
remove msk.su tld

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -5177,8 +5177,8 @@ app##center#yangchen > iframe#external-frame[src="https://im136.mom/"]:not([clas
 ||dichvutonghop.vip^$all,to=~giaohangtietkiem.vn
 ||giaohangtietkiem24.com^$all,to=~giaohangtietkiem.vn
 
-! https://social.immibis.com/notice/AjwiBkDIwtyORTzsAq
-||msk.su^$all
+! https://web.archive.org/web/20240917130138/https://social.immibis.com/notice/AjwiBkDIwtyORTzsAq
+||bensonmarketing.msk.su^$all
 
 ! https://social.immibis.com/notice/Ajz20OCipGbiOZVVaK
 ||bleyeare.com^$all


### PR DESCRIPTION
Instead of the domain from the post via the link, the entire TLD msk.su was blocked

### URL(s) where the issue occurs

`[At least one URL for a web page where the clearly described issue occurs is **mandatory**. The backticks surrounding the URLs is important, it prevents the URL from being clickable. Warn with "NSFW" where applicable.]`

### Describe the issue

[Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder.]

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: [here]
- uBlock Origin version: [here]

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
