### PR TITLE
remove session_id parameter from Bluesky videos

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1658,6 +1658,8 @@ thehindu.com##+js(remove-cookie, _pc_private)
 ! https://github.com/uBlockOrigin/uAssets/pull/27500
 ||go.bsky.app/redirect*^u=http$urlskip=?u
 
+||video.bsky.app$removeparam=session_id
+
 ! https://www.farmersjournal.ie/news/news/my-farming-week-thomas-cosby-stradbally-co-laois-247317
 !#if cap_html_filtering
 farmersjournal.ie##^script:has-text(/detect|FingerprintJS/)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://bsky.app/`

### Describe the issue

Bluesky does session tracking between video segments when watching a video.

### Screenshot(s)

N/A

### Versions

- Browser/version: Firefox developer edition 137.0b3
- uBlock Origin version: 1.62.0

### Settings

N/A

### Notes

Example video playlist: `https://video.bsky.app/watch/did%3Aplc%3Agfk3o3vzzkwxwvpbfgpzcqqp/bafkreiecw3pzhgta34xm7g5vzvmiat3rxzvrpdltc46mknucqs6gavwite/playlist.m3u8`

The better (subjective) way of doing this would've been to redirect `video.bsky.app` directly to `video.cdn.bsky.app` as that's where the actual videos are located, [see here](https://gist.github.com/mary-ext/ef8d6bb0113f7acc933752e265a759a8/5b3b729046a71ac1cd41196f44225e1d2c7102c2#file-user-bsky-annoyances-js-L47-L56), however:

- This also means that videos will no longer have their closed captions/subtitles (if there's any attached)
- We don't seem to have any rule syntax for doing this, as it involves more than just substituting the domain.

Just removing `session_id` will do.

Not sure if this is worth an inclusion, but doesn't hurt to try.