### PR TITLE
Bing.com web result getting blocked with the new filter

### DIFF
--- a/filters/quick-fixes.txt
+++ b/filters/quick-fixes.txt
@@ -188,7 +188,6 @@ smsonline.cloud##aside[class^="css-"]:has(> p:has-text(Advertisement) + ins.adsb
 ! https://github.com/uBlockOrigin/uAssets/pull/26342
 ! https://github.com/uBlockOrigin/uAssets/issues/26393
 ! https://github.com/uBlockOrigin/uAssets/issues/26623
-bing.com##ol#b_results > li[class="b_algo"]:has(> div[class="b_title"]):has(> div[class="b_tpcn"] > a[class="tilk"]:not([href^="https://www.bing.com/"]))
 bing.com##+js(no-xhr-if, /fd/ls/lsp.aspx)
 bing.com##ol#b_results > li:has(> :is(.b_tpcn, .b_title, h2) a[href^="https://www.bing.com/aclk?"])
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
https://www.bing.com/search?q=hello%20world&qs=n&form=QBRE&sp=-1&lq=0&pq=hello%20world

`[At least one URL for a web page where the clearly described issue occurs is **mandatory**. The backticks surrounding the URLs is important, it prevents the URL from being clickable. Warn with "NSFW" where applicable.]`

### Describe the issue
Web result for Bing also blocked with Ads because of the new filter rule, all of them!
`bing.com##ol#b_results > li[class="b_algo"]:has(> div[class="b_title"]):has(> div[class="b_tpcn"] > a[class="tilk"]:not([href^="https://www.bing.com/"]))`


<br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>

[Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder.]

### Screenshot(s)

| With uBlock turned on | uBlock turned off |
| ------------------------ | -------------------- |
| ![image](https://github.com/user-attachments/assets/4821c594-212e-4b2b-a5ee-f495fd0e2d4c) | ![image](https://github.com/user-attachments/assets/9af61b15-0849-4ac4-b198-a1ef49c8459d) |

![image](https://github.com/user-attachments/assets/ac1cfd44-7a55-4716-a58e-dd27cda39791)


[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: [here]
- uBlock Origin version: [here]

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
