### PR TITLE
bcs16.ro - anti-contextmenu

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7853,3 +7853,6 @@ samurai.wordoco.com##body * :not(input):not(textarea):style(-webkit-touch-callou
 ! https://sporttotal.tv/ - anti-adb
 sporttotal.tv##+js(no-fetch-if, doubleclick)
 sporttotal.tv##+js(set, HTMLImageElement.prototype.onerror, undefined)
+
+! https://bcs16.ro/ - anti-contextmenu
+bcs16.ro##+js(aopw, document.oncontextmenu)


### PR DESCRIPTION
`https://bcs16.ro/`

firefox