### PR TITLE
urlskip filter for go.bsky.app/redirect

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1654,5 +1654,8 @@ videezy.com##+js(ra, onclick, a[onclick="fire_download_click_tracking();"], comp
 ! https://github.com/uBlockOrigin/uAssets/issues/27183
 thehindu.com##+js(remove-cookie, _pc_private)
 
+! https://github.com/bluesky-social/social-app/blob/d155b718b5b27003bad698c8d54ccf8b6a3f295c/src/lib/strings/url-helpers.ts#L323-L336
+||go.bsky.app/redirect$urlskip=?u
+
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://main.bsky.dev/` and soon `https://bsky.app/` (1.99 release possibly in under a day from now)

### Describe the issue

Clicking on external links now gets proxied to `https://go.bsky.app/redirect?u=<url>`. 

### Screenshot(s)

N/A

### Versions

- Browser/version: Firefox developer edition 137.0b3
- uBlock Origin version: 1.62.0

### Settings

- N/A

### Notes

https://github.com/bluesky-social/social-app/blob/d155b718b5b27003bad698c8d54ccf8b6a3f295c/src/lib/strings/url-helpers.ts#L323-L336

Only primary click is affected. Link anchor is still the original URL so middle click and context menu is unaffected.
