### PR TITLE
Fix CPPA consent warning on theguardian.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -4087,6 +4087,8 @@ wilfa.com##+js(trusted-set-cookie, _pandectes_gdpr, eyJjb3VudHJ5Ijp7ImNvZGUiOiJG
 
 ! https://github.com/uBlockOrigin/uAssets/issues/27450
 theguardian.com##+js(trusted-click-element, button.sp_choice_type_11)
+! US IP (CPPA California)
+sourcepoint.theguardian.com##+js(trusted-click-element, button[title="Do not sell or share my personal information"], , 1000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/27488
 max.com##+js(trusted-click-element, 'div[aria-labelledby="dialog-heading"] div[class^="StyledButtonsWrapper"] > button + button, #dialog-dynamic-section div[class^="StyledButtonsWrapper"] > button + button', '', 500)


### PR DESCRIPTION
US (california) specific consent message for theguardian