### PR TITLE
Merge all Anti-adblock rules into START/END

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -995,9 +995,6 @@ sovetromantica.com##+js(set, fuckAdBlock, trueFunc)
 ! https://github.com/NanoMeow/QuickReports/issues/4360
 scriptinghelpers.org##.shvertise-banner
 
-! mbs.jp right click
-mbs.jp##+js(aopw, document.oncontextmenu)
-
 ! https://github.com/NanoMeow/QuickReports/issues/4372
 polyflore.net##+js(nostif, adBlockDetected)
 
@@ -3728,9 +3725,6 @@ citas.in##+js(aeld, copy)
 ! radichubu.jp right click
 radichubu.jp##+js(ra, onContextMenu, body)
 
-! https://github.com/NanoMeow/QuickReports/issues/4360
-scriptinghelpers.org##.shvertise-banner
-
 ! mbs.jp right click
 mbs.jp##+js(aopw, document.oncontextmenu)
 
@@ -4540,9 +4534,6 @@ hitproversion.com##style:has-text(user-select:):remove()
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/83556
 news.dwango.jp##+js(ra, oncontextmenu, body)
-
-! https://github.com/uBlockOrigin/uAssets/issues/9159
-olarila.com##+js(nostif, offsetHeight)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/9170
 blisseyhusband.in##+js(acs, jQuery, contextmenu)

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -83,30 +83,6 @@ impots.gouv.fr##+js(set, PASSER_videoPAS_apres, 0)
 
 ! flickr.com "Upgrade to Flickr Pro to hide these ads" 
 flickr.com##.moola-search-view:has-text(hide these ads)
-! END: Anti-adblock
-
-! https://github.com/uBlockOrigin/uAssets/issues/933
-! https://github.com/easylist/EasyListHebrew/issues/332
-||holyclock.com^$3p
-||shomershabes.com^$3p
-||shomershabes.co.il^$3p
-
-! https://github.com/uBlockOrigin/uAssets/issues/2044
-pinterest.*##[data-test-giftwrap]
-pinterest.*###desktopWrapper:style(position: static !important;)
-pinterest.*##.gridCentered:style(margin-top: auto !important;)
-! https://github.com/uBlockOrigin/uAssets/issues/5030
-pinterest.*##div[data-test-id="giftWrap"]
-pinterest.*##div[class="Closeup__wrapper"] > div > div[style^="cursor: default"]
-pinterest.*##div[class="GrowthUnauthPinImage__imageDim"]
-pinterest.*##.GrowthUnauthPinImage > a > div[class^="Jea"]:has(button[class^="noButtonStyles "])
-pinterest.*##.Hsu.iyn.zI7:nth-of-type(2) > div > .FullPageModal__scroller
-! https://www.reddit.com/r/uBlockOrigin/comments/1hzblue/how_to_bypass_pinterest_forced_register/
-pinterest.*##+js(set-local-storage-item, DWEB_PIN_IMAGE_CLICK_COUNT, $remove$)
-pinterest.*##+js(trusted-replace-argument, Storage.prototype.setItem, 0, json:"DWEB", condition, DWEB_PIN_IMAGE_CLICK_COUNT)
-! "Sign Up to download"
-pinterest.*##+js(set-local-storage-item, unauthDownloadCount, $remove$)
-pinterest.*##+js(trusted-replace-argument, Storage.prototype.setItem, 0, json:"", condition, unauthDownloadCount)
 
 ! https://github.com/NanoAdblocker/NanoFilters/issues/120
 files.minecraftforge.net##.promo-container
@@ -114,58 +90,11 @@ files.minecraftforge.net##.promo-container
 ! https://github.com/NanoAdblocker/NanoFilters/issues/134
 tv.mademyday.com##.blnotice
 
-! https://github.com/uBlockOrigin/uAssets/issues/2972
-mimaletamusical.blogspot.com##+js(aopw, document.oncontextmenu)
-
-! https://github.com/uBlockOrigin/uAssets/issues/2992
-fmhikayeleri.com##+js(acs, document.oncontextmenu)
-
-! https://github.com/uBlockOrigin/uAssets/issues/3032
-experts-exchange.com###topHeaderBannerWrap
-experts-exchange.com##.navigationWrapper:style(top: 0px !important;)
-
-! https://forums.lanik.us/viewtopic.php?f=62&t=41296
-digitalsynopsis.com##+js(aopr, disableSelection)
-digitalsynopsis.com##+js(aopr, document.oncontextmenu)
-
-! https://forums.lanik.us/viewtopic.php?f=62&t=41301
-filefox.cc##+js(aeld, blur)
-
-! https://github.com/uBlockOrigin/uAssets/issues/3096 right click
-visionias.net##+js(acs, $, contextmenu)
-
-! https://github.com/uBlockOrigin/uAssets/issues/2546
-99bitcoins.com##+js(nostif, ThriveGlobal)
-
 ! https://github.com/NanoAdblocker/NanoFilters/issues/156
 punto-informatico.it##+js(aopr, blazemedia_adBlock)
 
-! https://github.com/uBlockOrigin/uAssets/pull/3117
-! https://github.com/uBlockOrigin/uAssets/issues/6938
-uol.com.br##+js(aeld, copy)
-uol.com.br##+js(aopw, addLink)
-*/lib.ucopy/ucopy.js$script,domain=uol.com.br
-! https://github.com/uBlockOrigin/uAssets/issues/6938#issuecomment-898859152
-ne10.uol.com.br##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/3115
-@@||umterps.com^$ghide
-umterps.com##.single-ad
-
-! https://forums.lanik.us/viewtopic.php?f=62&t=41339
-cars.com##.dialog
-cars.com##body:style(overflow: auto !important; position: initial !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/2672
-peliculas24.me##+js(aopw, disableSelection)
-peliculas24.me##+js(aeld, contextmenu)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/3199
 warringtonguardian.co.uk##+js(aopw, _sp_)
-
-! right click, select, copy cristoiublog.ro
-cristoiublog.ro##+js(aopw, document.oncontextmenu)
-cristoiublog.ro##+js(aopw, document.onselectstart)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3204
 myfxbook.com##+js(nostif, checkForAds)
@@ -198,35 +127,15 @@ racefans.net##.textwidget
 ! https://github.com/uBlockOrigin/uAssets/issues/3319
 eca-anime.net##+js(acs, document.getElementById, advert-tester)
 
-! https://github.com/uBlockOrigin/uAssets/issues/3325
-gazetadopovo.com.br##+js(aeld, copy)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/854
 ! https://forums.lanik.us/viewtopic.php?p=133969#p133969
 foodnetwork.com##.o-AdhesionNotifier
 
-! https://github.com/uBlockOrigin/uAssets/issues/3372
-gaypornmasters.com##+js(aopr, document.oncontextmenu)
-||gaypornmasters.com^$csp=script-src *
-gaypornmasters.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
 ! https://github.com/NanoMeow/QuickReports/issues/47
 gearside.com##+js(set, nebula.session.flags.adblock, undefined)
 
-! https://github.com/uBlockOrigin/uAssets/issues/3380
-braziljournal.com##+js(acs, document.oncopy)
-braziljournal.com##body:style(overflow: auto !important;)
-braziljournal.com##.in.fade
-
-! https://github.com/uBlockOrigin/uAssets/issues/3382
-emol.com##+js(aopr, addLink)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/3411
 @@||radioline.co/*/ad$1p
-
-! https://github.com/uBlockOrigin/uAssets/issues/2938
-voirfilms.*##+js(aopr, document.oncontextmenu)
-voirfilms.*##+js(aopr, document.onselectstart)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3278#issuecomment-421038747
 nytimes.com##+js(set, _adBlockCheck, true)
@@ -237,6 +146,7 @@ nytimes.com##+js(set, navigator.storage.estimate, undefined)
 !#if env_firefox
 nytimes.com##+js(set, webkitRequestFileSystem, noopFunc)
 !#endif
+
 ! https://github.com/uBlockOrigin/uAssets/issues/5677#issuecomment-596154482
 nytimes.com##.ReactModalPortal:has(.welcomeAd)
 
@@ -255,104 +165,22 @@ mixmods.com.br##+js(aopr, abde)
 columbiaspectator.com##+js(nostif, ads, 2000)
 
 ! https://github.com/NanoMeow/QuickReports/issues/97
-knshow.com##+js(aopr, document.oncontextmenu)
-knshow.com##+js(aeld, /^(?:contextmenu|copy|selectstart)$/)
 @@||knshow.com^$ghide
 knshow.com##.adsbygoogle
 knshow.com##div[id^="div-gpt-ad-"]
-
-! https://github.com/uBlockOrigin/uAssets/issues/3514
-classicreload.com###sliding-popup.sliding-popup-bottom
-
-! https://www.reddit.com/r/uBlockOrigin/comments/9gr8tv/force_allow_text_copy/
-jusbrasil.com.br##+js(aeld, /^(?:contextmenu|copy)$/, preventDefault)
-
-! https://github.com/NanoMeow/QuickReports/issues/108
-descarga-animex.*##+js(aeld, /^(?:contextmenu|keydown)$/)
-
-! https://github.com/uBlockOrigin/uAssets/issues/3447#issuecomment-422715065
-deezer.com##+js(aopr, onbeforeunload)
-! https://github.com/uBlockOrigin/uAssets/issues/5030
-deezer.com###modal_login:upward(2)
-! https://github.com/uBlockOrigin/uAssets/issues/22961
-! https://www.reddit.com/r/uBlockOrigin/comments/1bkft5k/ublock_annoyances_filter_is_breaking_scrolling_on/
-! deezer.com##.chakra-portal:has(> [data-focus-lock-disabled] > .chakra-modal__content-container a.chakra-button[href^="https://www.deezer.com/payment/go.php?origin=paywall_pressure"])
-! deezer.com##body.force-scrollbar:style(overflow-y: scroll !important;)
-deezer.com##+js(trusted-click-element, .chakra-portal .chakra-modal__content-container > section.chakra-modal__content > .chakra-modal__header:has(> .chakra-stack > a[href^="https://www.deezer.com/payment/go.php?origin=paywall_pressure"]) + button.chakra-modal__close-btn)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3535
 ! https://github.com/uBlockOrigin/uAssets/issues/4067
 tvtropes.org##+js(set, valid_user, true)
 ||global.proper.io/tvtropes.min.js$script,redirect=noopjs,domain=tvtropes.org
 
-! https://github.com/uBlockOrigin/uAssets/issues/3545
-springfieldspringfield.co.uk##+js(aopr, addLink)
-
 ! https://github.com/NanoMeow/QuickReports/issues/117
 @@||justtrucks.com.au^$ghide
 justtrucks.com.au##+js(set, Drupal.behaviors.detectAdblockers, noopFunc)
 @@||justtrucks.com.au^$image
 
-! https://github.com/ryanbr/fanboy-adblock/issues/554
-omr.com###dsgvoModal
-omr.com##.modal-backdrop
-omr.com##body:style(overflow: auto !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/3553
-indiatimes.com##+js(aeld, copy)
-
-! https://github.com/uBlockOrigin/uAssets/issues/911#issuecomment-423771909
-||adsrt.com/assets/js/particles.min.js$script
-
-! https://github.com/uBlockOrigin/uAssets/issues/3591
-nulled.life##+js(ra, oncontextmenu)
-
-! https://github.com/jspenguin2017/uBlockProtector/issues/992
-mediafire.com##+js(nostif, scan, 500)
-
-! https://github.com/uBlockOrigin/uAssets/issues/3599
-ebc.com.br##+js(ra, oncopy)
-
-! https://github.com/uBlockOrigin/uAssets/issues/3614
-||tours.fr/include/js/tagAnalyticsCNIL.php$script,1p
-
 ! https://github.com/NanoMeow/QuickReports/issues/142
 flyertalk.com##+js(acs, $, AdBlock)
-
-! https://forums.lanik.us/viewtopic.php?f=62&t=41811
-artsy.net##+js(aeld, scroll)
-
-! https://github.com/uBlockOrigin/uAssets/issues/3621
-searchenginewatch.com##+js(acs, jQuery, #sign-up-popup)
-
-! popular on FB
-facebook.com,facebookcorewwwi.onion,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##.fbUserStory:has-text(Popular Across Facebook)
-facebook.com,facebookcorewwwi.onion,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##.userContentWrapper:has-text(Popular Across Facebook)
-! https://github.com/uBlockOrigin/uAssets/issues/3367#issuecomment-1993620105 - "Suggested for you" posts
-! https://github.com/uBlockOrigin/uAssets/issues/3367#issuecomment-2248409212
-!#if cap_html_filtering
-! ||facebook.com/api/graphql/$xhr,replace=/\{"newest_lbl_for_brs"[^\n]+?"follow_button":\{"__typename":"CometFeedStoryFollowButtonStrategy"[^\n]+"cursor":"[^"]+"\}/{}/g,domain=web.facebook.com|www.facebook.com
-||facebook.com/api/graphql/$xhr,1p,replace=/,"category_sensitive"[^\n]+?"follow_button":\{"__typename":"CometFeedStoryFollowButtonStrategy"[^\n]+"cursor":"[^"]+"\}/}/g,domain=web.facebook.com|www.facebook.com
-!#else
-! web.facebook.com,www.facebook.com##+js(trusted-replace-xhr-response, '/\{"newest_lbl_for_brs":[^\n]+?"follow_button":\{"__typename":"CometFeedStoryFollowButtonStrategy"[^\n]+"cursor":"[^"]+"\}/g', {}, /api/graphql)
-web.facebook.com,www.facebook.com##+js(trusted-replace-xhr-response, '/,"category_sensitive"[^\n]+?"follow_button":\{"__typename":"CometFeedStoryFollowButtonStrategy"[^\n]+"cursor":"[^"]+"\}/g', }, /api/graphql)
-!#endif
-! FB link redirection
-www.facebook.com##+js(json-prune, require.0.3.0.__bbox.define.[].2.is_linkshim_supported require.0.3.0.__bbox.define.[].2.click_ids)
-||l.facebook.com/l.php?u=$doc,urlskip=?u
-||l.instagram.com/?u=$doc,urlskip=?u
-
-! right click, select, copy => http://www.oggiscuola.com/web/2018/09/22/alzarsi-in-piedi-quando-entra-il-professore-e-una-forma-di-saluto-che-va-recuperata/
-oggiscuola.com##+js(acs, jQuery, overlay)
-||oggiscuola.com^$csp=style-src 'self' *
-||oggiscuola.com/*/banner$image
-
-! https://github.com/uBlockOrigin/uAssets/issues/3660
-odiario.com##+js(aeld, copy)
-
-! select, copy cittadinanza.biz | glistranieri.it
-cittadinanza.biz,glistranieri.it##+js(set, disableSelection, noopFunc)
-cittadinanza.biz,glistranieri.it##+js(aopw, document.oncontextmenu)
 
 ! https://github.com/NanoMeow/QuickReports/issues/179
 esercizinglese.com,pelisfull.tv##+js(aopw, adBlockDetected)
@@ -361,29 +189,11 @@ masternodes.pro###adblocker
 ! https://github.com/NanoMeow/QuickReports/issues/182
 ancient.eu##+js(set, ADBdetected, noopFunc)
 
-! https://github.com/uBlockOrigin/uAssets/issues/3699
-petrimazepa.com##.ui-dialog[tabindex="-1"]
-
-! https://github.com/uBlockOrigin/uAssets/issues/3704
-sabishiidesu.com##+js(acs, document.onkeydown)
-sabishiidesu.com##+js(aopw, document.oncontextmenu)
-sabishiidesu.com##.unselectable:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
 ! https://github.com/NanoMeow/QuickReports/issues/215
 gota.io##+js(aopr, fuckAdBlock)
 
-! https://github.com/uBlockOrigin/uAssets/issues/3738
-webcodegeeks.com##+js(nostif, onload_popup, 8000)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/3743
 greenocktelegraph.co.uk##+js(aopr, _sp_._networkListenerData)
-
-! select, copy http://www.livetennis.it/post/302572/atp-stoccolma-fabio-fognini-conquista-le-semifinali/
-livetennis.it##+js(ra, onselectstart)
-livetennis.it##p:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! select https://www.readlightnovel.org/the-good-for-nothing-seventh-young-lady/chapter-1091
-readlightnovel.org##.chapter-content3:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3790
 kashmirobserver.net##+js(acs, document.getElementById, ad-blocker)
@@ -393,12 +203,6 @@ allafinedelpalo.it##+js(aopr, ABDSettings)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3814
 cathouseonthekings.com##+js(acs, document.getElementById, .ab_detected)
-
-! https://github.com/uBlockOrigin/uAssets/issues/3830
-tinyppt.com##+js(aopw, document.ondragstart)
-tinyppt.com##+js(aopw, disableEnterKey)
-tinyppt.com##+js(acs, document.oncontextmenu)
-tinyppt.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3842
 wotlabs.net##:xpath('//*[contains(text(),"AdB")]')
@@ -437,17 +241,8 @@ centrumher.eu##+js(acs, jQuery, undefined)
 ! https://github.com/uBlockOrigin/uAssets/issues/3884
 opedge.com##+js(nostif, (), 2000)
 
-! https://github.com/uBlockOrigin/uAssets/issues/3880#issuecomment-433622746
-droidtekno.com##+js(aopw, document.ondragstart)
-droidtekno.com##+js(aopw, disableEnterKey)
-droidtekno.com##.unselectable:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/3885
 northwestfirearms.com,techkings.org##+js(set, samDetected, true)
-
-! https://github.com/uBlockOrigin/uAssets/issues/3898
-community.simtropolis.com##.ipsModal
-community.simtropolis.com##.ipsDialog
 
 ! https://github.com/uBlockOrigin/uAssets/issues/3900
 fabricjs.com##+js(nostif, (), 4000)
@@ -533,19 +328,8 @@ stoneyroads.com##.ad-container
 ! https://github.com/uBlockOrigin/uAssets/issues/3964
 pokemonforever.com##+js(set, google_jobrunner, true)
 
-! https://github.com/NanoMeow/QuickReports/issues/265
-businessemailetiquette.com##+js(aopw, disableEnterKey)
-businessemailetiquette.com##+js(aopw, document.ondragstart)
-businessemailetiquette.com##.unselectable:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://www.camp-firefox.de/forum/viewtopic.php?p=1096410#p1096410
-liveonsat.com##+js(ra, oncontextmenu)
-
 ! https://github.com/NanoMeow/QuickReports/issues/267
 bucketpages.com##+js(nostif, #advert-tracker, 500)
-
-! https://github.com/NanoMeow/QuickReports/issues/273
-xiaomi4mi.com##+js(aopw, document.oncontextmenu)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4031
 evades.io##.disable-prompt-header
@@ -558,6 +342,9 @@ orlygift.com##div[id^="div-gpt-ad"]
 ! https://github.com/uBlockOrigin/uAssets/issues/4042
 heroescommunity.com###he1
 
+! https://github.com/NanoMeow/QuickReports/issues/273
+xiaomi4mi.com##+js(aopw, document.oncontextmenu)
+
 ! https://github.com/uBlockOrigin/uAssets/issues/4041
 xhardhempus.com##+js(aopw, clickIE)
 
@@ -569,6 +356,1732 @@ steptalk.org##+js(nostif, (), 3000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4046
 short-story.net##+js(nostif, (), 2000)
+
+! https://forums.lanik.us/viewtopic.php?f=64&t=42119#p143017
+carsguide.com.au##+js(set, isAdblockDisabled, true)
+carsguide.com.au###adBlockMessage
+
+! https://github.com/NanoMeow/QuickReports/issues/309
+@@||dermatologytimes.com^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/issues/4120
+! https://github.com/NanoMeow/QuickReports/issues/32
+motherjones.com##.mj-adblock-widget
+
+! https://github.com/uBlockOrigin/uAssets/issues/4125
+boerse-express.com##+js(nostif, (), 1000)
+
+! https://github.com/uBlockOrigin/uAssets/issues/4135
+videohelp.com##+js(acs, document.getElementById, block)
+
+! https://github.com/NanoMeow/QuickReports/issues/342
+! https://github.com/NanoMeow/QuickReports/issues/617
+! https://github.com/NanoMeow/QuickReports/issues/1412
+polygon.com##+js(aopw, loadOutbrain)
+##.adblock-whitelist-messaging__article-wrapper
+##.adblock-whitelist-messaging__wrapper
+
+! https://github.com/uBlockOrigin/uAssets/issues/4151
+economictimes.indiatimes.com##+js(aopr, intsFequencyCap)
+! https://github.com/uBlockOrigin/uAssets/issues/10598
+economictimes.indiatimes.com##+js(aeld, contextmenu)
+
+! https://github.com/uBlockOrigin/uAssets/issues/4158
+! https://github.com/uBlockOrigin/uAssets/issues/26210
+numberempire.com##+js(nostif, w3ad, 1000)
+
+! https://github.com/uBlockOrigin/uAssets/issues/4207
+proxfree.com###pftop:style(height: auto !important;padding-bottom:5px !important)
+proxfree.com##.pflrgAds
+
+! https://github.com/uBlockOrigin/uAssets/issues/4237
+! https://github.com/NanoMeow/QuickReports/issues/3139
+@@||md5hashing.net^$ghide
+*$script,3p,redirect-rule=noopjs,domain=md5hashing.net
+md5hashing.net##.alert-danger.alert
+md5hashing.net##.red.b.center.mute
+
+! https://github.com/uBlockOrigin/uAssets/issues/4244
+siliconinvestor.com##+js(acs, document.getElementById, undefined)
+
+! https://github.com/uBlockOrigin/uAssets/issues/5489
+102bank.com,80beyond.spacestation-online.com,b4usa.com,badgerandblade.com,mzk.starachowice.eu##+js(aopw, adBlockDetected)
+||algosit.com^
+
+! https://twitter.com/holly/status/1070781008457490433
+merchoid.com###message-purchased
+
+! https://github.com/NanoMeow/QuickReports/issues/422
+@@||topspeed.com^$ghide
+topspeed.com##.adsninja-ad-zone
+topspeed.com##.txt-ad
+topspeed.com##.daily-vid-ad
+topspeed.com##.top-horizontal-ad-content
+
+! https://github.com/uBlockOrigin/uAssets/issues/4268#issuecomment-445481905
+webwereld.nl##+js(set, adsAreShown, true)
+
+! https://github.com/NanoMeow/QuickReports/issues/433
+sbenny.com##+js(nostif, (), 2000)
+forum.sbenny.com##.message-inner:has(.ads)
+
+! https://github.com/NanoMeow/QuickReports/issues/446
+howjsay.com##+js(nostif, (), 1500)
+
+! anti adb warning /bigleaguepolitics . com
+@@||bigleaguepolitics.com^$ghide
+
+! https://github.com/NanoMeow/QuickReports/issues/366
+fin24.com##+js(aopr, Date.prototype.toUTCString)
+
+! https://github.com/uBlockOrigin/uAssets/issues/4388
+palemoon.org##+js(set, abd, false)
+
+! https://github.com/uBlockOrigin/uAssets/issues/4409
+cagesideseats.com##+js(nostif, (), 1500)
+
+! https://github.com/uBlockOrigin/uAssets/issues/4368#issuecomment-449870173
+space-engineers.de##+js(acs, document.getElementById, undefined)
+
+! https://github.com/NanoMeow/QuickReports/issues/505
+@@||soundonsound.com^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/issues/4447
+@@||jrocknews.com^$ghide
+
+! https://github.com/NanoMeow/QuickReports/issues/531
+wheel-size.com##+js(set, detector_active, true)
+
+! https://github.com/uBlockOrigin/uAssets/issues/4551
+@@||creditonebank.com^$ghide
+
+! https://forums.lanik.us/viewtopic.php?p=144782#p144782
+aoezone.net##+js(set, aoezone_adchecker, true)
+
+! https://github.com/uBlockOrigin/uAssets/issues/4650
+r7.com###inner-ad-container
+
+! https://github.com/NanoMeow/QuickReports/issues/590
+xnxx.com##+js(aopr, fuckAdBlock)
+
+! https://github.com/NanoMeow/QuickReports/issues/595
+@@||pagead2.googlesyndication.com/pagead/*$image,domain=free-scores.com
+
+! https://github.com/NanoMeow/QuickReports/issues/33#issuecomment-457932561
+windowscentral.com##.swal-modal, .swal-overlay
+
+! https://github.com/NanoMeow/QuickReports/issues/631
+randaris.app##.adblock-box
+
+! nachrichten . at anti adb
+@@||nachrichten.at^$ghide
+
+! https://www.reddit.com/r/uBlockOrigin/comments/annrln/polygon_antiadblock/
+heroesneverdie.com##+js(nostif, adsBlocked)
+
+! https://github.com/NanoMeow/QuickReports/issues/648
+! https://github.com/jspenguin2017/uBlockProtector/issues/1019
+curbed.com,eater.com,funnyordie.com,mmafighting.com,mmamania.com,polygon.com,racked.com,riftherald.com,sbnation.com,theverge.com,vox.com##+js(nostif, adsBlocked)
+
+! bdcraft
+@@||bdcraft.net^$ghide
+bdcraft.net##+js(set, adsbygoogle, null)
+bdcraft.net##.cc-banner
+bdcraft.net##.hostBtn
+bdcraft.net##.adsbygoogle
+bdcraft.net###bottombanner
+bdcraft.net###header > .wrapper > [class]
+
+! https://github.com/uBlockOrigin/uAssets/issues/4947
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=yellowbridge.com
+
+! https://github.com/uBlockOrigin/uAssets/issues/4950
+diynetwork.com##.o-AdhesionNotifier
+
+! https://github.com/NanoMeow/QuickReports/issues/701
+androidcentral.com##.swal-overlay
+
+! https://github.com/NanoMeow/QuickReports/issues/713
+@@||eppingforestguardian.co.uk^$ghide
+eppingforestguardian.co.uk##.dfp-ad
+eppingforestguardian.co.uk##.mar-block-ad
+
+! https://github.com/NanoMeow/QuickReports/issues/714
+||code.adsales.snidigital.com/lib/*/sni-ads.min.js$script,domain=travelchannel.com
+
+! https://github.com/uBlockOrigin/uAssets/issues/5002
+diffnow.com##:xpath(//div[contains(text(),"Adblock")]/..)
+
+! https://github.com/NanoMeow/QuickReports/issues/783
+ruwix.com##+js(nostif, NoAd, 8000)
+
+! https://github.com/NanoMeow/QuickReports/issues/885
+rp5.by##+js(nostif, (), 700)
+
+! https://github.com/uBlockOrigin/uAssets/issues/5286
+postandcourier.com##.tp-backdrop, .tp-modal
+
+! https://github.com/NanoMeow/QuickReports/issues/1324
+@@||globalnews.ca^$ghide
+globalnews.ca##.ad-container
+globalnews.ca###headerAd
+
+! https://github.com/uBlockOrigin/uAssets/issues/186#issuecomment-486142318
+wired.co.uk##+js(set, ads_not_blocked, true)
+
+! https://github.com/NanoMeow/QuickReports/issues/1073
+polygon.com##+js(nostif, adsBlocked)
+
+! https://github.com/NanoMeow/QuickReports/issues/1071
+twinkietown.com##+js(nostif, adsBlocked)
+
+! https://github.com/NanoMeow/QuickReports/issues/1114
+@@||dcdirtylaundry.com^$ghide
+
+! https://github.com/NanoMeow/QuickReports/issues/1126
+@@||sostariffe.it^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/issues/5530
+playonlinux.com##+js(acs, $, load)
+
+! https://github.com/uBlockOrigin/uAssets/issues/2101#issuecomment-491625176
+zdnet.de##+js(aopr, can_i_run_ads)
+
+! https://github.com/NanoMeow/QuickReports/issues/1209
+cinemablend.com##+js(aopr, __cmpGdprAppliesGlobally)
+
+! https://github.com/uBlockOrigin/uAssets/issues/5613
+@@||metabattle.com^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/issues/5643
+gq-magazine.co.uk##+js(set, ads_not_blocked, true)
+
+! turbolab .it anti adb warning
+turbolab.it##+js(nostif, warning)
+
+! https://github.com/NanoMeow/QuickReports/issues/1311
+medicalnewstoday.com##.sticky_ad_container
+
+! https://github.com/NanoMeow/QuickReports/issues/1338
+buienradar.nl##+js(set, hideBannerBlockedMessage, true)
+buienradar.nl###adholderContainerHeader
+
+! glamourmagazine.co.uk anti adb annoyance
+glamourmagazine.co.uk##+js(set, ads_not_blocked, true)
+
+! https://github.com/NanoMeow/QuickReports/issues/1394
+9xbuddy.com##+js(nostif, adsbygoogle)
+
+! https://forums.lanik.us/viewtopic.php?f=62&t=43213
+dispatch.com##.tp-modal
+dispatch.com##.tp-active.tp-backdrop
+dispatch.com##body:style(overflow: auto !important;)
+
+! https://github.com/NanoMeow/QuickReports/issues/1470
+anisearch.com#@##bannerads
+
+! https://github.com/uBlockOrigin/uAssets/issues/5911#issuecomment-511588571
+context.reverso.net##.blocked:style(filter: none !important;)
+context.reverso.net##.blocked .text:style(filter: none!important;-webkit-filter: none!important;)
+context.reverso.net###blocked-results-banner
+
+! https://github.com/NanoMeow/QuickReports/issues/1508
+hardware.info##body > div:nth-of-type(1) > div:has-text(adblocker)
+hardware.info##.sidebar_right_bottom
+hardware.info##.sidebar_right_top
+
+! https://github.com/uBlockOrigin/uAssets/issues/5970
+med1.de##+js(aopr, _sp_._networkListenerData)
+
+! https://github.com/NanoMeow/QuickReports/issues/1527
+@@||mentalmars.com^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/issues/5979
+neowin.net##+js(aopr, _sp_.mms.startMsg)
+neowin.net##[class^="sp_veil"]
+neowin.net##[id^="sp_message_panel_id"]
+
+! https://github.com/NanoMeow/QuickReports/issues/1588
+@@||independent.ie^$ghide
+
+! https://forums.lanik.us/viewtopic.php?f=62&t=43327&p=148979#p148979
+@@||nzz.ch^$ghide
+nzz.ch###adnz_maxiboard_1
+
+! https://github.com/uBlockOrigin/uAssets/issues/6021
+watson.de,watson.ch##+js(nostif, AdBlocker)
+
+! https://github.com/NanoMeow/QuickReports/issues/292
+babel.com##[id^=adReplacement]
+babel.com##.infopub
+
+! https://github.com/NanoMeow/QuickReports/issues/1620
+@@||airbnbhell.com^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/issues/4707
+clk.ink##+js(set, blurred, false)
+
+! https://github.com/uBlockOrigin/uAssets/issues/6050
+smashboards.com##+js(nosiif, height)
+
+! https://github.com/uBlockOrigin/uAssets/issues/6093
+@@||cdnjs.cloudflare.com/ajax/libs/blockadblock/*/blockadblock.min.js$script,domain=starblast.io
+@@||starblast.io^$ghide
+*$script,redirect-rule=noopjs,domain=starblast.io
+
+! https://github.com/NanoMeow/QuickReports/issues/1709
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,domain=files2zip.com
+files2zip.com##div.black.banner
+
+! https://www.reddit.com/r/uBlockOrigin/comments/cvm6pn/how_to_get_rid_of_blurred_text_on_websites_such/
+enotes.com##.obscured:style(color: black !important;text-shadow: none !important; filter: none !important)
+enotes.com##.paywall-mount
+
+! https://github.com/NanoMeow/QuickReports/issues/1396
+@@||wired.com^$ghide
+wired.com##.ad
+
+! https://github.com/NanoMeow/QuickReports/issues/1780
+@@||belfasttelegraph.co.uk^$ghide
+
+! https://github.com/NanoMeow/QuickReports/issues/1822
+tomsguide.com##+js(aopr, _sp_._networkListenerData)
+
+! https://github.com/NanoMeow/QuickReports/issues/1832
+@@||flightaware.com^$ghide
+
+! https://www.reddit.com/r/uBlockOrigin/comments/d5ekq0/antiadblock_detected_wwwlesoirbe/
+lesoir.be##+js(aopr, abStyle)
+
+! https://github.com/uBlockOrigin/uAssets/issues/6318
+xe.gr##+js(nostif, modal)
+
+! https://github.com/NanoMeow/QuickReports/issues/1865
+@@||typing-speed.net^$ghide
+
+! https://github.com/NanoMeow/QuickReports/issues/1867
+plagiarisma.net###noty_bottom_layout_container
+
+! https://forums.lanik.us/viewtopic.php?f=62&t=43618
+bold.dk##+js(acs, eval, abd)
+
+! https://github.com/NanoMeow/QuickReports/issues/1933
+@@||as.com^$ghide
+as.com##.publi
+
+! https://github.com/NanoMeow/QuickReports/issues/1948
+pureinfotech.com##+js(acs, jQuery, ai_adb)
+
+! https://forums.lanik.us/viewtopic.php?f=62&t=43651
+fairyabc.com##+js(nostif, adblock)
+
+! https://github.com/uBlockOrigin/uAssets/issues/4802
+@@||minecraft-schematics.com^$ghide
+minecraft-schematics.com##.adsbygoogle
+minecraft-schematics.com##[href^="http://www.pingperfect.com/aff.php"]
+
+! https://github.com/NanoMeow/QuickReports/issues/2119
+@@||dumpert.nl^$ghide
+
+! https://github.com/NanoMeow/QuickReports/issues/2123
+@@||beinsports.com^$ghide
+
+! https://github.com/NanoMeow/QuickReports/issues/2143
+@@||mizonatv.com^$ghide
+
+! https://github.com/NanoMeow/QuickReports/issues/2154
+nakedcapitalism.com##+js(aopw, ABD)
+
+! https://github.com/uBlockOrigin/uAssets/issues/6509
+molineuxmix.co.uk##+js(acs, $, undefined)
+
+! https://github.com/NanoMeow/QuickReports/issues/2240
+foxnews.com##:xpath('//*[contains(text(),"blocking software")]/../../..')
+/google-funding-choices.js$script,domain=foxnews.com
+
+! https://github.com/NanoMeow/QuickReports/issues/2257
+laptopmag.com##+js(aopr, _sp_.mms.startMsg)
+
+! https://github.com/uBlockOrigin/uAssets/issues/6572
+windows101tricks.com##+js(aopr, __cmpGdprAppliesGlobally)
+windows101tricks.com##+js(set, better_ads_adblock, 0)
+
+! https://github.com/NanoMeow/QuickReports/issues/2535
+minecraftforge.net##+js(nostif, body)
+
+! https://github.com/NanoMeow/QuickReports/issues/2545
+forum.nlmod.net##+js(acs, document.createElement, adblock)
+
+! https://github.com/uBlockOrigin/uAssets/issues/6759
+fontsfree.pro##+js(set, adBlock, false)
+
+! https://github.com/uBlockOrigin/uAssets/issues/6767
+earnload.*##+js(set, blurred, false)
+
+! https://github.com/NanoMeow/QuickReports/issues/2605
+insidermonkey.com##+js(aopr, ABD)
+
+! https://github.com/NanoMeow/QuickReports/issues/2640
+venea.net##+js(aeld, , ads)
+
+! https://github.com/NanoMeow/QuickReports/issues/2341
+@@||puhutv.com^$ghide
+
+! https://github.com/NanoMeow/QuickReports/issues/2635
+theherald-news.com##+js(nostif, null)
+
+! https://github.com/NanoMeow/QuickReports/issues/2665
+libgen.*##+js(nostif, appendMessage)
+
+! https://github.com/uBlockOrigin/uAssets/issues/7811
+! https://github.com/uBlockOrigin/uAssets/issues/11335
+keybr.com##+js(nostif, (), 5000)
+
+! edmontonjournal .com anti adb warning
+@@||edmontonjournal.com^$ghide
+
+! gamebanana anti adblock notice
+gamebanana.com##+js(aopr, adBlockDetected)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/42495#issuecomment-574761083
+@@||metropoles.com^$ghide
+
+! https://github.com/NanoMeow/QuickReports/issues/2787
+hedgeaccordingly.com##+js(aopw, ABD)
+
+! https://github.com/uBlockOrigin/uAssets/issues/6877
+theregister.co.uk##+js(aopr, adtoniq)
+
+! https://www.reddit.com/r/firefox/comments/eu70aq/turn_off_ublock_origin_howaboutno/
+@@||merryjane.com/static/images/ads.png^$image,1p
+
+! ymovies .to anti adb warning
+ymovies.*##.alert-danger.alert
+
+! almasdarnews .com warning anti adb #2421
+almasdarnews.com##+js(acs, jQuery, ai_adb)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/78541
+*$xhr,redirect-rule=noopjs,domain=maxedtech.com
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=maxedtech.com
+@@||googlesyndication.com^$xhr,domain=maxedtech.com
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/49311
+nmac.to##.alert-errors.in.fade.alert
+
+! https://github.com/NanoMeow/QuickReports/issues/2972
+livescience.com##+js(aopr, _sp_.mms.startMsg)
+
+! https://github.com/NanoMeow/QuickReports/issues/2981
+@@||queer.pl^$ghide
+queer.pl#@#[class^="ad-"]
+queer.pl##.box-adv
+
+! https://github.com/uBlockOrigin/uAssets/issues/6945
+@@||snipboard.io^$ghide
+
+! musicradar .com and other sites anti adb warning
+digitalcameraworld.com,guitarworld.com,musicradar.com##+js(aopr, _sp_.mms.startMsg)
+
+! https://github.com/uBlockOrigin/uAssets/issues/6956
+mocospace.com##+js(nostif, adblocker)
+
+! bigten .org anti adb warning
+@@||bigten.org^$xhr,1p
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/50013
+strangermeetup.com##+js(set, adsEnabled, true)
+
+! ai_adb warning
+casertace.net,civildigital.com,lesmoutonsenrages.fr,venusarchives.com,verpornocomic.com##+js(acs, jQuery, ai_adb)
+
+! https://github.com/NanoMeow/QuickReports/issues/3095
+@@||frontpage.fok.nl^$ghide
+frontpage.fok.nl###wa_web_headertofloor
+frontpage.fok.nl##div.commercial_space
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/50414
+civicx.com##.adblock_detector
+
+! mp3fy .com anti adb warning
+@@||mp3fy.com^$ghide
+
+! https://github.com/NanoMeow/QuickReports/issues/3924
+radarbox.com##+js(set, ads_enabled, true)
+
+! https://forums.lanik.us/viewtopic.php?p=153251#p153251
+keighleynews.co.uk##+js(aopr, _sp_.mms.startMsg)
+
+! https://github.com/uBlockOrigin/uAssets/issues/7058
+!#if env_chromium
+!newyorker.com##+js(acs, navigator.storage.estimate)
+!#endif
+!#if env_firefox
+newyorker.com##+js(set, webkitRequestFileSystem, noopFunc)
+!#endif
+
+! mt07-forum/auto-treff anti-adb
+mt07-forum.de,auto-treff.com##+js(acs, $, offsetHeight)
+
+! https://github.com/NanoMeow/QuickReports/issues/3310
+dxmaps.com##+js(nostif, adsbygoogle, 5000)
+
+! photoshop-online anti-adb
+photoshop-online.biz##+js(nostif, google_jobrunner)
+photoshop-online.biz##div.aslot
+
+! https://github.com/NanoMeow/QuickReports/issues/3447
+loudersound.com##+js(aopr, _sp_._networkListenerData)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/fsgpzp/adblock_detected_on_this_website/
+boomlive.in###ad_blocker_detect_dialog
+boomlive.in##.advert-panel
+
+! lewdzone.com adblock notice
+lewdzone.com##div.loading-links
+
+! https://github.com/NanoMeow/QuickReports/issues/3458
+hearthstone-decks.net##+js(acs, jQuery, ai_check)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/52709
+bejson.com##+js(set, killads, true)
+
+! https://forums.lanik.us/viewtopic.php?p=153944#p153944
+deezer.com##+js(nostif, bait)
+deezer.com##.abp-banner
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/53356
+idahopress.com##.tnc-overlay.tncms-block
+idahopress.com###blox-message-incompatible
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/53425
+adslayuda.com##+js(set, better_ads_adblock, null)
+
+! https://github.com/NanoMeow/QuickReports/issues/3559
+creativebloq.com##+js(aopr, _sp_.mms.startMsg)
+
+! Steady anti adb warning
+handball-world.news,mobiflip.de,titanic-magazin.de,mimikama.org,langweiledich.net,der-postillon.com,perlentaucher.de,lwlies.com,serieslyawesome.tv,critic.de,mediotejo.net,nahrungsmittel-intoleranz.com,madeinbocholt.de,goodnews-magazin.de,wallauonline.de##+js(nostif, steady-adblock)
+handball-world.news##small
+
+! https://github.com/NanoMeow/QuickReports/issues/3578
+simpleflying.com##.simpl-adlabel
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/53650
+masrawy.com##+js(acs, document.getElementById, adblockerdetected)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/53694
+milfzr.com##+js(acs, $, juicyads)
+
+! litecompare .com anti adb notice
+@@||litecompare.com^$ghide
+
+! fiscomania .com anti adb notice
+@@||fiscomania.com^$ghide
+
+! playbill .com anti adb warning
+playbill.com##+js(nostif, offsetHeight)
+
+! https://github.com/NanoMeow/QuickReports/issues/3687
+t3.com##+js(aopr, _sp_.mms.startMsg)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/54544
+smokingmeatforums.com##+js(acs, $, btoa)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/54629
+servedez.com###realpop_optincontent
+
+! https://affiliate.fc2.com/ anti-adblock
+affiliate.fc2.com##+js(nostif, checkFeed, 1000)
+
+! thegatewaypundit .com anti adb warning
+thegatewaypundit.com##+js(aeld, , adtoniq)
+
+! https://github.com/uBlockOrigin/uAssets/issues/7359
+@@||9lives.be^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/issues/7371
+jeu2048.fr##+js(aopw, FuckAdBlock)
+
+! https://github.com/NanoAdblocker/NanoFilters/issues/499
+duolingo.com##h2:has-text(Using an ad blocker?):upward(3)
+
+! https://github.com/uBlockOrigin/uAssets/issues/7363
+@@||holowczak.com^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/issues/7373
+*$script,redirect-rule=noopjs,domain=luchaonline.com
+
+! https://github.com/uBlockOrigin/uAssets/issues/7384
+taperaki.gr##.widget_et_ads
+
+! https://github.com/NanoMeow/QuickReports/issues/3846
+4x4earth.com##+js(set, adBlockDetected, false)
+4x4earth.com##+js(nostif, samOverlay)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3877
+endorfinese.com.br##+js(nostif, google_jobrunner)
+
+! https://github.com/uBlockOrigin/uAssets/issues/7417
+baby.be##.warning
+
+! https://github.com/NanoMeow/QuickReports/issues/3894
+@@||receivesmsonline.net/ads.js$script,1p
+
+! https://www.reddit.com/r/uBlockOrigin/comments/gmtlci/adblocking_detected/
+||wetransfer.net/*/adblocker$3p,domain=wetransfer.com
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/55781
+stevensducks.com###sidearm-adblock-modal
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/55846
+trojmiasto.pl##+js(aopr, adBlockDetected)
+
+! https://github.com/NanoMeow/QuickReports/issues/3914
+diffchecker.com##+js(nostif, adStillHere)
+
+! anti adb annoyance
+sythe.org##:xpath('//*[contains(text(),"Adblock")]')
+
+! https://github.com/NanoMeow/QuickReports/issues/3963
+moving2canada.com##.ad-blocker-notice
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/56323
+extreme-down.*##p > b:xpath('//*[contains(text(),"AdBlock")]')
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/56652
+poedb.tw##+js(aopr, adBlockDetected)
+
+! https://github.com/NanoMeow/QuickReports/issues/3169
+malekal.com##+js(nostif, adb)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/57099
+tabstats.com##.afill
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/57295
+motortrader.com.my##+js(aopr, canRunAds)
+
+! https://github.com/NanoMeow/QuickReports/issues/4161
+abola.pt##+js(acs, $, Adblock)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/57830
+unixhow.com##+js(acs, eval, isNaN)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/57962
+rottentomatoes.com##+js(set, mps._queue.abdetect, null)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/58166
+betaprofiles.com##.adblock
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/58292
+imgur.com##.Footer-whitelist
+
+! thisisfutbol .com anti adb notice
+@@||thisisfutbol.com^$ghide
+thisisfutbol.com##.ad-billboard
+thisisfutbol.com##.c-header__advert
+thisisfutbol.com###snack_dex6
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/59406
+nuggetroyale.io##.mainMenuAdBox
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/59414
+tileman.io##.adbanner:remove()
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/59749
+sovetromantica.com##+js(set, fuckAdBlock, trueFunc)
+*$xhr,redirect-rule=nooptext,domain=sovetromantica.com
+
+! https://github.com/NanoMeow/QuickReports/issues/4360
+scriptinghelpers.org##.shvertise-banner
+
+! mbs.jp right click
+mbs.jp##+js(aopw, document.oncontextmenu)
+
+! https://github.com/NanoMeow/QuickReports/issues/4372
+polyflore.net##+js(nostif, adBlockDetected)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/59933
+nightpoint.io##+js(nofab)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/59974
+striketactics.net###unit_a_cont
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/59995
+chemz.io##.menu_ad1Box
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/60026
+*$xhr,redirect-rule=nooptext,domain=mazmorra.io
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/60037
+sketchful.io###moneySquare
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/60100
+download.mokeedev.com##div.center-align
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/60183
+liga.net##.modal-backdrop
+liga.net###addBlockModal
+liga.net##body:style(overflow:auto !important)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/60407
+getintopc.com##body > div[attr="[object Object]"]
+
+! https://github.com/NanoAdblocker/NanoFilters/issues/540
+longecity.org##+js(set, abp, false)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/60575
+brighteon.com##body:style(overflow:auto !important)
+brighteon.com##div.overlay, .bottom-banner
+
+! humanbenchmark .com warning anti adb
+*$script,3p,domain=humanbenchmark.com
+
+! https://github.com/NanoMeow/QuickReports/issues/4489
+cpuid.com##+js(nostif, blocked, 1000)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/61381
+ratebeer.com##[class^="AdBlockDetector"]
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/61521
+*$script,redirect-rule=noopjs,domain=atlasobscura.com
+atlasobscura.com##.js-subscription-ask-modal
+atlasobscura.com##body.modal-open:style(overflow:auto !important)
+
+! https://github.com/NanoMeow/QuickReports/issues/4511
+webcamtaxi.com##+js(nostif, blocker)
+
+! abcya .com anti adb - warning
+*$script,domain=abcya.com,redirect-rule=noopjs
+
+! https://github.com/NanoMeow/QuickReports/issues/4545
+randomlists.com##.whine
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/61999
+good-football.org##+js(aopr, adBlockDetected)
+
+! https://github.com/NanoMeow/QuickReports/issues/4560
+beforeitsnews.com###top-alert
+
+! https://github.com/uBlockOrigin/uAssets/issues/11242
+@@||dailyvoice.com^$ghide
+*$xhr,redirect-rule=nooptext,domain=dailyvoice.com
+dailyvoice.com###nativo_rightrail1
+
+! https://forums.lanik.us/viewtopic.php?p=156522#p156522
+bluemoon-mcfc.co.uk##+js(nosiif, removeChild)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/64268
+routinehub.co###ethad
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/64589
+webqc.org###toplink
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/64711
+ohmygirl.ml##+js(acs, event, stopPropagation)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/65000
+telefon-treff.de##+js(acs, $, offsetHeight)
+
+! dodge-forum anti-adb
+dodge-forum.eu##+js(acs, $, offsetHeight)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/80714
+@@||samfw.com^$ghide
+samfw.com##.adsbygoogle
+||samfw.com/assets/*.gif$image
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/65693
+segnidalcielo.it##+js(nostif, google_jobrunner)
+
+! fangraphs.com anti adb annoyance
+@@||fangraphs.com/dfp.js$script,1p
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/65879
+fosspost.org##+js(nostif, an_message, 500)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/66004
+hentaialtadefinizione.it##+js(aopw, onload)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/ji8yhy/citynewsca_anti_adblock/
+||rogersmedia.com/utilityx.js^$script,3p
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/66378
+moneyguru.co##+js(acs, $, .height)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/66440
+mapgenie.io##.mt-1.mb-1.text-center
+
+! https://github.com/uBlockOrigin/uAssets/issues/8111
+||googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=googlesyndication_adsbygoogle.js,domain=colnect.com
+
+! https://github.com/uBlockOrigin/uAssets/issues/8136
+nwherald.com##+js(aopr, HTMLIFrameElement)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/67621
+progameguides.com##+js(aopr, admrlWpJsonP)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/jurv15/httpswwwztzacom_detect_ublock_using_ztprotect/
+zt-protect.*##main.py-4 > p
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/67845
+jimnong.tistory.com##.adblock-on
+
+! json2csharp.com anti-adb
+*$script,redirect-rule=noopjs,domain=json2csharp.com
+
+! nextplatform.com anti adb
+nextplatform.com###adtoniq-msgr-bar
+
+! 1fichier.com adblock message and modal
+1fichier.com##.ct_warn:has-text(adblock)
+1fichier.com##.ui-dialog[aria-describedby="modal-msg"]:has(a[href$="/console/abo.pl"][style^="text-decoration:underline"])
+1fichier.com##.ui-widget-overlay
+
+! https://github.com/uBlockOrigin/uAssets/issues/8347#issuecomment-744394924
+forum.release-apk.com##.has-profile.post:first-child:has-text(/adblock/i)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/70398
+bendigoadvertiser.com.au##+js(nosiif, modal)
+
+! 2iptv .com warning anti adb
+2iptv.com##+js(nostif, google_jobrunner)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/ktkw6p/proboards_based_forums_deploying_antiadblock/
+||ads.proboards.com^$script,redirect=noopjs
+||bidfilter.com^$script,redirect=noopjs
+
+! Anti-adb keybr.com
+keybr.com##.Placeholder
+
+! https://forums.lanik.us/viewtopic.php?f=62&t=38298
+kitguru.net##+js(acs, addEventListener, adsbygoogle.length)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/72222
+! https://github.com/AdguardTeam/AdguardFilters/issues/72225
+! https://github.com/AdguardTeam/AdguardFilters/issues/72227
+! https://github.com/AdguardTeam/AdguardFilters/issues/72228
+! https://github.com/AdguardTeam/AdguardFilters/issues/72229
+2hbn.com,bilgisentezi.com,farklifarkli.com,readingclock.com##.adace-popup
+bilgisentezi.com##.adace-slideup-slot-wrap
+
+! https://www.reddit.com/r/uBlockOrigin/comments/kzrus8/adblock_detected/
+*$script,redirect-rule=noopjs,domain=mail.inbox.lv
+
+! https://github.com/uBlockOrigin/uAssets/issues/8554
+htmlgames.com##.banner
+
+! https://github.com/uBlockOrigin/uAssets/issues/8551
+pbinfo.ro##.text-warning
+
+! https://github.com/uBlockOrigin/uAssets/issues/8560
+||gmod-servers.com/assets/js/jquery.adblock-detector.js$script,1p
+
+! https://github.com/uBlockOrigin/uAssets/issues/8578
+@@||freedomoutpost.com^$ghide
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/82216
+lcpdfr.com##+js(acs, $, AdBlock)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/76660
+whatfontis.com##+js(acs, $, adBlock)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/77079
+solotrend.net##+js(aopw, ai_front)
+
+! scrolller.com anti-adb
+scrolller.com##.notification[style^="height: 189px;"]
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/77665
+xtv.cz##+js(nostif, pgblck)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/ofstkl/adblock_warning_on_puhekuplacom/
+puhekupla.com#@#.googlead
+*$xhr,redirect-rule=nooptext,domain=puhekupla.com
+
+! https://github.com/DandelionSprout/adfilt/issues/63#issuecomment-812837952
+fakechatapp.com##.banner
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/79472
+toonytool.com##.banner
+
+! https://github.com/uBlockOrigin/uAssets/issues/8866
+!#if !env_firefox
+gmx.net##+js(set, document.documentElement.AdBlockDetection, noopFunc)
+!#endif
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/80139
+theblaze.com##+js(aopw, admrlWpJsonP)
+
+! https://github.com/uBlockOrigin/uAssets/issues/8878
+||cm.g.doubleclick.net/pixel$image,redirect=1x1.gif,domain=tpc.googlesyndication.com
+||tpc.googlesyndication.com/pagead/images/x_button_blue2.svg$image,redirect=1x1.gif,domain=tpc.googlesyndication.com
+||cm.g.doubleclick.net/pixel$image,redirect=1x1.gif,domain=diep.io
+||tpc.googlesyndication.com/pagead/images/x_button_blue2.svg$image,redirect=1x1.gif,domain=diep.io
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/80501
+||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js^$redirect=googlesyndication_adsbygoogle.js,script,domain=mifirm.net
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/80660
+cssreference.io##^script:has-text(window.carbonLoaded)
+!#if !cap_html_filtering
+cssreference.io##+js(aopr, carbonLoaded)
+!#endif
+cssreference.io##.placeholder
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/81105
+imagecolorpicker.com#@#div[id^="ezoic-pub-ad-"]
+
+! https://github.com/uBlockOrigin/uAssets/issues/8968
+revistavanityfair.es##+js(aopr, initAdBlockerPanel)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/81778
+spielspiele.de##.is-blocked
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/83712
+lowkeytech.com##+js(acs, String.prototype.charCodeAt, ai_)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/83664
+@@||dmax.de^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/issues/9159
+olarila.com##+js(nostif, offsetHeight)
+
+! https://github.com/uBlockOrigin/uAssets/issues/9208
+nbcsports.com##+js(aopw, admrlWpJsonP)
+
+! https://github.com/uBlockOrigin/uAssets/issues/9146#issuecomment-846390986
+techsini.com##+js(acs, jQuery, preventDefault)
+techsini.com##style:has-text(user-select:):remove()
+
+! katholisches. info warning popup
+katholisches.info##+js(nostif, pop)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/84616
+ubuntudde.com##+js(acs, String.prototype.charCodeAt, ai_)
+
+! https://github.com/uBlockOrigin/uAssets/issues/9339
+streaminglearningcenter.com##+js(nostif, ads)
+
+! https://github.com/uBlockOrigin/uAssets/issues/10422
+prepostseo.com##+js(nostif, 'head')
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/85982
+||belezaedieta.com^
+
+! sonnenverlauf/suncalc anti-adb
+sonnenverlauf.de,suncalc.org###adsGross1
+sonnenverlauf.de,suncalc.org###adsKlein
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/57758
+audiostereo.pl##+js(nostif, adb)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/o8wr0g/antiadblock_ygoprodeckcom/
+*$image,redirect-rule=1x1.gif,domain=ygoprodeck.com
+
+! https://github.com/uBlockOrigin/uAssets/issues/2060
+nicematin.com##+js(aeld, , AdB)
+
+! https://github.com/uBlockOrigin/uAssets/issues/23699
+bilibili.com##.adblock-tips
+
+! https://github.com/uBlockOrigin/uAssets/issues/9583
+fimfiction.net##+js(aeld, load, adLazy)
+
+! https://github.com/uBlockOrigin/uAssets/issues/9666
+tiermaker.com##+js(nostif, &adslot)
+
+! https://github.com/uBlockOrigin/uAssets/issues/9783
+spanishdict.com##+js(set, SD_BLOCKTHROUGH, true)
+spanishdict.com###removeAdsSidebar
+spanishdict.com##.ad-wrapper, #adTopLarge, [id^="adSide"], [id^="adMiddle"]
+
+! https://github.com/uBlockOrigin/uAssets/issues/9828
+dez.ro#@#.ad-placement
+
+! bwitter.me anti-adb
+bwitter.me###side > ins.adsbygoogle:upward(1)
+
+! https://github.com/uBlockOrigin/uBlock-issues/issues/1700
+windguru.net###warning-content
+
+! https://github.com/uBlockOrigin/uAssets/issues/9872
+thinkamericana.com##+js(nosiif, offsetHeight)
+
+! https://github.com/uBlockOrigin/uAssets/issues/9874
+menrec.com##+js(nosiif, offsetHeight)
+
+! https://github.com/uBlockOrigin/uAssets/issues/9878
+hendersonville.com##.adblock-detected
+
+! https://github.com/uBlockOrigin/uAssets/issues/9895
+*$image,redirect-rule=1x1.gif,domain=guardian.gg
+
+! https://github.com/uBlockOrigin/uAssets/pull/9925
+! https://github.com/uBlockOrigin/uAssets/issues/13297
+outlook.live.com##div[class][tabindex="-1"][role=region][aria-label][data-min-width][data-max-width] ~ div[class][data-max-width="2400"] + div[class]
+outlook.live.com###MainModule + div[class] > div[style^="width"] > div > i[data-icon-name="OutlookLogo"]:upward(3)
+outlook.live.com###MainModule div[data-max-width="2400"] + div[class]
+
+! https://github.com/uBlockOrigin/uAssets/pull/10037
+ptable.com##.Notice
+
+! https://www.reddit.com/r/uBlockOrigin/comments/q31fnc/mocahorg_adblocker_detection/
+mocah.org##+js(nosiif, adsbygoogle)
+
+! https://github.com/uBlockOrigin/uAssets/issues/10200
+*$script,redirect-rule=noopjs,domain=inbox.lv|inbox.la
+
+! https://github.com/uBlockOrigin/uAssets/issues/10224
+techtobo.com##.js-notices
+
+! https://github.com/uBlockOrigin/uAssets/issues/10226
+shopomo.co.uk##+js(nostif, ai_)
+c4ddownload.com,the-scorpions.com##+js(aopr, b2a)
+
+! https://github.com/uBlockOrigin/uAssets/issues/10233
+epn.bz##+js(set, ab, false)
+
+! https://github.com/uBlockOrigin/uAssets/issues/10252
+affbank.com##+js(set, canRunAds, true)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/qbcvtc/nbc_sports_anti_ad_block_workaround/
+nbcsportsedge.com##+js(aopw, admrlWpJsonP)
+
+! https://github.com/uBlockOrigin/uAssets/commit/e6d649c38a8e
+||piano.io^$domain=fastcompany.com
+
+! https://github.com/uBlockOrigin/uAssets/issues/10295
+_google_ads.$badfilter
+
+! https://www.reddit.com/r/uBlockOrigin/comments/qkf91l/timeanddatecom/
+@@||timeanddate.com^$ghide
+timeanddate.com###ad300
+
+! https://github.com/uBlockOrigin/uAssets/issues/10458
+buondua.com##.noblock-modal
+buondua.com##body.tingle-enabled:style(position: static!important;overflow: auto!important;)
+
+! https://github.com/uBlockOrigin/uAssets/issues/10781
+@@||coinpayu.com^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/pull/10979
+||4399.com/antijs/Antiindulgence.js
+
+! https://github.com/uBlockOrigin/uAssets/issues/10976
+dhd24.com#@#.adunit
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/103536
+otomobilgunluklerim.com##.adblockalert
+otomobilgunluklerim.com##.ad_block_detected:style(overflow: auto !important;)
+
+! https://github.com/uBlockOrigin/uAssets/issues/11129
+ssuathletics.com##+js(acs, document.querySelector, adblock)
+
+! https://github.com/cjx82630/cjxlist/commit/6529adc701822ea1467b9e5a38ad823d27cc1d1e
+52bdys.com##+js(aopr, onload)
+
+! geektyper.com anti-adb
+geektyper.com###itemz[style^="position:fixed; top:10px"]
+
+! https://github.com/uBlockOrigin/uAssets/issues/11195
+fotofilter.de##.banner
+
+! https://github.com/uBlockOrigin/uAssets/issues/11330
+mail.tm##:xpath('//*[contains(text(),"blocker")]')
+
+! https://github.com/BottledSoda/RoWebImprover/issues/7
+@@||curs-valutar-bnr.ro^$ghide
+curs-valutar-bnr.ro##.adsbygoogle:style(max-height: 1px !important;left:-9999px !important;position:absolute !important)
+
+! https://github.com/uBlockOrigin/uAssets/issues/11517
+funnygames.*##.is-blocked
+
+! https://github.com/uBlockOrigin/uAssets/issues/11615
+||thresholdforum.s3.us-east-2.amazonaws.com/arn:aws:s3:::thresholdforum/javascript_adblockdetector/$script
+
+! https://www.reddit.com/r/uBlockOrigin/comments/sla82r/how_to_fix_blurring_on_this_website/
+meteoblue.com##+js(set, mb.advertisingShouldBeEnabled, false)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3068
+pornhub.*##+js(rc, hasAdAlert, header)
+pornhub.*###js-abContainterMain
+
+! https://github.com/uBlockOrigin/uAssets/issues/11762
+grandoldteam.com##+js(acs, $, test)
+
+! https://github.com/uBlockOrigin/uAssets/issues/11775
+gamingsinners.com##+js(acs, $, test)
+
+! eshentai. tv warning
+eshentai.tv##.aviso
+
+! https://github.com/uBlockOrigin/uAssets/issues/11815
+pushsquare.com##+js(aopr, _sp_._networkListenerData)
+
+! warning msg
+elitepvpers.com##+js(nostif, $)
+elitepvpers.com##+js(acs, $, Promise)
+
+! https://github.com/uBlockOrigin/uAssets/issues/12119
+101soundboards.com##.blocked-notice-small
+
+! codehelppro.com anti-adblock
+@@||codehelppro.com^$ghide
+codehelppro.com##.adsbygoogle
+
+! https://github.com/uBlockOrigin/uAssets/issues/12462
+coolwallpapers.me##+js(nosiif, dfgh-adsbygoogle)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/113837
+@@||freshersnow.com^$ghide
+freshersnow.com##.adsbygoogle
+
+! fnbrjp.com anti-adb
+fnbrjp.com##+js(nostif, 広告)
+
+! allthingsvegas. com anti adb warning
+@@||allthingsvegas.com^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/issues/12623
+valid.x86.fr##+js(rmnt, script, /setTimeout.*style/)
+valid.x86.fr##.fullwidth
+valid.x86.fr##.widget-advert
+
+! https://www.reddit.com/r/uBlockOrigin/comments/tydsev/adblocker_detected_on_unidiversfr/
+unidivers.fr##+js(no-xhr-if, googlesyndication)
+
+! waves4you. com anti adblock
+waves4you.com##+js(aost, String.prototype.charCodeAt, ai_)
+
+! techus. website anti adb soft
+techus.website##+js(nostif, ai_)
+
+! https://github.com/uBlockOrigin/uAssets/issues/13037
+@@||ruyamanga.com^$ghide
+
+! light.gg soft anti-adb
+light.gg##.items-right-square
+light.gg##.remove-turtles
+light.gg###ad-blocker-nudge
+
+! https://github.com/uBlockOrigin/uAssets/issues/13418
+/wp-content/themes/*/public/js/detect-adblock.js$script,1p
+
+! anti adb warning leekduck. com
+leekduck.com##+js(nostif, abp)
+
+! https://github.com/uBlockOrigin/uAssets/issues/14170
+minimum-wage.org##.alert-dismissible
+
+! https://github.com/uBlockOrigin/uAssets/issues/14191
+morosedog.gitlab.io##+js(set, checkAds, noopFunc)
+
+! https://github.com/uBlockOrigin/uAssets/issues/14306
+htforum.net##+js(nostif, show)
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/129173
+craftpip.github.io##+js(nostif, adsok)
+
+! https://github.com/uBlockOrigin/uAssets/issues/14749
+modrinth.com##.info-wrapper[ethical-ads-big=""]
+modrinth.com##.content-wrapper[ethical-ads-big]
+modrinth.com##.info-wrapper[data-v-7cd21295]
+
+! https://www.iphoneincanada.ca/ anti-adb
+iphoneincanada.ca##.slbElement
+
+! www.dailyprincetonian.com anti-adb
+||blink.net/iframe.html$domain=dailyprincetonian.com
+
+! www.anisearch.com ad reinjection
+@@||cdn.privacy-mgmt.com^$script,xhr,domain=anisearch.com
+||anisearch.com/*?p=1|$frame
+
+! https://www.reddit.com/r/uBlockOrigin/comments/xy6lh0/
+pixwox.com##+js(nostif, length, 3000)
+
+! www.lamusica.com anti-adb
+lamusica.com##.modal-open:style(overflow: auto !important;)
+lamusica.com##div[id$="___BV_modal_outer_"]
+
+! https://profreehost.com/ anti-adb
+||profreehost.com/includes/js/customBottom.js$script,1p
+
+! https://www.slideshare.net/secret/r4TGJDeZF0s9jt anti adb, exit-modal
+slideshare.net##+js(acs, ab_tests)
+slideshare.net##+js(aeld, mouseleave, scribd_ad)
+
+! https://github.com/uBlockOrigin/uAssets/issues/15598
+@@||startpage.com^$ghide
+
+! anti adb annoyance golfdigest.com
+golfdigest.com##+js(aost, document.createElement, admiral)
+
+! https://www.duhoctrungquoc.vn/wiki/ja/%E3%83%A1%E3%82%A4%E3%83%B3%E3%83%9A%E3%83%BC%E3%82%B8 (wikipedia copy)
+duhoctrungquoc.vn###danger_adblock
+
+! tarnkappe. info anti adblock annoyance
+tarnkappe.info##+js(set, traffective, true)
+tarnkappe.info##.around-desktop-ad:upward(1)
+tarnkappe.info##div[style="min-height: 300px;"]
+tarnkappe.info##.interscroller-wrapper[style^="height: 700px; "]
+
+! https://github.com/uBlockOrigin/uAssets/issues/15784
+@@||discordbotlist.com^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/issues/16251
+memoryhackers.org##+js(acs, RegExp, googlebot)
+
+! technologyreview.jp soft paywall
+technologyreview.jp##+js(cookie-remover, kpwc)
+technologyreview.jp##.meter
+
+! grabify. link anti adb warning
+@@||grabify.link^$ghide
+
+! https://www.reddit.com/r/uBlockOrigin/comments/10acynj/
+steamcollector.com##+js(acs, document.querySelectorAll, adblock)
+steamcollector.com##.abg-card
+
+! https://github.com/uBlockOrigin/uAssets/issues/16529
+textcleaner.net##+js(no-fetch-if, googlesyndication)
+
+! sneakernews.com anti-adb
+sneakernews.com##+js(aopr, sneakerGoogleTag)
+
+! https://github.com/uBlockOrigin/uAssets/issues/16545
+socialcounts.org##+js(no-fetch-if, googlesyndication)
+
+! https://github.com/uBlockOrigin/uAssets/issues/16570
+*$script,3p,redirect-rule=noopjs,domain=fflogs.com
+fflogs.com###bottom-banner, #top-banner
+fflogs.com##.ad-placement
+fflogs.com##.side-rail-ads
+
+! freefilesync. org anti-blocker
+freefilesync.org#@#.adsbygoogle
+
+! https://gith
+! https://raider.io/ anti-adb
+||intergient.com^$script,domain=raider.io,redirect-rule=noopjs
+
+! jojoy.io anti-adb - triggered only on mobile
+jojoy.io###ad_block_reminder_dialog
+
+! https://github.com/uBlockOrigin/uAssets/issues/16896
+mgsm.pl##+js(acs, checkAdblockBait)
+mgsm.pl##^script:has-text(checkAdblockBait)
+
+! https://github.com/uBlockOrigin/uAssets/issues/4241#issuecomment-1468322284
+actiongame.com,brain-games.co.uk,classicgame.com,games-site.co.uk,hiddenobjectgames.com,mahjong.co.uk,mahjong.com,match3.co.uk,match3games.com,mindgames.com,neongames.co.uk,neongames.com,solitaireonline.com,timemanagementgame.com##.adBlocked,.banner
+
+! zunda.site chat anti-adb
+zunda.site###ad_box:style(height: 50px !important;)
+
+! romviet.com anti adblock annoyance
+romviet.com##+js(noeval-if, AdBlocker)
+
+! squidboards.com anti-adb
+squidboards.com##.top_block
+
+! https://github.com/uBlockOrigin/uAssets/issues/17632
+regex101.com##.yOGxa
+
+! https://github.com/uBlockOrigin/uAssets/issues/14765#issuecomment-1527523594
+bluemediafile.*##+js(set, Time_Start, 0)
+bluemediafile.*##+js(nano-sib, i--, , 0.02)
+
+! https://github.com/uBlockOrigin/uAssets/issues/18046
+@@||luckydesigner.space/adview_$xhr,1p
+
+! https://github.com/uBlockOrigin/uAssets/issues/18048
+neilpatel.com##+js(no-xhr-if, /hotjar|googletagmanager/)
+
+! Soft Anti-Blocker
+jsfiddle.net##+js(nostif, modal)
+regexr.com##div.hello
+
+! https://github.com/uBlockOrigin/uAssets/issues/18169
+ikorektor.pl##+js(nostif, ad)
+ikorektor.pl###ad-top-dsk
+ikorektor.pl##.adx1
+
+! https://github.com/uBlockOrigin/uAssets/issues/18180
+theonegenerator.com##+js(no-fetch-if, ads)
+
+! https://github.com/webcompat/web-bugs/issues/119017 (Firefox ESR and Opera)
+nppes.cms.hhs.gov##div#unsupportedBrowser
+
+! goldenstateofmind.com anti adblock annoyance
+goldenstateofmind.com##+js(nostif, concertAds)
+
+! https://github.com/uBlockOrigin/uAssets/issues/18606
+9now.com.au##[id="toggle_notification_notification-ad-blocker"]:upward(1)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/14gghvf/
+! https://github.com/easylist/easylist/issues/16421
+||pagead2.googlesyndication.com/pagead/show_ads.js$script,redirect=noopjs,domain=ageofconsent.net
+
+! https://github.com/uBlockOrigin/uAssets/issues/18641
+neoseeker.com##+js(nostif, whetherdo)
+
+! https://github.com/uBlockOrigin/uAssets/issues/18667
+xeiaso.net##.adaptive
+
+! https://github.com/uBlockOrigin/uAssets/issues/19015
+lapresse.ca##.brz_msg_wall_body
+lapresse.ca##body > div[style]:has(.brz_msg_wall_body)
+lapresse.ca##body:style(overflow: auto !important)
+
+! https://github.com/uBlockOrigin/uAssets/issues/19271#issuecomment-1664958435
+161.97.70.5##+js(rmnt, script, isadb)
+
+! https://github.com/uBlockOrigin/uAssets/issues/19280
+zerogpt.net##+js(nostif, adsbygoogle)
+
+! https://github.com/uBlockOrigin/uAssets/issues/19370
+||mms.cnn.com^$1p
+
+! https://github.com/AdguardTeam/AdguardFilters/issues/159897
+*$script,1p,redirect-rule=noopjs,domain=punishworld.com
+
+! https://github.com/uBlockOrigin/uAssets/issues/19472
+guildstats.eu##.gDiv
+
+! admiral
+aboutchromebooks.com,ancient.eu,comingsoon.net,daysoftheyear.com,edn.com,gearjunkie.com,harvardmagazine.com,lgbtqnation.com,majorgeeks.com,mangainn.net,medievalists.net,sherdog.com,sidereel.com,statesman.com,winhelponline.com##+js(aopr, googletag)
+boston.com,britannica.com,cattime.com,dogtime.com,download.mokeedev.com,freep.com,ijr.com,inquirer.net,knowyourmeme.com,nationalreview.com,nofilmschool.com,order-order.com,savvytime.com,techlicious.com,technicpack.net,thedraftnetwork.com,wrestlezone.com,xda-developers.com##+js(acs, document.createElement, adm*,xhamster8.*,xhamsterporno.mx,xhbig.com,xhbranch5.com,xhchannel.com,xhdate.world,xhday.com,xhday1.com,xhlease.world,xhmoon5.com,xhofficial.com,xhopen.com,xhplanet1.com,xhplanet2.com,xhreal2.com,xhreal3.com,xhspot.com,xhtotal.com,xhtree.com,xhvictory.com,xhwebsite.com,xhwebsite2.com,xhwebsite5.com,xhwide1.com,xhwide2.com,xhwide5.com##+js(set, initials.layout.layoutPromoProps.promoMessagesWrapperProps.shouldDisplayAdblockMessage, false)
+
+! https://github.com/uBlockOrigin/uAssets/issues/20084
+270towin.com##+js(set-session-storage-item, fs.adb.dis, 1)
+
+! https://github.com/uBlockOrigin/uAssets/issues/20113
+photopea.com##.confirm:has-text(AdBlocker)
+
+! https://github.com/uBlockOrigin/uAssets/issues/20190
+cyanlabs.net#@#ins.adsbygoogle[data-ad-slot]
+cyanlabs.net#@#ins.adsbygoogle[data-ad-client]
+cyanlabs.net##ins.adsbygoogle:style(visibility: hidden !important;)
+
+! https://github.com/uBlockOrigin/uAssets/issues/20228
+uploadvr.com##.force-load-ad
+
+! getemoji.com anti adblock annoyance
+getemoji.com##+js(set-session-storage-item, fs.adb.dis, 1)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/17g3pww/photocollage_com_detect_addblockers/
+2pdfconverter.com,annotation.com,changefaces.com,chartle.com,coloringonline.com,fakechatapp.com,files2zip.com,mapimage.com,maproute.com,mindclouds.com,phideo.com,photocollage.com,photoeditor.com,photoenlarger.com,photofilters.com,photoresizer.com,postermaker.com,qrapp.com,stripbackground.com,toonytool.com,wordclouds.com,youtubetrimmer.com##.banner
+
+! https://github.com/uBlockOrigin/uAssets/issues/20294
+marinetraffic.com##+js(set, mtGlobal.disabledAds, true)
+marinetraffic.com##.under-map-wrapper:upward(1)
+
+! https://github.com/uBlockOrigin/uAssets/issues/20341
+lethalpanda.com##+js(aopr, b2a)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/17iihqp/anime_news_network_rolled_out_antiadblocker/
+animenewsnetwork.com##+js(set, ANN.ads.adblocked, false)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/17mifyx/adblocker_detected_on_hackthebox_website/
+||hackthebox.com/build/assets/just-detect-adblock-$script,1p
+
+! https://github.com/uBlockOrigin/uAssets/issues/20430
+heidisql.com##+js(rpnt, script, if(floovy()) {, if(false) {)
+
+! https://www.concertarchives.org/concerts/queens-of-the-stone-age-39b3e73b-f1e1-4c2b-9f29-d1aa157b452d - anti-adb
+||pub.network^$script,3p,redirect=noopjs,domain=concertarchives.org
+concertarchives.org#@#[data-freestar-ad]
+concertarchives.org##.freestar-placement
+
+! https://github.com/uBlockOrigin/uAssets/issues/20555
+bluesnews.com##+js(nostif, nn_mpu1, 5000)
+
+! https://github.com/uBlockOrigin/uAssets/issues/20574
+broncoshq.com##+js(rmnt, script, XF)
+broncoshq.com##+js(acs, $, btoa)
+
+! https://github.com/uBlockOrigin/uAssets/issues/20657
+alfred.camera##+js(aeld, DOMContentLoaded, ads)
+alfred.camera##+js(nosiif, ads)
+
+! https://github.com/uBlockOrigin/uAssets/issues/20725
+decider.com,nypost.com,pagesix.com##+js(aopr, googletag.cmd)
+
+! https://github.com/uBlockOrigin/uAssets/issues/21005
+cheersandgears.com##+js(rmnt, script, fetch)
+
+! https://github.com/uBlockOrigin/uAssets/issues/21051
+moovitapp.com##+js(trusted-click-element, [data-automation="continue-to-ads-btn"], , 10000)
+moovitapp.com##.init.open
+moovitapp.com##.top-banner
+
+! https://github.com/uBlockOrigin/uAssets/issues/20886
+digminecraft.com##+js(set, placeAdsHandler, noopFunc)
+
+! https://github.com/uBlockOrigin/uAssets/issues/21072
+@@||iphoneincanada.ca^$ghide
+iphoneincanada.ca##.adthrive-ad
+
+! https://github.com/uBlockOrigin/uAssets/issues/21255
+*$image,domain=peacocktv.com,redirect-rule=1x1.gif
+peacocktv.com##.playb$script,xhr,1p
+@@||cheatnetwork.eu^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/issues/21424
+how-to-pc.info,programming-link.info##+js(set, pqdxwidthqt, false)
+@@||how-to-pc.info^$ghide
+
+! https://community.brave.com/t/asheville-com-ad-appearing/522978
+asheville.com##+js(nostif, adblock)
+
+! https://github.com/uBlockOrigin/uAssets/issues/21582
+maxroll.gg##+js(set, nitroAds.loaded, true)
+@@||s.nitropay.com/n.svg$xhr,domain=maxroll.gg
+
+! https://mineskin.org/gallery banners
+mineskin.org##+js(aopw, ABB_config)
+
+! https://github.com/uBlockOrigin/uAssets/issues/21812
+@@||sheffieldforum.co.uk^$xhr,1p
+
+! nsmb .com anti-adb
+nsmb.com##+js(no-xhr-if, googlesyndication)
+nsmb.com###header-banner
+
+! https://github.com/uBlockOrigin/uAssets/issues/21919
+afterclass.io##+js(set-session-storage-item, adblock, true)
+
+! https://github.com/uBlockOrigin/uAssets/issues/21991
+@@||hbstack.dev^$script,xhr,1p
+
+! https://github.com/uBlockOrigin/uAssets/issues/22140
+mcskinhistory.com##+js(no-fetch-if, ads)
+
+! viewing .nyc banners
+viewing.nyc##+js(no-fetch-if, googlesyndication)
+
+! https://github.com/uBlockOrigin/uAssets/issues/22314
+tmz.com##.canvas-video-block--aside
+
+! notificationsounds .com anti-adb banners
+notificationsounds.com##+js(nostif, adsbygoogle, 2000)
+
+! tweaking4all .com anti-adb banners
+tweaking4all.com##+js(nostif, adsbygoogle, 2000)
+
+! hitokageproduction .com anti-adb banner
+hitokageproduction.com##+js(set, topMessage, noopFunc)
+
+! https://github.com/uBlockOrigin/uAssets/issues/22693
+vnexpress.net##+js(set, adblock, 2)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/1b906te/pop_up_that_says_to_not_use_adblockers_on/
+d4armory.io,helldivers.io##+js(aopr, nitroAds)
+helldivers.io###gwvideo
+
+! fightful .com anti-adb modal
+fightful.com##+js(nosiif, getComputedStyle)
+
+! conservationmag .org anti-adb popup
+@@||conservationmag.org^$ghide
+
+! https://github.com/uBlockOrigin/uAssets/pull/23279
+!#if cap_html_filtering
+xanimu.com,cosxplay.com##^script:has-text(adblock)
+!#else
+xanimu.com,cosxplay.com##+js(rmnt, script, adblock)
+!#endif
+
+! https://github.com/EasyDutch-uBO/EasyDutch/issues/127
+solarmagazine.nl##+js(no-xhr-if, ads)
+
+! https://github.com/hogekai/ad-compass/tree/main
+||jsdelivr.net/npm/ad-compass@latest/dist/ad-compass.umd.js
+
+! https://github.com/uBlockOrigin/uAssets/issues/23472
+timeanddate.com##+js(aeld, load, ad-wrap)
+
+! https://github.com/uBlockOrigin/uAssets/issues/23773
+thehouseofportable.com###htp
+
+! https://www.reddit.com/r/uBlockOrigin/comments/1d204k4/antiadblock_message_at_httpswwwlcpdfrcom/
+lcpdfr.com##+js(aopr, FuckAdBlock)
+
+! https://fancaps.net/anime/ adblock detection
+||a.pub.network/fancaps-net/pubfig.min.js$script,redirect=noopjs,domain=fancaps.net
+
+! https://www.reddit.com/r/uBlockOrigin/comments/1dmthrd/strange_thing_ive_been_noticing_not_sure_how_it/
+||web.archive.org/web/*/http://rpc.blogrolling.com/display.php?r=$1p,script
+
+! https://www.swagbucks.com/ - anti-adb
+swagbucks.com#@#.ad_warn
+swagbucks.com#@##topAd
+
+! https://doubledouble.top/ - soft anti-adb
+doubledouble.top##.totally-not-an-ad
+
+! https://www.reddit.com/r/uBlockOrigin/comments/1dkss3r/readcomiconline_detecting_adblock/
+readcomiconline.li##+js(rmnt, script, checkAdsBlocked)
+
+! https://www.autopareri.com/ - soft anti-adb
+autopareri.com##+js(no-fetch-if, googlesyndication)
+
+! https://pokemonsleep.club soft anti-adb
+@@||pokemonsleep.club^$script,1p
+
+! https://github.com/uBlockOrigin/uAssets/issues/24975
+||cined.com/content/plugins/abss-adblock
+
+! https://www.etools.ch anti-adb
+@@||etools.ch^$ghide
+
+! https://www.reddit.com/r/uBlockOrigin/commenAssets/issues/26435
+baomidou.com##astro-island[opts^="{\"name\":\"CheckAdBlocked\""]
+
+! https://github.com/uBlockOrigin/uAssets/issues/26511
+||images.$frame,1p,domain=nintendolife.com|purexbox.com|pushsquare.com|timeextension.com
+nintendolife.com##.insert-blocker
+
+! t3n.de anti adblock in articles
+||assets.t3n.de/t3n-de/assets/t3n/2018/scripts/abdtn-$script,1p
+
+! https://github.com/uBlockOrigin/uAssets/issues/26840
+@@||u.gg^$ghide
+
+! https://www.pokeos.com/ - anti-adb banners
+pokeos.com##+js(no-fetch-if, doubleclick)
+||pokeos.com/pokeos-uploads/ads/adblock/$image
+
+! https://forums.lanik.us/viewtopic.php?t=48667-www-cowcotland-com
+cowcotland.com##+js(rmnt, script, /adbl/i)
+
+! https://github.com/uBlockOrigin/uAssets/issues/27309
+bloxd.io##.AdBanner
+
+! https://sporttotal.tv/ - anti-adb
+sporttotal.tv##+js(no-fetch-if, doubleclick)
+sporttotal.tv##+js(set, HTMLImageElement.prototype.onerror, undefined)
+
+! kunststoffe.de anti adblock annoyance
+@@||kunststoffe.de/ads_tracking.js$xhr,1p
+
+! END: Anti-adblock
+
+! https://github.com/uBlockOrigin/uAssets/issues/933
+! https://github.com/easylist/EasyListHebrew/issues/332
+||holyclock.com^$3p
+||shomershabes.com^$3p
+||shomershabes.co.il^$3p
+
+! https://github.com/uBlockOrigin/uAssets/issues/2044
+pinterest.*##[data-test-giftwrap]
+pinterest.*###desktopWrapper:style(position: static !important;)
+pinterest.*##.gridCentered:style(margin-top: auto !important;)
+! https://github.com/uBlockOrigin/uAssets/issues/5030
+pinterest.*##div[data-test-id="giftWrap"]
+pinterest.*##div[class="Closeup__wrapper"] > div > div[style^="cursor: default"]
+pinterest.*##div[class="GrowthUnauthPinImage__imageDim"]
+pinterest.*##.GrowthUnauthPinImage > a > div[class^="Jea"]:has(button[class^="noButtonStyles "])
+pinterest.*##.Hsu.iyn.zI7:nth-of-type(2) > div > .FullPageModal__scroller
+! https://www.reddit.com/r/uBlockOrigin/comments/1hzblue/how_to_bypass_pinterest_forced_register/
+pinterest.*##+js(set-local-storage-item, DWEB_PIN_IMAGE_CLICK_COUNT, $remove$)
+pinterest.*##+js(trusted-replace-argument, Storage.prototype.setItem, 0, json:"DWEB", condition, DWEB_PIN_IMAGE_CLICK_COUNT)
+! "Sign Up to download"
+pinterest.*##+js(set-local-storage-item, unauthDownloadCount, $remove$)
+pinterest.*##+js(trusted-replace-argument, Storage.prototype.setItem, 0, json:"", condition, unauthDownloadCount)
+
+! https://github.com/uBlockOrigin/uAssets/issues/2972
+mimaletamusical.blogspot.com##+js(aopw, document.oncontextmenu)
+
+! https://github.com/uBlockOrigin/uAssets/issues/2992
+fmhikayeleri.com##+js(acs, document.oncontextmenu)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3032
+experts-exchange.com###topHeaderBannerWrap
+experts-exchange.com##.navigationWrapper:style(top: 0px !important;)
+
+! https://forums.lanik.us/viewtopic.php?f=62&t=41296
+digitalsynopsis.com##+js(aopr, disableSelection)
+digitalsynopsis.com##+js(aopr, document.oncontextmenu)
+
+! https://forums.lanik.us/viewtopic.php?f=62&t=41301
+filefox.cc##+js(aeld, blur)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3096 right click
+visionias.net##+js(acs, $, contextmenu)
+
+! https://github.com/uBlockOrigin/uAssets/issues/2546
+99bitcoins.com##+js(nostif, ThriveGlobal)
+
+! https://github.com/uBlockOrigin/uAssets/pull/3117
+! https://github.com/uBlockOrigin/uAssets/issues/6938
+uol.com.br##+js(aeld, copy)
+uol.com.br##+js(aopw, addLink)
+*/lib.ucopy/ucopy.js$script,domain=uol.com.br
+! https://github.com/uBlockOrigin/uAssets/issues/6938#issuecomment-898859152
+ne10.uol.com.br##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3115
+@@||umterps.com^$ghide
+umterps.com##.single-ad
+
+! https://forums.lanik.us/viewtopic.php?f=62&t=41339
+cars.com##.dialog
+cars.com##body:style(overflow: auto !important; position: initial !important;)
+
+! https://github.com/uBlockOrigin/uAssets/issues/2672
+peliculas24.me##+js(aopw, disableSelection)
+peliculas24.me##+js(aeld, contextmenu)
+
+! right click, select, copy cristoiublog.ro
+cristoiublog.ro##+js(aopw, document.oncontextmenu)
+cristoiublog.ro##+js(aopw, document.onselectstart)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3325
+gazetadopovo.com.br##+js(aeld, copy)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3372
+gaypornmasters.com##+js(aopr, document.oncontextmenu)
+||gaypornmasters.com^$csp=script-src *
+gaypornmasters.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3380
+braziljournal.com##+js(acs, document.oncopy)
+braziljournal.com##body:style(overflow: auto !important;)
+braziljournal.com##.in.fade
+
+! https://github.com/uBlockOrigin/uAssets/issues/3382
+emol.com##+js(aopr, addLink)
+
+! https://github.com/uBlockOrigin/uAssets/issues/2938
+voirfilms.*##+js(aopr, document.oncontextmenu)
+voirfilms.*##+js(aopr, document.onselectstart)
+
+! https://github.com/NanoMeow/QuickReports/issues/97
+knshow.com##+js(aopr, document.oncontextmenu)
+knshow.com##+js(aeld, /^(?:contextmenu|copy|selectstart)$/)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3514
+classicreload.com###sliding-popup.sliding-popup-bottom
+
+! https://www.reddit.com/r/uBlockOrigin/comments/9gr8tv/force_allow_text_copy/
+jusbrasil.com.br##+js(aeld, /^(?:contextmenu|copy)$/, preventDefault)
+
+! https://github.com/NanoMeow/QuickReports/issues/108
+descarga-animex.*##+js(aeld, /^(?:contextmenu|keydown)$/)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3447#issuecomment-422715065
+deezer.com##+js(aopr, onbeforeunload)
+! https://github.com/uBlockOrigin/uAssets/issues/5030
+deezer.com###modal_login:upward(2)
+! https://github.com/uBlockOrigin/uAssets/issues/22961
+! https://www.reddit.com/r/uBlockOrigin/comments/1bkft5k/ublock_annoyances_filter_is_breaking_scrolling_on/
+! deezer.com##.chakra-portal:has(> [data-focus-lock-disabled] > .chakra-modal__content-container a.chakra-button[href^="https://www.deezer.com/payment/go.php?origin=paywall_pressure"])
+! deezer.com##body.force-scrollbar:style(overflow-y: scroll !important;)
+deezer.com##+js(trusted-click-element, .chakra-portal .chakra-modal__content-container > section.chakra-modal__content > .chakra-modal__header:has(> .chakra-stack > a[href^="https://www.deezer.com/payment/go.php?origin=paywall_pressure"]) + button.chakra-modal__close-btn)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3545
+springfieldspringfield.co.uk##+js(aopr, addLink)
+
+! https://github.com/ryanbr/fanboy-adblock/issues/554
+omr.com###dsgvoModal
+omr.com##.modal-backdrop
+omr.com##body:style(overflow: auto !important;)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3553
+indiatimes.com##+js(aeld, copy)
+
+! https://github.com/uBlockOrigin/uAssets/issues/911#issuecomment-423771909
+||adsrt.com/assets/js/particles.min.js$script
+
+! https://github.com/uBlockOrigin/uAssets/issues/3591
+nulled.life##+js(ra, oncontextmenu)
+
+! https://github.com/jspenguin2017/uBlockProtector/issues/992
+mediafire.com##+js(nostif, scan, 500)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3599
+ebc.com.br##+js(ra, oncopy)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3614
+||tours.fr/include/js/tagAnalyticsCNIL.php$script,1p
+
+! https://forums.lanik.us/viewtopic.php?f=62&t=41811
+artsy.net##+js(aeld, scroll)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3621
+searchenginewatch.com##+js(acs, jQuery, #sign-up-popup)
+
+! popular on FB
+facebook.com,facebookcorewwwi.onion,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##.fbUserStory:has-text(Popular Across Facebook)
+facebook.com,facebookcorewwwi.onion,facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion##.userContentWrapper:has-text(Popular Across Facebook)
+! https://github.com/uBlockOrigin/uAssets/issues/3367#issuecomment-1993620105 - "Suggested for you" posts
+! https://github.com/uBlockOrigin/uAssets/issues/3367#issuecomment-2248409212
+!#if cap_html_filtering
+! ||facebook.com/api/graphql/$xhr,replace=/\{"newest_lbl_for_brs"[^\n]+?"follow_button":\{"__typename":"CometFeedStoryFollowButtonStrategy"[^\n]+"cursor":"[^"]+"\}/{}/g,domain=web.facebook.com|www.facebook.com
+||facebook.com/api/graphql/$xhr,1p,replace=/,"category_sensitive"[^\n]+?"follow_button":\{"__typename":"CometFeedStoryFollowButtonStrategy"[^\n]+"cursor":"[^"]+"\}/}/g,domain=web.facebook.com|www.facebook.com
+!#else
+! web.facebook.com,www.facebook.com##+js(trusted-replace-xhr-response, '/\{"newest_lbl_for_brs":[^\n]+?"follow_button":\{"__typename":"CometFeedStoryFollowButtonStrategy"[^\n]+"cursor":"[^"]+"\}/g', {}, /api/graphql)
+web.facebook.com,www.facebook.com##+js(trusted-replace-xhr-response, '/,"category_sensitive"[^\n]+?"follow_button":\{"__typename":"CometFeedStoryFollowButtonStrategy"[^\n]+"cursor":"[^"]+"\}/g', }, /api/graphql)
+!#endif
+! FB link redirection
+www.facebook.com##+js(json-prune, require.0.3.0.__bbox.define.[].2.is_linkshim_supported require.0.3.0.__bbox.define.[].2.click_ids)
+||l.facebook.com/l.php?u=$doc,urlskip=?u
+||l.instagram.com/?u=$doc,urlskip=?u
+
+! right click, select, copy => http://www.oggiscuola.com/web/2018/09/22/alzarsi-in-piedi-quando-entra-il-professore-e-una-forma-di-saluto-che-va-recuperata/
+oggiscuola.com##+js(acs, jQuery, overlay)
+||oggiscuola.com^$csp=style-src 'self' *
+||oggiscuola.com/*/banner$image
+
+! https://github.com/uBlockOrigin/uAssets/issues/3660
+odiario.com##+js(aeld, copy)
+
+! select, copy cittadinanza.biz | glistranieri.it
+cittadinanza.biz,glistranieri.it##+js(set, disableSelection, noopFunc)
+cittadinanza.biz,glistranieri.it##+js(aopw, document.oncontextmenu)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3699
+petrimazepa.com##.ui-dialog[tabindex="-1"]
+
+! https://github.com/uBlockOrigin/uAssets/issues/3704
+sabishiidesu.com##+js(acs, document.onkeydown)
+sabishiidesu.com##+js(aopw, document.oncontextmenu)
+sabishiidesu.com##.unselectable:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3738
+webcodegeeks.com##+js(nostif, onload_popup, 8000)
+
+! select, copy http://www.livetennis.it/post/302572/atp-stoccolma-fabio-fognini-conquista-le-semifinali/
+livetennis.it##+js(ra, onselectstart)
+livetennis.it##p:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
+
+! select https://www.readlightnovel.org/the-good-for-nothing-seventh-young-lady/chapter-1091
+readlightnovel.org##.chapter-content3:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3830
+tinyppt.com##+js(aopw, document.ondragstart)
+tinyppt.com##+js(aopw, disableEnterKey)
+tinyppt.com##+js(acs, document.oncontextmenu)
+tinyppt.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3880#issuecomment-433622746
+droidtekno.com##+js(aopw, document.ondragstart)
+droidtekno.com##+js(aopw, disableEnterKey)
+droidtekno.com##.unselectable:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
+
+! https://github.com/uBlockOrigin/uAssets/issues/3898
+community.simtropolis.com##.ipsModal
+community.simtropolis.com##.ipsDialog
+
+! https://github.com/NanoMeow/QuickReports/issues/265
+businessemailetiquette.com##+js(aopw, disableEnterKey)
+businessemailetiquette.com##+js(aopw, document.ondragstart)
+businessemailetiquette.com##.unselectable:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
+
+! https://www.camp-firefox.de/forum/viewtopic.php?p=1096410#p1096410
+liveonsat.com##+js(ra, oncontextmenu)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4049
 hindi-gk.com##p:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
@@ -595,20 +2108,6 @@ skionline.*##body[oncontextmenu]:remove-attr(/^on(contextmenu|copy|dragstart|sel
 skionline.*##+js(ra, oncontextmenu|oncopy|ondragstart|onselect|onselectstart, body, complete)
 !#endif
 
-! https://forums.lanik.us/viewtopic.php?f=64&t=42119#p143017
-carsguide.com.au##+js(set, isAdblockDisabled, true)
-carsguide.com.au###adBlockMessage
-
-! https://github.com/NanoMeow/QuickReports/issues/309
-@@||dermatologytimes.com^$ghide
-
-! https://github.com/uBlockOrigin/uAssets/issues/4120
-! https://github.com/NanoMeow/QuickReports/issues/32
-motherjones.com##.mj-adblock-widget
-
-! https://github.com/uBlockOrigin/uAssets/issues/4125
-boerse-express.com##+js(nostif, (), 1000)
-
 ! https://github.com/NanoMeow/QuickReports/issues/329
 kurazone.net##+js(aopw, clickIE4)
 kurazone.net##+js(aopw, disableSelection)
@@ -618,35 +2117,16 @@ techtrickseo.com##+js(aopw, disable_copy)
 techtrickseo.com##+js(aopw, disableSelection)
 techtrickseo.com##.unselectable:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! https://github.com/uBlockOrigin/uAssets/issues/4135
-videohelp.com##+js(acs, document.getElementById, block)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4141 right click
 calorielijst.nl##+js(aopw, clickIE)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4148
 humo.be##+js(set, checkPrivacyWall, noopFunc)
 
-! https://github.com/NanoMeow/QuickReports/issues/342
-! https://github.com/NanoMeow/QuickReports/issues/617
-! https://github.com/NanoMeow/QuickReports/issues/1412
-polygon.com##+js(aopw, loadOutbrain)
-##.adblock-whitelist-messaging__article-wrapper
-##.adblock-whitelist-messaging__wrapper
-
-! https://github.com/uBlockOrigin/uAssets/issues/4151
-economictimes.indiatimes.com##+js(aopr, intsFequencyCap)
-! https://github.com/uBlockOrigin/uAssets/issues/10598
-economictimes.indiatimes.com##+js(aeld, contextmenu)
-
 ! timponline . ro right click, select, copy
 timponline.ro##+js(aopw, disable_copy)
 timponline.ro##+js(aopw, disableSelection)
 timponline.ro##+js(aopw, nocontext)
-
-! https://github.com/uBlockOrigin/uAssets/issues/4158
-! https://github.com/uBlockOrigin/uAssets/issues/26210
-numberempire.com##+js(nostif, w3ad, 1000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4187 right click, select
 singingdalong.blogspot.com##+js(ra, oncontextmenu|ondragstart|onselectstart)
@@ -690,65 +2170,27 @@ filmesonlinex.co##+js(ra, oncontextmenu|ondragstart|onselectstart|onkeydown)
 booksmedicos.org##+js(aopw, disableSelection)
 booksmedicos.org##+js(acs, jQuery, document)
 
-! https://github.com/uBlockOrigin/uAssets/issues/4207
-proxfree.com###pftop:style(height: auto !important;padding-bottom:5px !important)
-proxfree.com##.pflrgAds
-
 ! https://forums.lanik.us/viewtopic.php?f=62&t=42259
 instagram.com##[class]:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/4237
-! https://github.com/NanoMeow/QuickReports/issues/3139
-@@||md5hashing.net^$ghide
-*$script,3p,redirect-rule=noopjs,domain=md5hashing.net
-md5hashing.net##.alert-danger.alert
-md5hashing.net##.red.b.center.mute
-
-! https://github.com/uBlockOrigin/uAssets/issues/4244
-siliconinvestor.com##+js(acs, document.getElementById, undefined)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4253
 jobsbotswana.info##+js(acs, jQuery, restriction)
 jobsbotswana.info##+js(aopw, document.oncontextmenu)
 jobsbotswana.info##body:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
 
-! https://github.com/uBlockOrigin/uAssets/issues/5489
-102bank.com,80beyond.spacestation-online.com,b4usa.com,badgerandblade.com,mzk.starachowice.eu##+js(aopw, adBlockDetected)
-||algosit.com^
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4271
 republicadecuritiba.net##+js(aopw, nocontext)
 republicadecuritiba.net##.unselectable:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://twitter.com/holly/status/1070781008457490433
-merchoid.com###message-purchased
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4268#issuecomment-445405264
 ||gaypornwave.com^$csp=script-src *
 gaypornwave.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! https://github.com/NanoMeow/QuickReports/issues/422
-@@||topspeed.com^$ghide
-topspeed.com##.adsninja-ad-zone
-topspeed.com##.txt-ad
-topspeed.com##.daily-vid-ad
-topspeed.com##.top-horizontal-ad-content
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4268#issuecomment-445478692
 @@||mywrestling.com.pl^$ghide
 
-! https://github.com/uBlockOrigin/uAssets/issues/4268#issuecomment-445481905
-webwereld.nl##+js(set, adsAreShown, true)
-
-! https://github.com/NanoMeow/QuickReports/issues/433
-sbenny.com##+js(nostif, (), 2000)
-forum.sbenny.com##.message-inner:has(.ads)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/58#issuecomment-446707009
 ||wp.com/wp-content/themes/vip/pmc-plugins/$script,domain=deadline.com
-
-! https://github.com/NanoMeow/QuickReports/issues/446
-howjsay.com##+js(nostif, (), 1500)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4325
 vpnmentor.com##+js(nostif, bioEp.showPopup)
@@ -756,25 +2198,16 @@ vpnmentor.com##+js(nostif, bioEp.showPopup)
 ! select / copy informagiovani-italia . com
 informagiovani-italia.com##body:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! anti adb warning /bigleaguepolitics . com
-@@||bigleaguepolitics.com^$ghide
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4357 right click / copy / ctrl-U
 techsupportall.com##+js(aeld, /^(?:contextmenu|copy|keydown)$/)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4367 right click / copy
 badayak.com##+js(acs, document.oncontextmenu)
 
-! https://github.com/NanoMeow/QuickReports/issues/366
-fin24.com##+js(aopr, Date.prototype.toUTCString)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4369
 djelfa.info##+js(aopr, document.onmousedown)
 djelfa.info##+js(aopw, document.oncontextmenu)
 djelfa.info##+js(ra, onselectstart)
-
-! https://github.com/uBlockOrigin/uAssets/issues/4388
-palemoon.org##+js(set, abd, false)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4386
 portableapps.com##+js(nostif, innerHTML)
@@ -788,23 +2221,11 @@ theartofnakedwoman.*##+js(aopw, intializemarquee)
 ! https://github.com/uBlockOrigin/uAssets/issues/4408
 j-lyric.net##+js(ra, oncontextmenu|onselectstart)
 
-! https://github.com/uBlockOrigin/uAssets/issues/4409
-cagesideseats.com##+js(nostif, (), 1500)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4411
 /wp-content/plugins/christmasify/*
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4368#issuecomment-449870173
-space-engineers.de##+js(acs, document.getElementById, undefined)
-
-! https://github.com/uBlockOrigin/uAssets/issues/4368#issuecomment-449870173
 motogon.ru##+js(aopr, oSpPOptions)
-
-! https://github.com/NanoMeow/QuickReports/issues/505
-@@||soundonsound.com^$ghide
-
-! https://github.com/uBlockOrigin/uAssets/issues/4447
-@@||jrocknews.com^$ghide
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4501
 aulete.com.br##.definicao_verbete_homologado_interna:style(height:100% !important;)
@@ -829,12 +2250,6 @@ mercurynews.com##body.modal-open:style(overflow-x: hidden !important; overflow-y
 ! https://github.com/uBlockOrigin/uAssets/issues/4524
 megawypas.com##+js(ra, oncontextmenu)
 
-! https://github.com/NanoMeow/QuickReports/issues/531
-wheel-size.com##+js(set, detector_active, true)
-
-! https://github.com/uBlockOrigin/uAssets/issues/4551
-@@||creditonebank.com^$ghide
-
 ! https://github.com/uBlockOrigin/uAssets/issues/741
 demolandia.net##+js(aopr, document.oncontextmenu)
 
@@ -842,17 +2257,11 @@ demolandia.net##+js(aopr, document.oncontextmenu)
 kirannewsagency.com##+js(aopw, disableSelection)
 kirannewsagency.com##+js(acs, document.oncontextmenu)
 
-! https://forums.lanik.us/viewtopic.php?p=144782#p144782
-aoezone.net##+js(set, aoezone_adchecker, true)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4611
 otempo.com.br##+js(aeld, copy)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4618
 meteo.org.pl##+js(ra, oncontextmenu)
-
-! https://github.com/uBlockOrigin/uAssets/issues/4650
-r7.com###inner-ad-container
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4652
 insurance-corporate.blogspot.com##+js(ra, oncontextmenu|ondragstart|onkeydown|onmousedown|onselectstart)
@@ -873,12 +2282,6 @@ europixhd.*,topeuropix.*##+js(acs, document.oncontextmenu)
 ! https://github.com/NanoAdblocker/NanoFilters/issues/260
 fanfiction.net,fictionpress.com##.storytextp:style(user-select: text !important; -webkit-user-select: text !important;)
 
-! https://github.com/NanoMeow/QuickReports/issues/590
-xnxx.com##+js(aopr, fuckAdBlock)
-
-! https://github.com/NanoMeow/QuickReports/issues/595
-@@||pagead2.googlesyndication.com/pagead/*$image,domain=free-scores.com
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4730
 radioony.fm##+js(set, pageService.initDownloadProtection, noopFunc)
 
@@ -888,9 +2291,6 @@ polskacanada.com##*:style(-webkit-touch-callout: default !important; -webkit-use
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4735
 lugarcerto.com.br##+js(aeld, mouseout, pop)
-
-! https://github.com/NanoMeow/QuickReports/issues/33#issuecomment-457932561
-windowscentral.com##.swal-modal, .swal-overlay
 
 ! gezimanya . com right click, copy, select
 gezimanya.com##+js(ra, oncontextmenu|onselectstart|onselect|oncopy)
@@ -903,21 +2303,12 @@ starsunfolded.com##+js(aopw, disableSelection)
 ! https://github.com/uBlockOrigin/uAssets/issues/4781
 cmjornal.pt##+js(aopw, document.oncopy)
 
-! https://github.com/NanoMeow/QuickReports/issues/631
-randaris.app##.adblock-box
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4787
 ctrl.blog##+js(aopr, a1lck)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/amvxds/blocked_element_keeps_reappearing_on_forums/
 coffeeforums.co.uk##+js(acs, document.getElementById, undefined)
 ||coffeeforums.co.uk/banners/$image
-
-! nachrichten . at anti adb
-@@||nachrichten.at^$ghide
-
-! https://www.reddit.com/r/uBlockOrigin/comments/annrln/polygon_antiadblock/
-heroesneverdie.com##+js(nostif, adsBlocked)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4809
 wader.toys##+js(aopw, document.oncontextmenu)
@@ -936,21 +2327,8 @@ mexiconewsdaily.com##+js(set, detectPrivateMode, noopFunc)
 ! https://github.com/uBlockOrigin/uAssets/issues/3673
 technologyreview.com##+js(set, webkitRequestFileSystem, undefined)
 
-! https://github.com/NanoMeow/QuickReports/issues/648
-! https://github.com/jspenguin2017/uBlockProtector/issues/1019
-curbed.com,eater.com,funnyordie.com,mmafighting.com,mmamania.com,polygon.com,racked.com,riftherald.com,sbnation.com,theverge.com,vox.com##+js(nostif, adsBlocked)
-
 ! right click https://github.com/uBlockOrigin/uAssets/issues/4822
 them4ufree.info##+js(acs, document.oncontextmenu)
-
-! bdcraft
-@@||bdcraft.net^$ghide
-bdcraft.net##+js(set, adsbygoogle, null)
-bdcraft.net##.cc-banner
-bdcraft.net##.hostBtn
-bdcraft.net##.adsbygoogle
-bdcraft.net###bottombanner
-bdcraft.net###header > .wrapper > [class]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4877
 athletic.net##+js(acs, $, blur)
@@ -964,12 +2342,6 @@ athletic.net##*:style(-webkit-user-select: text !important; -moz-user-select: te
 athletic.net##.ng-star-inserted.sign-up-box
 athletic.net##[_ngcontent-serverapp-c134]:style(text-shadow: none !important; color: #000 !important;)
 
-! https://github.com/uBlockOrigin/uAssets/issues/4947
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=yellowbridge.com
-
-! https://github.com/uBlockOrigin/uAssets/issues/4950
-diynetwork.com##.o-AdhesionNotifier
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4953
 ! disabled for #7183
 !tapatalk.com##+js(aopr, IS_VIP_PLUS)
@@ -978,9 +2350,6 @@ diynetwork.com##.o-AdhesionNotifier
 bloombergquint.com##+js(aopw, addLinkToCopy)
 bloombergquint.com##^script:has-text(/addLinkToCopy/i)
 bloombergquint.com##+js(aopr, getSelection)
-
-! https://github.com/NanoMeow/QuickReports/issues/701
-androidcentral.com##.swal-overlay
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4985
 ! https://github.com/uBlockOrigin/uAssets/issues/5030
@@ -996,17 +2365,6 @@ instagram.com###react-root ~ div[class*=" "][class$=" "][role="presentation"]:ha
 !#if env_mobile
 instagram.com##.xZ2Xk:has-text(/App/)
 !#endif
-
-! https://github.com/NanoMeow/QuickReports/issues/713
-@@||eppingforestguardian.co.uk^$ghide
-eppingforestguardian.co.uk##.dfp-ad
-eppingforestguardian.co.uk##.mar-block-ad
-
-! https://github.com/NanoMeow/QuickReports/issues/714
-||code.adsales.snidigital.com/lib/*/sni-ads.min.js$script,domain=travelchannel.com
-
-! https://github.com/uBlockOrigin/uAssets/issues/5002
-diffnow.com##:xpath(//div[contains(text(),"Adblock")]/..)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5030
 addons.opera.com##+js(nostif, showOverlay)
@@ -1069,9 +2427,6 @@ quora.com##.signup_wall_prevent_scroll:style(position: unset !important; padding
 ! right click, select ##5086
 tecnotutoshd.net##+js(aopw, document.oncontextmenu)
 tecnotutoshd.net##+js(acs, disableselect, reEnable)
-
-! https://github.com/NanoMeow/QuickReports/issues/783
-ruwix.com##+js(nostif, NoAd, 8000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5107
 revolvermag.com##.emma-show
@@ -1136,9 +2491,6 @@ listatv.pl##+js(ra, oncontextmenu)
 ! https://github.com/uBlockOrigin/uAssets/issues/5224
 dzwignice.info##+js(aeld, contextmenu)
 
-! https://github.com/NanoMeow/QuickReports/issues/885
-rp5.by##+js(nostif, (), 700)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/5244
 psychologiazycia.com##+js(acs, document.oncontextmenu)
 psychologiazycia.com##+js(acs, disableselect, reEnable)
@@ -1177,9 +2529,6 @@ salary.com###sgpb-popup-dialog-main-div-wrapper, .sgpb-theme-1-overlay
 ! https://github.com/uBlockOrigin/uAssets/issues/5285
 fearlesssalarynegotiation.com##.seva-overlay
 
-! https://github.com/uBlockOrigin/uAssets/issues/5286
-postandcourier.com##.tp-backdrop, .tp-modal
-
 ! annoying grammarly overlay / popup spellcheck .net,spellchecker .net,spellweb .com
 ! https://github.com/uBlockOrigin/uAssets/issues/5953
 */bioep.js$script,domain=~tomshw.it
@@ -1202,11 +2551,6 @@ autoblog.com##body:style(overflow-x: hidden !important; overflow-y: scroll !impo
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5305#issuecomment-481954139
 cepuluh.com##+js(ra, oncontextmenu|onkeydown|onmousedown)
-
-! https://github.com/NanoMeow/QuickReports/issues/1324
-@@||globalnews.ca^$ghide
-globalnews.ca##.ad-container
-globalnews.ca###headerAd
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5321
 dailymail.co.uk##^script:has-text(We think our Android)
@@ -1238,24 +2582,9 @@ husseinezzat.com##+js(aeld, contextmenu)
 husseinezzat.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
 husseinezzat.com##+js(aeld, keydown)
 
-! https://github.com/uBlockOrigin/uAssets/issues/186#issuecomment-486142318
-wired.co.uk##+js(set, ads_not_blocked, true)
-
-! https://github.com/NanoMeow/QuickReports/issues/1073
-polygon.com##+js(nostif, adsBlocked)
-
-! https://github.com/NanoMeow/QuickReports/issues/1071
-twinkietown.com##+js(nostif, adsBlocked)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/5305#issuecomment-487302508
 statelibrary.us##+js(aopr, document.oncontextmenu)
 statelibrary.us##+js(aeld, keydown, disable_in_input)
-
-! https://github.com/NanoMeow/QuickReports/issues/1114
-@@||dcdirtylaundry.com^$ghide
-
-! https://github.com/NanoMeow/QuickReports/issues/1126
-@@||sostariffe.it^$ghide
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5489#issuecomment-489295062
 amlesson.ru##+js(aopw, disable_keystrokes)
@@ -1263,9 +2592,6 @@ amlesson.ru##+js(aopw, disableSelection)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5526
 infomoney.com.br##+js(aopr, addLink)
-
-! https://github.com/uBlockOrigin/uAssets/issues/5530
-playonlinux.com##+js(acs, $, load)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5536
 tabonitobrasil.*##+js(aopr, disableSelection)
@@ -1280,34 +2606,16 @@ tunovelaligera.com##+js(rmnt, style, /wccp|user-select/)
 ! https://github.com/uBlockOrigin/uAssets/issues/5489#issuecomment-489892660
 auepaisagismo.com,auepaisajismo.com##body:style(overflow: auto !important;)
 
-! https://github.com/uBlockOrigin/uAssets/issues/2101#issuecomment-491625176
-zdnet.de##+js(aopr, can_i_run_ads)
-
-! https://github.com/NanoMeow/QuickReports/issues/1209
-cinemablend.com##+js(aopr, __cmpGdprAppliesGlobally)
-
 ! bigulnews .tv right click, select, ctrl-U
 bigulnews.tv##+js(aeld, /contextmenu|keydown|keyup|copy/)
 bigulnews.tv##+js(aopw, stopPrntScr)
 bigulnews.tv##*::selection:style(background-color:#338FFF!important)
-
-! https://github.com/uBlockOrigin/uAssets/issues/5613
-@@||metabattle.com^$ghide
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5615
 targetstudy.com##+js(aopw, stopSelect)
 
 ! discord's "give nitro" button
 discordapp.com##[class^="buttonWrapper"][tabindex="2"]
-
-! https://github.com/uBlockOrigin/uAssets/issues/5643
-gq-magazine.co.uk##+js(set, ads_not_blocked, true)
-
-! turbolab .it anti adb warning
-turbolab.it##+js(nostif, warning)
-
-! https://github.com/NanoMeow/QuickReports/issues/1311
-medicalnewstoday.com##.sticky_ad_container
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5759
 !#if env_firefox
@@ -1329,10 +2637,6 @@ m.youtube.com,music.youtube.com,tv.youtube.com,www.youtube.com,youtubekids.com##
 ! https://m.youtube.com/ - background playback prevention
 m.youtube.com##+js(aeld, visibilitychange, /bgmobile|\{\w\.\w+\(\)\}/)
 
-! https://github.com/NanoMeow/QuickReports/issues/1338
-buienradar.nl##+js(set, hideBannerBlockedMessage, true)
-buienradar.nl###adholderContainerHeader
-
 ! https://github.com/uBlockOrigin/uAssets/issues/5769
 ||lightboxcdn.com^$domain=foreignpolicy.com
 foreignpolicy.com##.fb_lightbox-lock:style(overflow-x: hidden !important; overflow-y: scroll !important;)
@@ -1346,12 +2650,6 @@ luoghidavedere.it##+js(acs, document.onselectstart)
 !#if env_firefox
 msn.com##p:style(-moz-user-select: text !important; -moz-user-drag: text !important;)
 !#endif
-
-! glamourmagazine.co.uk anti adb annoyance
-glamourmagazine.co.uk##+js(set, ads_not_blocked, true)
-
-! https://github.com/NanoMeow/QuickReports/issues/1394
-9xbuddy.com##+js(nostif, adsbygoogle)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/5855
 megatube.xxx##+js(ra, oncontextmenu)
@@ -1387,11 +2685,6 @@ chimica-online.it##+js(aopr, disableselect)
 ! https://github.com/uBlockOrigin/uAssets/issues/5882
 coag.pl,quicksleeper.pl##+js(aopr, document.oncontextmenu)
 
-! https://forums.lanik.us/viewtopic.php?f=62&t=43213
-dispatch.com##.tp-modal
-dispatch.com##.tp-active.tp-backdrop
-dispatch.com##body:style(overflow: auto !important;)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/5913
 elektro-plast.com.pl##+js(ra, oncontextmenu)
 
@@ -1404,61 +2697,14 @@ australianfrequentflyer.com.au##.focus-guest-alert
 ! https://github.com/uBlockOrigin/uAssets/issues/5911
 dev.mysql.com##.login-callout
 
-! https://github.com/NanoMeow/QuickReports/issues/1470
-anisearch.com#@##bannerads
-
-! https://github.com/uBlockOrigin/uAssets/issues/5911#issuecomment-511588571
-context.reverso.net##.blocked:style(filter: none !important;)
-context.reverso.net##.blocked .text:style(filter: none!important;-webkit-filter: none!important;)
-context.reverso.net###blocked-results-banner
-
-! https://github.com/NanoMeow/QuickReports/issues/1508
-hardware.info##body > div:nth-of-type(1) > div:has-text(adblocker)
-hardware.info##.sidebar_right_bottom
-hardware.info##.sidebar_right_top
-
-! https://github.com/uBlockOrigin/uAssets/issues/5970
-med1.de##+js(aopr, _sp_._networkListenerData)
-
-! https://github.com/NanoMeow/QuickReports/issues/1527
-@@||mentalmars.com^$ghide
-
-! https://github.com/uBlockOrigin/uAssets/issues/5979
-neowin.net##+js(aopr, _sp_.mms.startMsg)
-neowin.net##[class^="sp_veil"]
-neowin.net##[id^="sp_message_panel_id"]
-
 ! https://github.com/uBlockOrigin/uAssets/issues/5985
 lexlog.pl##+js(aopr, document.oncontextmenu)
 lexlog.pl##+js(aopr, document.onmousedown)
 lexlog.pl##+js(aopr, document.onselectstart)
 
-! https://github.com/NanoMeow/QuickReports/issues/1588
-@@||independent.ie^$ghide
-
 ! https://github.com/uBlockOrigin/uAssets/issues/6013
 softwaretestinghelp.com##.Campaign
 softwaretestinghelp.com##body:style(overflow: auto !important;)
-
-! https://forums.lanik.us/viewtopic.php?f=62&t=43327&p=148979#p148979
-@@||nzz.ch^$ghide
-nzz.ch###adnz_maxiboard_1
-
-! https://github.com/uBlockOrigin/uAssets/issues/6021
-watson.de,watson.ch##+js(nostif, AdBlocker)
-
-! https://github.com/NanoMeow/QuickReports/issues/292
-babel.com##[id^=adReplacement]
-babel.com##.infopub
-
-! https://github.com/NanoMeow/QuickReports/issues/1620
-@@||airbnbhell.com^$ghide
-
-! https://github.com/uBlockOrigin/uAssets/issues/4707
-clk.ink##+js(set, blurred, false)
-
-! https://github.com/uBlockOrigin/uAssets/issues/6050
-smashboards.com##+js(nosiif, height)
 
 ! yeane .org right click, select, ctrl-U
 yeane.org##+js(acs, document.oncontextmenu)
@@ -1471,32 +2717,15 @@ bitblokes.de##[href^="https://airvpn.org/"]
 ! https://github.com/uBlockOrigin/uAssets/issues/6073
 recantodasletras.com.br##+js(aopr, RL.licenseman.init)
 
-! https://github.com/uBlockOrigin/uAssets/issues/6093
-@@||cdnjs.cloudflare.com/ajax/libs/blockadblock/*/blockadblock.min.js$script,domain=starblast.io
-@@||starblast.io^$ghide
-*$script,redirect-rule=noopjs,domain=starblast.io
-
 ! https://forums.lanik.us/viewtopic.php?f=62&t=43420
 vedbex.com##.in.fade
 vedbex.com##body:style(overflow: auto !important;)
 ||vedbex.com/*banners$image
 ||vedbex.com/*/sponsers$image
 
-! https://github.com/NanoMeow/QuickReports/issues/1709
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=noopjs,domain=files2zip.com
-files2zip.com##div.black.banner
-
-! https://www.reddit.com/r/uBlockOrigin/comments/cvm6pn/how_to_get_rid_of_blurred_text_on_websites_such/
-enotes.com##.obscured:style(color: black !important;text-shadow: none !important; filter: none !important)
-enotes.com##.paywall-mount
-
 ! https://github.com/uBlockOrigin/uAssets/issues/6206
 mtbtutoriales.com##+js(aopw, reEnable)
 mtbtutoriales.com##+js(acs, document.oncontextmenu)
-
-! https://github.com/NanoMeow/QuickReports/issues/1396
-@@||wired.com^$ghide
-wired.com##.ad
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6240
 news.chosun.com##+js(aeld, copy, getSelection)
@@ -1504,33 +2733,12 @@ news.chosun.com##+js(aeld, copy, getSelection)
 ! https://github.com/MajkiIT/polish-ads-filter/issues/14597#issuecomment-528321503
 portalwrc.pl##+js(aeld, contextmenu)
 
-! https://github.com/NanoMeow/QuickReports/issues/1780
-@@||belfasttelegraph.co.uk^$ghide
-
 ! https://answersafrica .com/joe-bonamassa-bio-wife-net-worth-girlfriend.html right click - select - copy - ctrl-U
 answersafrica.com##+js(acs, document.oncontextmenu)
 answersafrica.com##body:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
 
 ! thewpclub .net right click, select, copy
 /wp-content/plugins/content-protector-pack/*
-
-! https://github.com/NanoMeow/QuickReports/issues/1822
-tomsguide.com##+js(aopr, _sp_._networkListenerData)
-
-! https://github.com/NanoMeow/QuickReports/issues/1832
-@@||flightaware.com^$ghide
-
-! https://www.reddit.com/r/uBlockOrigin/comments/d5ekq0/antiadblock_detected_wwwlesoirbe/
-lesoir.be##+js(aopr, abStyle)
-
-! https://github.com/uBlockOrigin/uAssets/issues/6318
-xe.gr##+js(nostif, modal)
-
-! https://github.com/NanoMeow/QuickReports/issues/1865
-@@||typing-speed.net^$ghide
-
-! https://github.com/NanoMeow/QuickReports/issues/1867
-plagiarisma.net###noty_bottom_layout_container
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6323
 felico.pl##+js(acs, document.oncontextmenu)
@@ -1545,9 +2753,6 @@ chowhound.com##.fb_lightbox-overlay
 chowhound.com##.preloaded_lightbox
 chowhound.com##.fb_lightbox-lock:style(overflow-x: hidden !important; overflow-y: scroll !important;)
 
-! https://forums.lanik.us/viewtopic.php?f=62&t=43618
-bold.dk##+js(acs, eval, abd)
-
 ! https://forums.lanik.us/viewtopic.php?f=62&t=43617
 liverpool.no##+js(nostif, offsetHeight)
 
@@ -1557,10 +2762,6 @@ mainframestechhelp.com##*:style(-webkit-touch-callout: default !important; -webk
 
 ! right click, select, copy mainframegurukul .com/srcsinc/drona/programming/languages/jcl/sort/sort-outrec-jcl.html
 mainframegurukul.com##+js(ra, oncontextmenu|onselectstart|ondragstart)
-
-! https://github.com/NanoMeow/QuickReports/issues/1933
-@@||as.com^$ghide
-as.com##.publi
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6363
 digicular.com##html:style(overflow: hidden !important;)
@@ -1575,12 +2776,6 @@ badzjeszczelepszy.pl##+js(aopr, ga_ExitPopup3339)
 
 ! https://github.com/NanoMeow/QuickReports/issues/1941
 androidweblog.com##+js(aeld, , t.preventDefault)
-
-! https://github.com/NanoMeow/QuickReports/issues/1948
-pureinfotech.com##+js(acs, jQuery, ai_adb)
-
-! https://forums.lanik.us/viewtopic.php?f=62&t=43651
-fairyabc.com##+js(nostif, adblock)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6397
 tunein.com##.dark-theme-dialog__dialogBody___106Di
@@ -1615,11 +2810,6 @@ cronista.com##+js(aeld, copy, replaceCopiedText)
 ! gamershit .altervista .org right click msg
 gamershit.altervista.org##+js(aopr, document.oncontextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/issues/4802
-@@||minecraft-schematics.com^$ghide
-minecraft-schematics.com##.adsbygoogle
-minecraft-schematics.com##[href^="http://www.pingperfect.com/aff.php"]
-
 ! theitaliantimes .it right click, select, copy ..
 theitaliantimes.it##+js(ra, oncontextmenu|onselectstart|ondragstart|oncopy|oncut|onpaste|onbeforecopy)
 
@@ -1637,20 +2827,8 @@ anisubindo.*##+js(aopw, disableSelection)
 ! mbahhanif .site select / copy
 mbahhanif.site##body:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
 
-! https://github.com/NanoMeow/QuickReports/issues/2119
-@@||dumpert.nl^$ghide
-
-! https://github.com/NanoMeow/QuickReports/issues/2123
-@@||beinsports.com^$ghide
-
-! https://github.com/NanoMeow/QuickReports/issues/2143
-@@||mizonatv.com^$ghide
-
 ! https://github.com/uBlockOrigin/uAssets/issues/6489
 serwis-zamkow.com##+js(acs, document.oncontextmenu)
-
-! https://github.com/NanoMeow/QuickReports/issues/2154
-nakedcapitalism.com##+js(aopw, ABD)
 
 ! https://github.com/NanoMeow/QuickReports/issues/2164
 govtech.com###interstitial
@@ -1661,13 +2839,6 @@ lublin.eu##+js(aeld, contextmenu)
 ! right click tekloggers .com/2019/10/iklan-anime-pocari-sweat-ternyata.html
 tekloggers.com##+js(ra, oncontextmenu|onkeydown|onmousedown)
 
-! https://github.com/uBlockOrigin/uAssets/issues/6509
-molineuxmix.co.uk##+js(acs, $, undefined)
-
-! https://github.com/NanoMeow/QuickReports/issues/2240
-foxnews.com##:xpath('//*[contains(text(),"blocking software")]/../../..')
-/google-funding-choices.js$script,domain=foxnews.com
-
 ! nfltraderumors.co right click, select
 nfltraderumors.co##+js(aopw, ondragstart)
 nfltraderumors.co##body:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
@@ -1676,13 +2847,6 @@ nfltraderumors.co##body:style(-webkit-touch-callout: default !important; -webkit
 blog.kwick.de##+js(acs, jQuery, contextmenu)
 blog.kwick.de##+js(aopr, disableselect)
 blog.kwick.de##+js(aopr, document.onkeydown)
-
-! https://github.com/NanoMeow/QuickReports/issues/2257
-laptopmag.com##+js(aopr, _sp_.mms.startMsg)
-
-! https://github.com/uBlockOrigin/uAssets/issues/6572
-windows101tricks.com##+js(aopr, __cmpGdprAppliesGlobally)
-windows101tricks.com##+js(set, better_ads_adblock, 0)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6575
 virpe.com##+js(aopr, document.oncontextmenu)
@@ -1751,12 +2915,6 @@ estadao.com.br##+js(aeld, copy)
 kimkazandi.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
 kimkazandi.com##.autoplay
 
-! https://github.com/NanoMeow/QuickReports/issues/2535
-minecraftforge.net##+js(nostif, body)
-
-! https://github.com/NanoMeow/QuickReports/issues/2545
-forum.nlmod.net##+js(acs, document.createElement, adblock)
-
 ! impotsurlerevenu.or enable right click
 impotsurlerevenu.org##+js(aopr, alerte_declanchee)
 
@@ -1772,32 +2930,11 @@ feel-the-darkness.rocks##+js(aopr, document.oncontextmenu)
 feel-the-darkness.rocks##+js(aopr, document.onmousedown)
 feel-the-darkness.rocks##+js(aopr, disableSelection)
 
-! https://github.com/uBlockOrigin/uAssets/issues/6759
-fontsfree.pro##+js(set, adBlock, false)
-
 ! https://github.com/NanoMeow/QuickReports/issues/2601
 skidrowcodex.net##+js(aopw, stopPrntScr)
 
-! https://github.com/uBlockOrigin/uAssets/issues/6767
-earnload.*##+js(set, blurred, false)
-
 ! https://github.com/NanoMeow/QuickReports/issues/2622
 mdpr.jp##+js(ra, oncontextmenu|onmousedown|onselectstart)
-
-! https://github.com/NanoMeow/QuickReports/issues/2635
-theherald-news.com##+js(nostif, null)
-
-! https://github.com/NanoMeow/QuickReports/issues/2605
-insidermonkey.com##+js(aopr, ABD)
-
-! https://github.com/NanoMeow/QuickReports/issues/2640
-venea.net##+js(aeld, , ads)
-
-! https://github.com/NanoMeow/QuickReports/issues/2341
-@@||puhutv.com^$ghide
-
-! https://github.com/NanoMeow/QuickReports/issues/2665
-libgen.*##+js(nostif, appendMessage)
 
 ! https://github.com/NanoMeow/QuickReports/issues/2680
 bricksrus.com##+js(aopr, document.oncontextmenu)
@@ -1820,19 +2957,9 @@ kurazone.net##.post-body:style(-webkit-touch-callout: default !important; -webki
 ! https://github.com/NanoMeow/QuickReports/issues/2707
 kurosave.com##+js(aopr, document.body.setAttribute)
 
-! https://github.com/uBlockOrigin/uAssets/issues/7811
-! https://github.com/uBlockOrigin/uAssets/issues/11335
-keybr.com##+js(nostif, (), 5000)
-
 ! https://github.com/NanoMeow/QuickReports/issues/2720
 mangaku.*##+js(acs, $, contextmenu)
 mangaku.*##+js(aeld, contextmenu)
-
-! edmontonjournal .com anti adb warning
-@@||edmontonjournal.com^$ghide
-
-! gamebanana anti adblock notice
-gamebanana.com##+js(aopr, adBlockDetected)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10888#issuecomment-1523943368
 www.reddit.com###nsfw-desktop-auth-blocking-modal-dialog,#nsfw-desktop-auth-blocking-modal-overlay-element
@@ -1852,9 +2979,6 @@ reddit.com##body:style(overflow: auto !important;)
 sh.reddit.com,www.reddit.com##+js(trusted-set-local-storage-item, xpromo-consolidation, $currentDate$)
 !#endif
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/42495#issuecomment-574761083
-@@||metropoles.com^$ghide
-
 ! https://github.com/uBlockOrigin/uAssets/issues/6833
 fotor.com##+js(nostif, offsetHeight)
 fotor.com##._1Pece
@@ -1873,9 +2997,6 @@ techopedia.com##.modal-open:style(overflow: auto !important; padding-top: 0 !imp
 ! https://github.com/uBlockOrigin/uAssets/issues/6848
 uta-net.com##+js(aeld, /contextmenu|selectstart|copy/)
 ||uta-net.com/reverse/user/phplib/img/1pix.gif$image
-
-! https://github.com/NanoMeow/QuickReports/issues/2787
-hedgeaccordingly.com##+js(aopw, ABD)
 
 ! downloadtutorials .net right click, select, copy
 downloadtutorials.net##+js(aeld, /contextmenu|selectstart|copy/)
@@ -1904,12 +3025,6 @@ atribuna.com.br##+js(ra, oncontextmenu|onkeydown)
 ! vinaurl .in blocked keys
 vinaurl.*##+js(ra, onkeydown)
 
-! https://github.com/uBlockOrigin/uAssets/issues/6877
-theregister.co.uk##+js(aopr, adtoniq)
-
-! https://www.reddit.com/r/firefox/comments/eu70aq/turn_off_ublock_origin_howaboutno/
-@@||merryjane.com/static/images/ads.png^$image,1p
-
 ! https://github.com/uBlockOrigin/uAssets/issues/6888
 diariodoiguacu.com.br##+js(ra, ondragstart|onselectstart)
 
@@ -1921,9 +3036,6 @@ fizyka.org##body:style(-webkit-touch-callout: default !important; -webkit-user-s
 
 ! https://github.com/NanoMeow/QuickReports/issues/2869
 @@||readonepiece.com/wp-content/$script,1p
-
-! ymovies .to anti adb warning
-ymovies.*##.alert-danger.alert
 
 ! https://github.com/NanoMeow/QuickReports/issues/2878
 adnan-tech.com##+js(ra, oncontextmenu)
@@ -1949,14 +3061,6 @@ ofuxico.com.br##+js(aeld, copy)
 ! nzbstars .com right click
 nzbstars.com##+js(ra, oncontextmenu)
 
-! almasdarnews .com warning anti adb #2421
-almasdarnews.com##+js(acs, jQuery, ai_adb)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/78541
-*$xhr,redirect-rule=noopjs,domain=maxedtech.com
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=maxedtech.com
-@@||googlesyndication.com^$xhr,domain=maxedtech.com
-
 ! ideaberita .com ctrl-u select
 ideaberita.com##+js(aopr, document.onkeydown)
 ideaberita.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
@@ -1971,9 +3075,6 @@ tepat.id##*::selection:style(background-color:#338FFF!important)
 
 ! https://github.com/NanoMeow/QuickReports/issues/2944
 isikuota.co.id##*:style(-webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/49311
-nmac.to##.alert-errors.in.fade.alert
 
 ! langitmovie .com right click, select
 langitmovie.com##+js(aopr, document.oncontextmenu)
@@ -1998,19 +3099,11 @@ oceanof-games.com##*:style(-webkit-touch-callout: default !important; -webkit-us
 download.ipeenk.com##+js(acs, document.oncontextmenu)
 download.ipeenk.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! https://github.com/NanoMeow/QuickReports/issues/2972
-livescience.com##+js(aopr, _sp_.mms.startMsg)
-
 ! https://github.com/NanoMeow/QuickReports/issues/2979
 doranobi-fansub.id##+js(acs, jQuery, disable_hot_keys)
 doranobi-fansub.id##+js(acs, document.oncontextmenu)
 doranobi-fansub.id##+js(aopr, disable_copy)
 doranobi-fansub.id##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/NanoMeow/QuickReports/issues/2981
-@@||queer.pl^$ghide
-queer.pl#@#[class^="ad-"]
-queer.pl##.box-adv
 
 ! https://github.com/NanoMeow/QuickReports/issues/2991
 ponselharian.com##+js(aopr, document.oncontextmenu)
@@ -2020,17 +3113,8 @@ ponselharian.com##+js(aopr, disableSelection)
 ! https://github.com/uBlockOrigin/uAssets/issues/6943
 itvn.pl,itvnextra.pl,kuchniaplus.pl,miniminiplus.pl,player.pl,ttv.pl,tvn.pl,tvn24.pl,tvn24bis.pl,tvn7.pl,tvnfabula.pl,tvnstyle.pl,tvnturbo.pl,x-link.pl,x-news.pl##+js(aeld, contextmenu, a)
 
-! https://github.com/uBlockOrigin/uAssets/issues/6945
-@@||snipboard.io^$ghide
-
-! musicradar .com and other sites anti adb warning
-digitalcameraworld.com,guitarworld.com,musicradar.com##+js(aopr, _sp_.mms.startMsg)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/6954
 alexeiportableapp.blogspot.com##+js(acs, document.oncontextmenu)
-
-! https://github.com/uBlockOrigin/uAssets/issues/6956
-mocospace.com##+js(nostif, adblocker)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6963
 nogizaka46.com##+js(ra, oncontextmenu)
@@ -2039,31 +3123,14 @@ nogizaka46.com##+js(ra, oncontextmenu)
 karamellstore.com.br##+js(nostif, exit_popup, 10000)
 ||smarthint.co^$3p
 
-! bigten .org anti adb warning
-@@||bigten.org^$xhr,1p
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/50013
-strangermeetup.com##+js(set, adsEnabled, true)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/6968
 nostracasa.com.br##+js(ra, oncontextmenu|onselectstart|ondragstart)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6969
 oparana.com.br##+js(acs, document.oncontextmenu)
 
-! ai_adb warning
-casertace.net,civildigital.com,lesmoutonsenrages.fr,venusarchives.com,verpornocomic.com##+js(acs, jQuery, ai_adb)
-
-! https://github.com/NanoMeow/QuickReports/issues/3095
-@@||frontpage.fok.nl^$ghide
-frontpage.fok.nl###wa_web_headertofloor
-frontpage.fok.nl##div.commercial_space
-
 ! https://github.com/NanoMeow/QuickReports/issues/3123
 lolle21.com##+js(acs, document.oncontextmenu)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/50414
-civicx.com##.adblock_detector
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6999
 apps.jeurissen.co##.adsbygoogle:upward(1)
@@ -2086,14 +3153,8 @@ utamap.com##*:style(-webkit-touch-callout: default !important; -webkit-user-sele
 utaten.com##+js(ra, oncontextmenu|onselectstart)
 utaten.com##.lyricBody:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! mp3fy .com anti adb warning
-@@||mp3fy.com^$ghide
-
 ! https://github.com/uBlockOrigin/uAssets/issues/7023
 verdadeiroolhar.pt##+js(acs, document.onselectstart)
-
-! https://github.com/NanoMeow/QuickReports/issues/3924
-radarbox.com##+js(set, ads_enabled, true)
 
 ! https://github.com/NanoMeow/QuickReports/issues/3181
 mangaid.click##+js(acs, document.oncontextmenu)
@@ -2109,9 +3170,6 @@ librospreuniversitariospdf.blogspot.com##+js(acs, document.onkeydown)
 librospreuniversitariospdf.blogspot.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 librospreuniversitariospdf.blogspot.com##^script:has-text(debugger)
 
-! https://forums.lanik.us/viewtopic.php?p=153251#p153251
-keighleynews.co.uk##+js(aopr, _sp_.mms.startMsg)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/7054
 manianomikata.com##+js(acs, document.oncontextmenu)
 manianomikata.com##+js(aopw, disableSelection)
@@ -2124,14 +3182,6 @@ quotev.com##div.storyView:style(-webkit-touch-callout: default !important; curso
 ! https://github.com/NanoMeow/QuickReports/issues/3216
 underconsideration.com##+js(nostif, test.remove)
 
-! https://github.com/uBlockOrigin/uAssets/issues/7058
-!#if env_chromium
-!newyorker.com##+js(acs, navigator.storage.estimate)
-!#endif
-!#if env_firefox
-newyorker.com##+js(set, webkitRequestFileSystem, noopFunc)
-!#endif
-
 ! https://github.com/NanoMeow/QuickReports/issues/3236
 nekopoi.web.id##+js(acs, document.oncopy)
 nekopoi.web.id##+js(ra, oncontextmenu|ondragstart)
@@ -2141,9 +3191,6 @@ kickante.com.br##+js(aeld, mouseleave)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7070
 scribd.com##+js(aeld, /^(mouseout|mouseleave)$/)
-
-! mt07-forum/auto-treff anti-adb
-mt07-forum.de,auto-treff.com##+js(acs, $, offsetHeight)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7093
 foreignaffairs.com##+js(nostif, noscroll, 3000)
@@ -2155,9 +3202,6 @@ hienzo.com##*:style(-webkit-touch-callout: default !important; -webkit-user-sele
 ! tfp.is anticopy/selection/keydown
 tfp.is##+js(acs, document.oncontextmenu)
 tfp.is##body:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/NanoMeow/QuickReports/issues/3310
-dxmaps.com##+js(nostif, adsbygoogle, 5000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7105
 kapiert.de##+js(aeld, contextmenu)
@@ -2199,32 +3243,12 @@ dramacute.*##+js(acs, disableSelection)
 hitcena.pl##+js(aeld, contextmenu)
 hitcena.pl##body:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! photoshop-online anti-adb
-photoshop-online.biz##+js(nostif, google_jobrunner)
-photoshop-online.biz##div.aslot
-
-! https://github.com/NanoMeow/QuickReports/issues/3447
-loudersound.com##+js(aopr, _sp_._networkListenerData)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/7176
 livedays.jp##p,ul,ol:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://www.reddit.com/r/uBlockOrigin/comments/fsgpzp/adblock_detected_on_this_website/
-boomlive.in###ad_blocker_detect_dialog
-boomlive.in##.advert-panel
-
-! lewdzone.com adblock notice
-lewdzone.com##div.loading-links
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/fsupgm/best_way_to_enable_scrolling_after_hiding_a_popup/
 greatist.com###modal-host
 greatist.com##body:style(overflow: auto !important;)
-
-! https://github.com/NanoMeow/QuickReports/issues/3458
-hearthstone-decks.net##+js(acs, jQuery, ai_check)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/52709
-bejson.com##+js(set, killads, true)
 
 ! interviewgig .com select - copy
 interviewgig.com##+js(acs, document.onselectstart)
@@ -2241,10 +3265,6 @@ nonton78.com##+js(acs, onload, contextmenu)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/661#issuecomment-609018989
 boards.net,freeforums.net,proboards.com##+js(aeld, scroll)
-
-! https://forums.lanik.us/viewtopic.php?p=153944#p153944
-deezer.com##+js(nostif, bait)
-deezer.com##.abp-banner
 
 ! opportunitydesk anti-rightclick/anti-selection
 opportunitydesk.org##+js(aopr, disable_copy)
@@ -2263,29 +3283,15 @@ kbdfans.com##html:style(overflow: auto !important;)
 kamerabudaya.com##+js(ra, onselectstart|ondragstart|onmousedown|onkeydown|oncontextmenu, body)
 kamerabudaya.com##body:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/53356
-idahopress.com##.tnc-overlay.tncms-block
-idahopress.com###blox-message-incompatible
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/53425
-adslayuda.com##+js(set, better_ads_adblock, null)
-
 ! raccontivietati .com select
 raccontivietati.com##+js(aopr, disableSelection)
 raccontivietati.com##body:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/NanoMeow/QuickReports/issues/3559
-creativebloq.com##+js(aopr, _sp_.mms.startMsg)
 
 ! https://github.com/NanoMeow/QuickReports/issues/3561
 therealdeal.com##.async-hide:style(opacity:1!important)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7226
 intergate.info##+js(set, document.oncontextmenu, null)
-
-! Steady anti adb warning
-handball-world.news,mobiflip.de,titanic-magazin.de,mimikama.org,langweiledich.net,der-postillon.com,perlentaucher.de,lwlies.com,serieslyawesome.tv,critic.de,mediotejo.net,nahrungsmittel-intoleranz.com,madeinbocholt.de,goodnews-magazin.de,wallauonline.de##+js(nostif, steady-adblock)
-handball-world.news##small
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7238
 healthitsecurity.com###CoverPop-cover
@@ -2294,17 +3300,8 @@ healthitsecurity.com##.CoverPop-open:style(overflow: auto !important)
 ! https://github.com/uBlockOrigin/uAssets/issues/7241
 digitalfernsehen.de##+js(aeld, contextmenu)
 
-! https://github.com/NanoMeow/QuickReports/issues/3578
-simpleflying.com##.simpl-adlabel
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/53650
-masrawy.com##+js(acs, document.getElementById, adblockerdetected)
-
 ! https://github.com/AdguardTeam/AdguardFilters/issues/53667
 techieway.blogspot.com##+js(aopr, document.onselectstart)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/53694
-milfzr.com##+js(acs, $, juicyads)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/53717
 pornfd.com##.page-error
@@ -2361,21 +3358,12 @@ getnzlr.newzenler.com###zenPopupModal, .modal-backdrop
 getnzlr.newzenler.com##.modal-open:style(overflow: auto !important)
 !#endif
 
-! litecompare .com anti adb notice
-@@||litecompare.com^$ghide
-
-! fiscomania .com anti adb notice
-@@||fiscomania.com^$ghide
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/g61qeq/block_blur_effect_from_div/
 vol.at##.blur:style(filter: none !important)
 
 ! lokercirebon.com anti-rightclick/selection/keys annoyance
 lokercirebon.com##+js(aeld, /contextmenu|keydown|dragstart/)
 lokercirebon.com##style:has-text(::selection):remove()
-
-! playbill .com anti adb warning
-playbill.com##+js(nostif, offsetHeight)
 
 ! pentruea .com right click, copy
 pentruea.com##+js(acs, document.oncontextmenu)
@@ -2384,22 +3372,12 @@ pentruea.com##+js(aeld, copy)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/54259
 sanspo.com##body:style(user-select: text !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; -o-user-select: text !important;)
 
-
-! https://github.com/NanoMeow/QuickReports/issues/3687
-t3.com##+js(aopr, _sp_.mms.startMsg)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/7291
 visaonoticias.com##+js(ra, oncontextmenu|onselectstart|ondragstart|onclick)
 visaonoticias.com##body:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/54544
-smokingmeatforums.com##+js(acs, $, btoa)
-
 ! https://github.com/AdguardTeam/AdguardFilters/issues/54357
 as-selection.net##+js(ra, oncontextmenu|onselectstart)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/54629
-servedez.com###realpop_optincontent
 
 ! https://github.com/NanoMeow/QuickReports/issues/3715
 avdelphi.com##+js(aeld, , _0x)
@@ -2408,9 +3386,6 @@ avdelphi.com##+js(nosiif, debugger)
 
 ! https://github.com/NanoMeow/QuickReports/issues/3567#issuecomment-622575179
 suzylu.co.uk##+js(aeld, contextmenu)
-
-! https://affiliate.fc2.com/ anti-adblock
-affiliate.fc2.com##+js(nostif, checkFeed, 1000)
 
 ! https://github.com/NanoMeow/QuickReports/issues/3744
 music.apple.com##+js(aeld, contextmenu)
@@ -2476,24 +3451,6 @@ dood.*,ds2play.com,ds2video.com,d0o0d.com##+js(aeld, contextmenu)
 ! https://github.com/uBlockOrigin/uAssets/issues/7344
 freerapidleechlist.blogspot.com##+js(acs, document.oncontextmenu)
 
-! https://github.com/NanoAdblocker/NanoFilters/issues/499
-duolingo.com##h2:has-text(Using an ad blocker?):upward(3)
-
-! thegatewaypundit .com anti adb warning
-thegatewaypundit.com##+js(aeld, , adtoniq)
-
-! https://github.com/uBlockOrigin/uAssets/issues/7359
-@@||9lives.be^$ghide
-
-! https://github.com/uBlockOrigin/uAssets/issues/7371
-jeu2048.fr##+js(aopw, FuckAdBlock)
-
-! https://github.com/uBlockOrigin/uAssets/issues/7363
-@@||holowczak.com^$ghide
-
-! https://github.com/uBlockOrigin/uAssets/issues/7373
-*$script,redirect-rule=noopjs,domain=luchaonline.com
-
 ! altranotizia .it anti select
 altranotizia.it##+js(acs, disableSelection)
 
@@ -2501,21 +3458,11 @@ altranotizia.it##+js(acs, disableSelection)
 livemint.com##.subscription .paywall:style(height: unset !important; overflow: unset !important;)
 livemint.com##.subscription .paywall .subscriptionBox
 
-! https://github.com/uBlockOrigin/uAssets/issues/7384
-taperaki.gr##.widget_et_ads
-
 ! https://sekai-kabuka.com/ right click
 sekai-kabuka.com##+js(ra, oncontextmenu)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7396
 yaledailynews.com##+js(acs, $, undefined)
-
-! https://github.com/NanoMeow/QuickReports/issues/3846
-4x4earth.com##+js(set, adBlockDetected, false)
-4x4earth.com##+js(nostif, samOverlay)
-
-! https://github.com/uBlockOrigin/uAssets/issues/3877
-endorfinese.com.br##+js(nostif, google_jobrunner)
 
 ! right click, select https://github.com/uBlockOrigin/uAssets/issues/7400
 enjoytaiwan.co.kr##+js(ra, oncontextmenu|onselectstart|ondragstart)
@@ -2538,9 +3485,6 @@ tercihiniyap.net##+js(ra, oncontextmenu|onselectstart|ondragstart)
 ! https://github.com/NanoMeow/QuickReports/issues/3866
 vsco.co##+js(aeld, contextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/issues/7417
-baby.be##.warning
-
 ! https://github.com/uBlockOrigin/uAssets/issues/7425
 ciberduvidas.iscte-iul.pt##+js(aeld, copy)
 
@@ -2554,29 +3498,11 @@ mangatoon.*##*:style(-webkit-touch-callout: default !important; -webkit-user-sel
 ! tistory.com anti-contextmenu/selection
 tistory.com##+js(aopw, document.oncontextmenu)
 
-! https://github.com/NanoMeow/QuickReports/issues/3894
-@@||receivesmsonline.net/ads.js$script,1p
-
-! https://www.reddit.com/r/uBlockOrigin/comments/gmtlci/adblocking_detected/
-||wetransfer.net/*/adblocker$3p,domain=wetransfer.com
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/55781
-stevensducks.com###sidearm-adblock-modal
-
 ! https://github.com/AdguardTeam/AdguardFilters/issues/55778
 ziperto.com##+js(nosiif, visibility, 1000)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/55846
-trojmiasto.pl##+js(aopr, adBlockDetected)
-
 ! https://github.com/NanoMeow/QuickReports/issues/3908
 digitaltrends.com##+js(aopr, HTMLIFrameElement)
-
-! https://github.com/NanoMeow/QuickReports/issues/3914
-diffchecker.com##+js(nostif, adStillHere)
-
-! anti adb annoyance
-sythe.org##:xpath('//*[contains(text(),"Adblock")]')
 
 ! https://github.com/NanoMeow/QuickReports/issues/3898
 start.me##.widget-page__banner
@@ -2608,12 +3534,6 @@ money-sense.club##+js(ra, oncontextmenu|onMouseDown|style)
 festival-cannes.com##+js(aeld, contextmenu)
 festival-cannes.com##*::selection:style(background-color:#338FFF!important)
 
-! https://github.com/NanoMeow/QuickReports/issues/3963
-moving2canada.com##.ad-blocker-notice
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/56323
-extreme-down.*##p > b:xpath('//*[contains(text(),"AdBlock")]')
-
 ! https://github.com/NanoMeow/QuickReports/issues/3969
 thegearhunt.com##+js(aeld, /^(?:contextmenu|copy|keydown|mousedown)$/)
 thegearhunt.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
@@ -2642,12 +3562,6 @@ photobank.mainichi.co.jp##+js(set, commonUtil.openToast, null)
 ! https://github.com/uBlockOrigin/uAssets/issues/7308 right click annoyance, anti devtools
 strcloud.in,streamtape.*##+js(aeld, contextmenu)
 strtape.*,streamtape.*##+js(rmnt, script, /parseInt.*push.*setTimeout.*try.*catch/)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/56652
-poedb.tw##+js(aopr, adBlockDetected)
-
-! https://github.com/NanoMeow/QuickReports/issues/3169
-malekal.com##+js(nostif, adb)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7506
 jfdb.jp##+js(aeld, /contextmenu|keydown/)
@@ -2680,17 +3594,11 @@ ufret.jp##+js(aeld, contextmenu)
 ufret.jp##+js(aopr, nd_shtml)
 ufret.jp##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/57099
-tabstats.com##.afill
-
 ! https://github.com/uBlockOrigin/uAssets/pull/7537
 seoul.cs.land.to##+js(ra, onselectstart)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/57185
 sharree.com##+js(acs, $, .height)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/57295
-motortrader.com.my##+js(aopr, canRunAds)
 
 ! https://github.com/NanoMeow/QuickReports/issues/4076
 aviationweek.com##.content-body-wrapper:style(opacity:1!important)
@@ -2719,15 +3627,6 @@ malasngeblog.com##.post-body:style(-webkit-touch-callout: default !important; -w
 relet365.com##+js(aopr, disable_copy)
 relet365.com##+js(aopw, document.ondragstart)
 relet365.com##.unselectable,html:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important; cursor: auto !important)
-
-! https://github.com/NanoMeow/QuickReports/issues/4161
-abola.pt##+js(acs, $, Adblock)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/57830
-unixhow.com##+js(acs, eval, isNaN)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/57962
-rottentomatoes.com##+js(set, mps._queue.abdetect, null)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7594
 reportergazeta.pl##+js(set, document.oncontextmenu, null)
@@ -2758,16 +3657,10 @@ edailybuzz.com##*::selection:style(background-color:#338FFF!important)
 ! https://github.com/uBlockOrigin/uAssets/issues/7602
 kanjukulive.com##+js(ra, ondragstart|oncontextmenu)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/58166
-betaprofiles.com##.adblock
-
 ! https://github.com/uBlockOrigin/uAssets/issues/7609
 wikibious.com##+js(aopr, disable_copy)
 wikibious.com##+js(aopw, document.oncontextmenu)
 wikibious.com##.unselectable,html:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/58292
-imgur.com##.Footer-whitelist
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7617
 ananweb.jp##+js(aeld, contextmenu)
@@ -2780,12 +3673,6 @@ marfilius.blogspot.com##*:style(-webkit-touch-callout: default !important; -webk
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7628
 2219.net##+js(aopr, clickNS)
-
-! thisisfutbol .com anti adb notice
-@@||thisisfutbol.com^$ghide
-thisisfutbol.com##.ad-billboard
-thisisfutbol.com##.c-header__advert
-thisisfutbol.com###snack_dex6
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7642
 odoserwis.pl##body *:style(-webkit-user-select: auto !important; -moz-user-select: auto !important; -ms-user-select: auto !important; user-select: auto !important;)
@@ -2819,12 +3706,6 @@ blasianluvforever.com##+js(aopr, disableSelection)
 gomovies-online.*##[href="/user/profile/premium-membership"]
 gomovies-online.*##.ico.close
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/59406
-nuggetroyale.io##.mainMenuAdBox
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/59414
-tileman.io##.adbanner:remove()
-
 ! https://github.com/uBlockOrigin/uAssets/issues/7674
 daimangajiten.com##+js(aeld, contextmenu)
 daimangajiten.com##*:style(-ms-user-select:auto !important; -moz-user-select:auto !important; -webkit-user-select:auto !important; -webkit-touch-callout:default !important; user-select:auto !important)
@@ -2847,39 +3728,14 @@ citas.in##+js(aeld, copy)
 ! radichubu.jp right click
 radichubu.jp##+js(ra, onContextMenu, body)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/59749
-sovetromantica.com##+js(set, fuckAdBlock, trueFunc)
-*$xhr,redirect-rule=nooptext,domain=sovetromantica.com
-
 ! https://github.com/NanoMeow/QuickReports/issues/4360
 scriptinghelpers.org##.shvertise-banner
 
 ! mbs.jp right click
 mbs.jp##+js(aopw, document.oncontextmenu)
 
-! https://github.com/NanoMeow/QuickReports/issues/4372
-polyflore.net##+js(nostif, adBlockDetected)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/59933
-nightpoint.io##+js(nofab)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/59974
-striketactics.net###unit_a_cont
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/59995
-chemz.io##.menu_ad1Box
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/60026
-*$xhr,redirect-rule=nooptext,domain=mazmorra.io
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/60037
-sketchful.io###moneySquare
-
 ! icy-veins .com premium proposal
 icy-veins.com##+js(nostif, premium)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/60100
-download.mokeedev.com##div.center-align
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/60106
 compartiendofull.net##+js(nosiif, visibility, 1000)
@@ -2894,24 +3750,6 @@ indiatimes.com##*::selection:style(background-color:#338FFF!important)
 
 ! railf.jp and https://spectank.jp/sl0060045.html right click
 railf.jp,spectank.jp##+js(ra, oncontextmenu|oncopy)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/60183
-liga.net##.modal-backdrop
-liga.net###addBlockModal
-liga.net##body:style(overflow:auto !important)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/60407
-getintopc.com##body > div[attr="[object Object]"]
-
-! https://github.com/NanoAdblocker/NanoFilters/issues/540
-longecity.org##+js(set, abp, false)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/60575
-brighteon.com##body:style(overflow:auto !important)
-brighteon.com##div.overlay, .bottom-banner
-
-! humanbenchmark .com warning anti adb
-*$script,3p,domain=humanbenchmark.com
 
 /wp-content/plugins/secure-copy-content-protection/*$script
 
@@ -2940,20 +3778,6 @@ digital.lasegunda.com##*:style(-webkit-touch-callout: default !important; -webki
 ! mhwg.org anti right click, anti select
 mhwg.org##+js(ra, oncontextmenu|onselectstart|style, #body_game)
 
-! https://github.com/NanoMeow/QuickReports/issues/4489
-cpuid.com##+js(nostif, blocked, 1000)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/61381
-ratebeer.com##[class^="AdBlockDetector"]
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/61521
-*$script,redirect-rule=noopjs,domain=atlasobscura.com
-atlasobscura.com##.js-subscription-ask-modal
-atlasobscura.com##body.modal-open:style(overflow:auto !important)
-
-! https://github.com/NanoMeow/QuickReports/issues/4511
-webcamtaxi.com##+js(nostif, blocker)
-
 ! https://hibiki-radio.jp/description/Afterglow/detail right click, text selection
 hibiki-radio.jp##+js(aeld, contextmenu)
 hibiki-radio.jp##body:style(-webkit-user-select:auto !important; -webkit-touch-callout: default !important;)
@@ -2962,23 +3786,11 @@ hibiki-radio.jp##body:style(-webkit-user-select:auto !important; -webkit-touch-c
 autophorie.de##+js(aopr, disableSelection)
 autophorie.de##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! abcya .com anti adb - warning
-*$script,domain=abcya.com,redirect-rule=noopjs
-
 ! articlesmania .me right click, select, copy
 ||articlesmania.me^$csp=script-src * 'unsafe-eval' 'unsafe-inline'
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7793
 englishlands.net##+js(aopw, document.oncontextmenu)
-
-! https://github.com/NanoMeow/QuickReports/issues/4545
-randomlists.com##.whine
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/61999
-good-football.org##+js(aopr, adBlockDetected)
-
-! https://github.com/NanoMeow/QuickReports/issues/4560
-beforeitsnews.com###top-alert
 
 ! https://github.com/NanoMeow/QuickReports/issues/4577
 elheraldo.hn##+js(aopw, addLink)
@@ -2998,11 +3810,6 @@ fruit01.xyz##+js(aopr, disableSelection)
 fruit01.xyz##+js(aopw, document.oncontextmenu)
 fruit01.xyz##+js(set, document.onkeydown, noopFunc)
 
-! https://github.com/uBlockOrigin/uAssets/issues/11242
-@@||dailyvoice.com^$ghide
-*$xhr,redirect-rule=nooptext,domain=dailyvoice.com
-dailyvoice.com###nativo_rightrail1
-
 ! https://github.com/NanoMeow/QuickReports/issues/4612
 clipartmax.com##+js(aopw, document.oncontextmenu)
 
@@ -3015,9 +3822,6 @@ zeeebatch.blogspot.com##*:style(-webkit-touch-callout: default !important; -webk
 
 ! techdracula .com anti select
 techdracula.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://forums.lanik.us/viewtopic.php?p=156522#p156522
-bluemoon-mcfc.co.uk##+js(nosiif, removeChild)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7907
 blitzrechner.de##+js(aeld, copy)
@@ -3034,9 +3838,6 @@ garyfeinbergphotography.com##+js(aeld, contextmenu)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/64220
 bonobono.com##+js(ra, oncontextmenu|ondragstart|onselectstart, body)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/64268
-routinehub.co###ethad
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/izwxv9/website_block_copying_text/
 darktranslation.com##+js(aopw, stopPrntScr)
 darktranslation.com##*::selection:style(background-color:#338FFF!important)
@@ -3051,12 +3852,6 @@ routenote.com##+js(acs, onload)
 upstream.to##+js(acs, document.oncontextmenu)
 upstream.to##+js(aopr, _0xfff1)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/64589
-webqc.org###toplink
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/64711
-ohmygirl.ml##+js(acs, event, stopPropagation)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/4007
 planetagibi.com.br,planetagibiblog.com.br##+js(aopw, document.oncontextmenu)
 planetagibi.com.br,planetagibiblog.com.br##+js(aopw, document.onselectstart)
@@ -3067,12 +3862,6 @@ lyricstranslate.com##+js(set, getSelection, undefined)
 ! https://github.com/uBlockOrigin/uAssets/issues/7997
 trakteer.id##+js(aeld, /contextmenu|mousedown/)
 trakteer.id##article.post:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/65000
-telefon-treff.de##+js(acs, $, offsetHeight)
-
-! dodge-forum anti-adb
-dodge-forum.eu##+js(acs, $, offsetHeight)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7999
 megapixl.com##+js(nostif, .modal, 1000)
@@ -3110,40 +3899,14 @@ fandomwire.com##html:style(overflow:auto !important)
 ! https://github.com/uBlockOrigin/uAssets/issues/8037
 observatoriodocinema.uol.com.br##+js(acs, document.addEventListener, preventDefault)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/80714
-@@||samfw.com^$ghide
-samfw.com##.adsbygoogle
-||samfw.com/assets/*.gif$image
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/65693
-segnidalcielo.it##+js(nostif, google_jobrunner)
-
-! fangraphs.com anti adb annoyance
-@@||fangraphs.com/dfp.js$script,1p
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/65879
-fosspost.org##+js(nostif, an_message, 500)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/8054
 igniel.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/66004
-hentaialtadefinizione.it##+js(aopw, onload)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8069
 lyrical-nonsense.com##+js(aeld, copy)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8072
 alltechnerd.com##+js(aopw, document.oncontextmenu)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/66378
-moneyguru.co##+js(acs, $, .height)
-
-! https://www.reddit.com/r/uBlockOrigin/comments/ji8yhy/citynewsca_anti_adblock/
-||rogersmedia.com/utilityx.js^$script,3p
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/66440
-mapgenie.io##.mt-1.mb-1.text-center
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8092
 *$script,redirect-rule=noopjs,domain=exame.com
@@ -3152,15 +3915,9 @@ mapgenie.io##.mt-1.mb-1.text-center
 clubulbebelusilor.ro##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 clubulbebelusilor.ro##+js(aeld, contextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/issues/8111
-||googlesyndication.com/pagead/js/adsbygoogle.js$script,redirect=googlesyndication_adsbygoogle.js,domain=colnect.com
-
 ! https://github.com/uBlockOrigin/uAssets/issues/8130
 generationamiga.com##+js(aopr, disable_copy)
 generationamiga.com##+js(aopw, document.oncontextmenu)
-
-! https://github.com/uBlockOrigin/uAssets/issues/8136
-nwherald.com##+js(aopr, HTMLIFrameElement)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8140
 gridcoinstats.eu##[href="/about#support"]:upward(2)
@@ -3193,17 +3950,8 @@ nytimes.com##body.ReactModal__Body--open:style(position: unset !important; overf
 ! fix poplinks.idolmaster-official.jp anti-right click and anti-select
 poplinks.idolmaster-official.jp##+js(ra, oncontextmenu|onselectstart|onmousedown, body)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/67621
-progameguides.com##+js(aopr, admrlWpJsonP)
-
-! https://www.reddit.com/r/uBlockOrigin/comments/jurv15/httpswwwztzacom_detect_ublock_using_ztprotect/
-zt-protect.*##main.py-4 > p
-
 ! https://github.com/uBlockOrigin/uAssets/issues/8227
 jpnn.com##+js(aopr, document.oncopy)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/67845
-jimnong.tistory.com##.adblock-on
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8238
 daum.net##+js(acs, document.oncontextmenu)
@@ -3226,9 +3974,6 @@ loginhit.com.ng###ays_tooltip
 123movies.*##+js(nostif, _0x)
 123movies.*##+js(set, console.clear, noopFunc)
 
-! json2csharp.com anti-adb
-*$script,redirect-rule=noopjs,domain=json2csharp.com
-
 ! https://github.com/uBlockOrigin/uAssets/issues/8254
 diariodaregiao.com.br##body:style(-moz-user-select:text !important;-ms-user-select:text !important;user-select:text !important;)
 
@@ -3241,9 +3986,6 @@ szkolawohyn.pl##+js(set, document.oncontextmenu, noopFunc)
 ! newsforbolly .org anti right click, anti ctrl u, f12
 newsforbolly.org##+js(acs, document.oncontextmenu)
 newsforbolly.org##+js(ra, onkeydown)
-
-! nextplatform.com anti adb
-nextplatform.com###adtoniq-msgr-bar
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8284
 giromarilia.com.br##+js(ra, oncontextmenu|ondragstart|onselectstart)
@@ -3283,23 +4025,12 @@ ping.eu##center[style="margin-bottom: 2px;"]
 ! https://old.reddit.com/r/uBlockOrigin/comments/kaczfx/how_do_i_disable_css_that_disables_right_click/
 safetxt.net##+js(acs, $, contextmenu)
 
-! 1fichier.com adblock message and modal
-1fichier.com##.ct_warn:has-text(adblock)
-1fichier.com##.ui-dialog[aria-describedby="modal-msg"]:has(a[href$="/console/abo.pl"][style^="text-decoration:underline"])
-1fichier.com##.ui-widget-overlay
-
-! https://github.com/uBlockOrigin/uAssets/issues/8347#issuecomment-744394924
-forum.release-apk.com##.has-profile.post:first-child:has-text(/adblock/i)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/8374
 sokolow-mlp.pl##+js(acs, document.onmousedown)
 
 ! https://github.com/uBlockOrigin/uAssets/pull/3415
 blog.naver.com##+js(aeld, /contextmenu|selectstart|copy/)
 blog.naver.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/70398
-bendigoadvertiser.com.au##+js(nosiif, modal)
 
 ! fatgirlskinny.net overlay annoyance
 fatgirlskinny.net##.pum
@@ -3322,9 +4053,6 @@ raqmedia.com##body:style(-webkit-touch-callout: default !important; -webkit-user
 69translations.blogspot.com##+js(aopr, document.onselectstart)
 69translations.blogspot.com##+js(aopr, document.onmousedown)
 69translations.blogspot.com##+js(aopr, document.onclick)
-
-! 2iptv .com warning anti adb
-2iptv.com##+js(nostif, google_jobrunner)
 
 ! anti ctrl-u my-code4you.blogspot .com
 my-code4you.blogspot.com##+js(aopr, document.onkeydown)
@@ -3381,10 +4109,6 @@ fraudnavi.com##body:style(-moz-user-select: auto !important;-ms-user-select: aut
 javbest.xyz,javbix.com,javgrab.com##+js(acs, $, contextmenu)
 ||googleapis.com/loadermain.appspot.com/main.js$domain=javboys.com
 
-! https://www.reddit.com/r/uBlockOrigin/comments/ktkw6p/proboards_based_forums_deploying_antiadblock/
-||ads.proboards.com^$script,redirect=noopjs
-||bidfilter.com^$script,redirect=noopjs
-
 ! funivie .org anti right click / select
 funivie.org##+js(acs, document.oncontextmenu)
 funivie.org##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
@@ -3433,9 +4157,6 @@ ifdreamscametrue.com##+js(aopr, disableSelection)
 ! irisbuddies. ml anti select
 irisbuddies.*##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! Anti-adb keybr.com
-keybr.com##.Placeholder
-
 ! kijyomatome-ch.com anti right-click, select
 kijyomatome-ch.com##+js(ra, oncontextmenu|onselectstart, body)
 kijyomatome-ch.com##body:style(user-select:auto !important;-webkit-user-select:auto !important;-ms-user-select:auto !important;-moz-user-select:auto !important;-webkit-user-drag:auto !important)
@@ -3446,9 +4167,6 @@ juegosdetiempolibre.org##+js(aopr, disableSelection)
 
 ! kutub3lpdf .com anti right click, select, copy
 kutub3lpdf.com##+js(aeld, /contextmenu|copy|selectstart/)
-
-! https://forums.lanik.us/viewtopic.php?f=62&t=38298
-kitguru.net##+js(acs, addEventListener, adsbygoogle.length)
 
 ! la8osapofash .com visible text selection
 la8osapofash.com##*::selection:style(background-color:#338FFF!important)
@@ -3478,17 +4196,6 @@ lvturbo.com,sbbrisk.com,sbface.com,sbspeed.com,streamsb.net##+js(acs, check, deb
 lvturbo.com,sbbrisk.com,sbface.com,sbspeed.com,streamsb.net##+js(nosiif, _0x)
 ! https://sbasian.pro/d/ksnf8h4wn05p.html anti devtools
 sbasian.pro##+js(set, console.clear, noopFunc)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/72222
-! https://github.com/AdguardTeam/AdguardFilters/issues/72225
-! https://github.com/AdguardTeam/AdguardFilters/issues/72227
-! https://github.com/AdguardTeam/AdguardFilters/issues/72228
-! https://github.com/AdguardTeam/AdguardFilters/issues/72229
-2hbn.com,bilgisentezi.com,farklifarkli.com,readingclock.com##.adace-popup
-bilgisentezi.com##.adace-slideup-slot-wrap
-
-! https://www.reddit.com/r/uBlockOrigin/comments/kzrus8/adblock_detected/
-*$script,redirect-rule=noopjs,domain=mail.inbox.lv
 
 ! naijagists .com anti select
 naijagists.com##+js(aopr, disableSelection)
@@ -3610,12 +4317,6 @@ erexams.com##*:style(-webkit-touch-callout: default !important; -webkit-user-sel
 ! deportealdia.live anti right click; ref. https://github.com/AdguardTeam/AdguardFilters/issues/74115
 deportealdia.live##+js(acs, document.oncontextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/issues/8554
-htmlgames.com##.banner
-
-! https://github.com/uBlockOrigin/uAssets/issues/8551
-pbinfo.ro##.text-warning
-
 ! https://github.com/uBlockOrigin/uAssets/issues/8555
 ||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js^$script,redirect=googlesyndication_adsbygoogle.js,domain=hotcleaner.com
 hotcleaner.com##.adsbygoogle:upward(1):remove()
@@ -3625,14 +4326,8 @@ hotcleaner.com##body > div[id]:matches-css(position: fixed):style(visibility: hi
 vedantu.com##+js(aeld, contextmenu, preventDefault)
 vedantu.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! https://github.com/uBlockOrigin/uAssets/issues/8560
-||gmod-servers.com/assets/js/jquery.adblock-detector.js$script,1p
-
 ! https://github.com/uBlockOrigin/uAssets/issues/8575
 pcso-lottoresults.com##+js(aopr, document.oncontextmenu)
-
-! https://github.com/uBlockOrigin/uAssets/issues/8578
-@@||freedomoutpost.com^$ghide
 
 ! asiatv. online anti right click
 asiatv.*##+js(aeld, contextmenu)
@@ -3646,9 +4341,6 @@ fmovies.*##style:has-text(@media print):remove()
 
 ! japan-fans.com right click
 japan-fans.com##+js(acs, document.onmousedown)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/82216
-lcpdfr.com##+js(acs, $, AdBlock)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8624
 comprerural.com##+js(aopr, append_link)
@@ -3664,9 +4356,6 @@ stowarzyszenie-impuls.eu##+js(aeld, contextmenu)
 iovivoatenerife.it##+js(aopr, document.oncontextmenu)
 iovivoatenerife.it##+js(aopr, disableSelection)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/76660
-whatfontis.com##+js(acs, $, adBlock)
-
 ! viveretenerife. com anti right click
 viveretenerife.com##+js(aeld, contextmenu)
 
@@ -3681,9 +4370,6 @@ kangmartho.com##+js(acs, document.onselectstart)
 
 ! https://forums.lanik.us/viewtopic.php?f=62&t=45843&p=158994#p158994
 techjunkie.com##+js(aeld, mouseout)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/77079
-solotrend.net##+js(aopw, ai_front)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/m26n32/site_with_a_few_popups_blocks_ability_to_use_dev/
 goalup.live##+js(acs, $, contextmenu)
@@ -3711,25 +4397,15 @@ oferty.dsautomobiles.pl##+js(aeld, contextmenu)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/77375
 gats.io##+js(ra, oncontextmenu, body)
 
-! scrolller.com anti-adb
-scrolller.com##.notification[style^="height: 189px;"]
-
 ! cambiarevita. eu anti select
 cambiarevita.eu##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8723
 wzamrani.com##+js(aeld, contextmenu)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/77665
-xtv.cz##+js(nostif, pgblck)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/8734
 otakudesu.*##+js(acs, document.oncontextmenu)
 otakudesu.*##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://www.reddit.com/r/uBlockOrigin/comments/ofstkl/adblock_warning_on_puhekuplacom/
-puhekupla.com#@#.googlead
-*$xhr,redirect-rule=nooptext,domain=puhekupla.com
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8739
 promotor.pl##+js(ra, oncontextmenu, body)
@@ -3759,12 +4435,6 @@ tritinia.com##+js(aopr, document.oncontextmenu)
 tritinia.com##+js(aopr, disable_copy)
 tritinia.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! https://github.com/DandelionSprout/adfilt/issues/63#issuecomment-812837952
-fakechatapp.com##.banner
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/79472
-toonytool.com##.banner
-
 ! https://github.com/uBlockOrigin/uAssets/issues/8856
 enttechub.com##body:style(-webkit-touch-callout: default !important; -khtml-user-select: text !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
@@ -3785,14 +4455,6 @@ geotips.net##:not(input):not(textarea),img:style(-webkit-touch-callout: default 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/80026
 korona.co.jp##+js(ra, oncopy|oncontextmenu, body)
 
-! https://github.com/uBlockOrigin/uAssets/issues/8866
-!#if !env_firefox
-gmx.net##+js(set, document.documentElement.AdBlockDetection, noopFunc)
-!#endif
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/80139
-theblaze.com##+js(aopw, admrlWpJsonP)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/8870
 promotor-poz.kylos.pl##+js(ra, oncontextmenu)
 
@@ -3803,26 +4465,10 @@ novelism.jp##.select-none:style(-webkit-touch-callout: default !important; -webk
 ! https://www.reddit.com/r/uBlockOrigin/comments/mqovyt
 bemoneyaware.com##html:style(overflow: auto !important)
 
-! https://github.com/uBlockOrigin/uAssets/issues/8878
-||cm.g.doubleclick.net/pixel$image,redirect=1x1.gif,domain=tpc.googlesyndication.com
-||tpc.googlesyndication.com/pagead/images/x_button_blue2.svg$image,redirect=1x1.gif,domain=tpc.googlesyndication.com
-||cm.g.doubleclick.net/pixel$image,redirect=1x1.gif,domain=diep.io
-||tpc.googlesyndication.com/pagead/images/x_button_blue2.svg$image,redirect=1x1.gif,domain=diep.io
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/80501
-||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js^$redirect=googlesyndication_adsbygoogle.js,script,domain=mifirm.net
-
 ! gnt24365.net anti right click, select
 gnt24365.net##+js(acs, document.oncontextmenu)
 gnt24365.net##+js(acs, document.onselectstart)
 gnt24365.net##*:style(-webkit-touch-callout: default!important;-webkit-user-select: auto!important;-moz-user-select: auto!important;user-select: auto!important;)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/80660
-cssreference.io##^script:has-text(window.carbonLoaded)
-!#if !cap_html_filtering
-cssreference.io##+js(aopr, carbonLoaded)
-!#endif
-cssreference.io##.placeholder
 
 ! https://github.com/uBlockOrigin/uAssets/issues/8912
 zsti.zsti.civ.pl##+js(aeld, contextmenu, preventDefault)
@@ -3845,9 +4491,6 @@ truyenbanquyen.com##*:style(-webkit-touch-callout: default!important; -webkit-us
 globaledu.jp##+js(acs, document.oncontextmenu)
 globaledu.jp##+js(ra, oncontextmenu|onselectstart, body)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/81105
-imagecolorpicker.com#@#div[id^="ezoic-pub-ad-"]
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/mxqj6h/aeldjs_not_enough_for_piratelawyer_blocking/
 torrentlawyer.com##+js(set, document.oncontextmenu, noopFunc)
 torrentlawyer.com##+js(set, document.ondragstart, noopFunc)
@@ -3856,12 +4499,6 @@ torrentlawyer.com##+js(set, document.onselectstart, noopFunc)
 
 ! gsmfirmware. net anti select
 gsmfirmware.net##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/8968
-revistavanityfair.es##+js(aopr, initAdBlockerPanel)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/81778
-spielspiele.de##.is-blocked
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/81867
 charbelnemnom.com##+js(aeld, /contextmenu|keydown/)
@@ -3904,16 +4541,6 @@ hitproversion.com##style:has-text(user-select:):remove()
 ! https://github.com/AdguardTeam/AdguardFilters/issues/83556
 news.dwango.jp##+js(ra, oncontextmenu, body)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/83712
-lowkeytech.com##+js(acs, String.prototype.charCodeAt, ai_)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/83664
-@@||dmax.de^$ghide
-
-! https://github.com/uBlockOrigin/uAssets/issues/9146#issuecomment-846390986
-techsini.com##+js(acs, jQuery, preventDefault)
-techsini.com##style:has-text(user-select:):remove()
-
 ! https://github.com/uBlockOrigin/uAssets/issues/9159
 olarila.com##+js(nostif, offsetHeight)
 
@@ -3939,9 +4566,6 @@ japanxxxmovie.com,sexpox.com##+js(acs, $, contextmenu)
 ! https://github.com/uBlockOrigin/uAssets/issues/9204
 antena3.com,lasexta.com##+js(aeld, contextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/issues/9208
-nbcsports.com##+js(aopw, admrlWpJsonP)
-
 ! https://github.com/AdguardTeam/AdguardFilters/issues/84060
 pashplus.jp##+js(aeld, contextmenu)
 
@@ -3953,18 +4577,6 @@ upvideo.to##+js(aeld, contextmenu)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/9291
 kpopsea.com##+js(aeld, contextmenu)
-
-! katholisches. info warning popup
-katholisches.info##+js(nostif, pop)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/84616
-ubuntudde.com##+js(acs, String.prototype.charCodeAt, ai_)
-
-! https://github.com/uBlockOrigin/uAssets/issues/9339
-streaminglearningcenter.com##+js(nostif, ads)
-
-! https://github.com/uBlockOrigin/uAssets/issues/10422
-prepostseo.com##+js(nostif, 'head')
 
 ! youmath. it anti select
 youmath.it##+js(aopw, document.onmousedown)
@@ -3993,9 +4605,6 @@ lazytranslations.com##style:has-text(unselectable):remove()
 starbene.it##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 starbene.it##+js(acs, document.oncontextmenu)
 starbene.it##+js(aeld, /copy|contextmenu/)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/85982
-||belezaedieta.com^
 
 ! https://github.com/uBlockOrigin/uAssets/issues/9435
 operatorsekolahdbn.com##+js(aopr, document.onselectstart)
@@ -4027,10 +4636,6 @@ onlinecoursebay.com##+js(aeld, , mdp)
 utorrentgamesps2.blogspot.com##+js(acs, document.onkeydown)
 utorrentgamesps2.blogspot.com##+js(ra, onselectstart)
 
-! sonnenverlauf/suncalc anti-adb
-sonnenverlauf.de,suncalc.org###adsGross1
-sonnenverlauf.de,suncalc.org###adsKlein
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/o6d0vs/how_to_stop_websites_from_detecting_ublock/
 themosvagas.com.br##+js(acs, addEventListener, keydown)
 themosvagas.com.br##+js(acs, onload)
@@ -4039,9 +4644,6 @@ themosvagas.com.br##style:has-text(user-select:):remove()
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/o7bhur/problem_ubo_detected_on_fauxid/
 fauxid.com##+js(aeld, error)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/57758
-audiostereo.pl##+js(nostif, adb)
 
 ! tvstreampf. xyz anti right click / select / drag
 tvstreampf.xyz##+js(acs, document.ondragstart)
@@ -4058,9 +4660,6 @@ articlesmania.me##+js(acs, document.onkeydown)
 jobskaro.com##+js(aopr, disableEnterKey)
 jobskaro.com##+js(aopw, document.ondragstart)
 
-! https://www.reddit.com/r/uBlockOrigin/comments/o8wr0g/antiadblock_ygoprodeckcom/
-*$image,redirect-rule=1x1.gif,domain=ygoprodeck.com
-
 ! readm. org anti select
 readm.org##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
@@ -4069,9 +4668,6 @@ androidtvbox.eu##+js(aeld, dragstart)
 androidtvbox.eu##+js(aopr, nocontextmenu)
 androidtvbox.eu##+js(acs, document.ondragstart)
 androidtvbox.eu##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/2060
-nicematin.com##+js(aeld, , AdB)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/9477
 myhtebooks.com##+js(ra, oncontextmenu|ondragstart|onselectstart|onselect|oncopy|onbeforecopy|onkeydown|onunload)
@@ -4091,8 +4687,6 @@ urbharat.xyz##+js(set, document.onkeydown, null)
 bilibili.com##+js(aeld, selectionchange, quill.emitter)
 ! https://github.com/uBlockOrigin/uAssets/issues/23209
 bilibili.com##+js(aeld, copy)
-! https://github.com/uBlockOrigin/uAssets/issues/23699
-bilibili.com##.adblock-tips
 
 ! https://github.com/uBlockOrigin/uAssets/issues/9503
 sogou.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
@@ -4133,9 +4727,6 @@ yamibo.com##*:style(-webkit-touch-callout: default !important; -webkit-user-sele
 
 ! quicasting. it anti right click / select
 ||quicasting.it^$csp=script-src * 'unsafe-inline'
-
-! https://github.com/uBlockOrigin/uAssets/issues/9583
-fimfiction.net##+js(aeld, load, adLazy)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/9584
 totemat.pl##+js(aopr, disableSelection)
@@ -4233,9 +4824,6 @@ apk1s.com##style:has-text(user-select):remove()
 peekme.cc##+js(aeld, selectstart)
 peekme.cc##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! https://github.com/uBlockOrigin/uAssets/issues/9666
-tiermaker.com##+js(nostif, &adslot)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/9683
 dushu.qq.com##+js(aopr, document.oncontextmenu)
 dushu.qq.com##+js(aopr, document.oncopy)
@@ -4327,10 +4915,6 @@ logonews.cn##+js(set, document.oncopy, null)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/87250
 spanishdict.com##main > div[class*="-"] > div[class^="_"] > div[class^="_"] > div[class]:has(> div[class^="_"]:has-text(Do your part to support us))
-! https://github.com/uBlockOrigin/uAssets/issues/9783
-spanishdict.com##+js(set, SD_BLOCKTHROUGH, true)
-spanishdict.com###removeAdsSidebar
-spanishdict.com##.ad-wrapper, #adTopLarge, [id^="adSide"], [id^="adMiddle"]
 ! https://github.com/uBlockOrigin/uAssets/issues/18341
 spanishdict.com##.ReactModal__Overlay--after-open:has(iframe[srcdoc], img):has-text(signing up)
 ! https://github.com/uBlockOrigin/uAssets/issues/18342
@@ -4339,35 +4923,8 @@ spanishdict.com##.ReactModal__Overlay--after-open:has-text(/Premium|Try 7 days/)
 ! https://github.com/uBlockOrigin/uAssets/issues/5964#issuecomment-902058918
 rule34hentai.net##+js(aeld, contextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/issues/9828
-dez.ro#@#.ad-placement
-
 ! https://github.com/uBlockOrigin/uAssets/issues/9155#issuecomment-903867770
 cloudemb.com##+js(aeld, contextmenu)
-
-! bwitter.me anti-adb
-bwitter.me###side > ins.adsbygoogle:upward(1)
-
-! https://github.com/uBlockOrigin/uBlock-issues/issues/1700
-windguru.net###warning-content
-
-! https://github.com/uBlockOrigin/uAssets/issues/9872
-thinkamericana.com##+js(nosiif, offsetHeight)
-
-! https://github.com/uBlockOrigin/uAssets/issues/9874
-menrec.com##+js(nosiif, offsetHeight)
-
-! https://github.com/uBlockOrigin/uAssets/issues/9878
-hendersonville.com##.adblock-detected
-
-! https://github.com/uBlockOrigin/uAssets/issues/9895
-*$image,redirect-rule=1x1.gif,domain=guardian.gg
-
-! https://github.com/uBlockOrigin/uAssets/pull/9925
-! https://github.com/uBlockOrigin/uAssets/issues/13297
-outlook.live.com##div[class][tabindex="-1"][role=region][aria-label][data-min-width][data-max-width] ~ div[class][data-max-width="2400"] + div[class]
-outlook.live.com###MainModule + div[class] > div[style^="width"] > div > i[data-icon-name="OutlookLogo"]:upward(3)
-outlook.live.com###MainModule div[data-max-width="2400"] + div[class]
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/pjhnuc/site_crippling_basic_browser_functions/
 naaree.com##+js(aopw, disableEnterKey)
@@ -4407,9 +4964,6 @@ revouninstaller.com##body.modal-open:style(overflow: auto !important; padding-ri
 news24.jp##+js(aeld, contextmenu)
 news24.jp##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! https://github.com/uBlockOrigin/uAssets/pull/10037
-ptable.com##.Notice
-
 ! https://github.com/uBlockOrigin/uAssets/issues/10038
 blog.csdn.net##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 blog.csdn.net##.hljs-button.signin
@@ -4439,9 +4993,6 @@ whowantstuffs.blogspot.com##*:style(-webkit-touch-callout: default !important; -
 ! https://github.com/uBlockOrigin/uAssets/pull/10110
 ihbarweb.org.tr##+js(aeld, /^(?:copy|paste)$/, undefined)
 
-! https://www.reddit.com/r/uBlockOrigin/comments/q31fnc/mocahorg_adblocker_detection/
-mocah.org##+js(nosiif, adsbygoogle)
-
 ! unikampus.net anti select anti right-click
 unikampus.net##+js(aopr, document.oncontextmenu)
 unikampus.net##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
@@ -4456,31 +5007,18 @@ aksensei.com##+js(acs, document.onkeydown)
 ! https://github.com/uBlockOrigin/uAssets/issues/10187
 tekstowo.pl##+js(aopw, addLink)
 
-! https://github.com/uBlockOrigin/uAssets/issues/10200
-*$script,redirect-rule=noopjs,domain=inbox.lv|inbox.la
-
 ! https://github.com/uBlockOrigin/uAssets/issues/10202
 arti-definisi-pengertian.info##+js(set, document.oncontextmenu, null)
 arti-definisi-pengertian.info##+js(aopw, document.onselectstart)
 arti-definisi-pengertian.info##+js(aopw, document.ondragstart)
 arti-definisi-pengertian.info###ouibounce-modal
 
-! https://github.com/uBlockOrigin/uAssets/issues/10224
-techtobo.com##.js-notices
-
 ! libertatea. ro clipboard manipulation
 libertatea.ro##+js(aeld, copy)
-
-! https://github.com/uBlockOrigin/uAssets/issues/10226
-shopomo.co.uk##+js(nostif, ai_)
-c4ddownload.com,the-scorpions.com##+js(aopr, b2a)
 
 ! baixedetudo.net. br anti right click / copy / ctrl U / F12 
 baixedetudo.net.br##+js(aopw, document.oncontextmenu)
 baixedetudo.net.br##+js(aeld, /copy|keydown/)
-
-! https://github.com/uBlockOrigin/uAssets/issues/10233
-epn.bz##+js(set, ab, false)
 
 ! erinsakura. com anti copy
 erinsakura.com##+js(aeld, copy)
@@ -4488,23 +5026,11 @@ erinsakura.com##+js(aeld, copy)
 ! https://github.com/uBlockOrigin/uAssets/issues/10240
 njjzxl.net##+js(aeld, contextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/issues/10252
-affbank.com##+js(set, canRunAds, true)
-
-! https://www.reddit.com/r/uBlockOrigin/comments/qbcvtc/nbc_sports_anti_ad_block_workaround/
-nbcsportsedge.com##+js(aopw, admrlWpJsonP)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/10273
 gardenia.net##+js(ra, oncopy|oncut|onselectstart|style|unselectable, body, stay)
 gardenia.net##+js(set, document.body.oncut, null)
 gardenia.net##+js(set, document.body.oncopy, null)
 gardenia.net##+js(aeld, /copy|cut|selectstart/)
-
-! https://github.com/uBlockOrigin/uAssets/commit/e6d649c38a8e
-||piano.io^$domain=fastcompany.com
-
-! https://github.com/uBlockOrigin/uAssets/issues/10295
-_google_ads.$badfilter
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10319
 oploverz.*##+js(aopw, check)
@@ -4517,10 +5043,6 @@ elahmad.com##*:style(-webkit-touch-callout: default !important; -webkit-user-sel
 adpres.ro##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 adpres.ro##+js(aopw, stopPrntScr)
 
-! https://www.reddit.com/r/uBlockOrigin/comments/qkf91l/timeanddatecom/
-@@||timeanddate.com^$ghide
-timeanddate.com###ad300
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/qo0a54/adblock_detected/
 racevpn.com##+js(aopw, document.onkeydown)
 
@@ -4530,10 +5052,6 @@ messitv.net##.sharepost
 ! playpilot. com hbomax annoyance
 playpilot.com##.takeover.modals
 playpilot.com##body:style(overflow: auto !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/10458
-buondua.com##.noblock-modal
-buondua.com##body.tingle-enabled:style(position: static!important;overflow: auto!important;)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10470
 c315.cn##+js(ra, oncontextmenu|onselectstart|oncut|oncopy)
@@ -4590,9 +5108,6 @@ ibomma.pw##+js(acs, $, contextmenu)
 ! scrolller. com anti right click
 scrolller.com##+js(aeld, contextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/issues/10781
-@@||coinpayu.com^$ghide
-
 ! hollywoodmask. com anti select copy newsletter
 hollywoodmask.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 hollywoodmask.com##+js(aeld, /copy|cut|paste|selectstart/)
@@ -4608,9 +5123,6 @@ cafago.com##*:style(-webkit-touch-callout: default !important; -webkit-user-sele
 ! https://github.com/uBlockOrigin/uAssets/issues/10951
 tvzingvn.*,zingtvhd.*,zingvntv.*##+js(acs, onload, contextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/pull/10979
-||4399.com/antijs/Antiindulgence.js
-
 ! https://github.com/uBlockOrigin/uAssets/pull/10987
 mbalib.com##+js(aeld, /copy|cut|paste|selectstart/)
 
@@ -4621,18 +5133,11 @@ zgywyd.cn##+js(acs, document.oncontextmenu)
 wenku.baidu.com##+js(aeld, /contextmenu|dragstart|keydown/, event.dispatch.apply)
 ||hm.baidu.com/hm.js
 
-! https://github.com/uBlockOrigin/uAssets/issues/10976
-dhd24.com#@#.adunit  
-
 ! https://github.com/uBlockOrigin/uAssets/issues/10982
 ||jianbiaoku.com/content/js/copyFun.js$script,1p
 
 ! https://github.com/uBlockOrigin/uAssets/issues/10984
 yuque.com##+js(aeld, copy)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/103536
-otomobilgunluklerim.com##.adblockalert
-otomobilgunluklerim.com##.ad_block_detected:style(overflow: auto !important;)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11017
 picallow.com##+js(acs, document.oncontextmenu, nocontextmenu)
@@ -4652,12 +5157,6 @@ psihologiadeazi.ro##+js(aopr, disable_copy)
 psihologiadeazi.ro##+js(acs, jQuery, keydown)
 psihologiadeazi.ro##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! https://github.com/uBlockOrigin/uAssets/issues/11129
-ssuathletics.com##+js(acs, document.querySelector, adblock)
-
-! https://github.com/cjx82630/cjxlist/commit/6529adc701822ea1467b9e5a38ad823d27cc1d1e
-52bdys.com##+js(aopr, onload)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/11140
 cocomanga.com##+js(aeld, contextmenu)
 
@@ -4670,12 +5169,6 @@ brownsboys.com##+js(aopr, document.onselectstart)
 ! https://www.reddit.com/r/uBlockOrigin/comments/ru5yks/disabling_an_unnamed_javascript_that_disables/
 mercenaryenrollment.com##+js(acs, document.oncontextmenu)
 mercenaryenrollment.com##style:has-text(user-select):remove()
-
-! geektyper.com anti-adb
-geektyper.com###itemz[style^="position:fixed; top:10px"]
-
-! https://github.com/uBlockOrigin/uAssets/issues/11195
-fotofilter.de##.banner
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11245
 social-unlock.com##form#link a.submit:style(opacity: 1 !important; pointer-events: auto !important;)
@@ -4693,9 +5186,6 @@ nusantararom.org##.elementor-popup-modal
 ! https://github.com/uBlockOrigin/uAssets/issues/11326
 ! https://github.com/uBlockOrigin/uAssets/issues/5288#issuecomment-1097447454
 ! elpais.com##+js(nostif, run)
-
-! https://github.com/uBlockOrigin/uAssets/issues/11330
-mail.tm##:xpath('//*[contains(text(),"blocker")]')
 
 ! wawlist. com anti right click, select, ctrl,f-keys
 wawlist.com##+js(acs, document.oncontextmenu)
@@ -4737,17 +5227,10 @@ cintateknologi.com##*:style(-webkit-touch-callout: default !important; -webkit-u
 trucksbook.eu##.modal-backdrop
 trucksbook.eu##body:style(overflow: initial !important)
 
-! https://github.com/BottledSoda/RoWebImprover/issues/7
-@@||curs-valutar-bnr.ro^$ghide
-curs-valutar-bnr.ro##.adsbygoogle:style(max-height: 1px !important;left:-9999px !important;position:absolute !important)
-
 ! atlas-geografic. net anti right click - select - f-keys
 atlas-geografic.net##+js(aopr, document.oncontextmenu)
 atlas-geografic.net##+js(aopw, disableEnterKey)
 atlas-geografic.net##+js(aopw, document.ondragstart)
-
-! https://github.com/uBlockOrigin/uAssets/issues/11517
-funnygames.*##.is-blocked
 
 ! farm-ro.desigusxpro. com clipboard manipulation
 farm-ro.desigusxpro.com##+js(aopr, document.oncopy)
@@ -4761,12 +5244,6 @@ linkmate.xyz##+js(aeld, , key)
 ! yhocdata. com f-keys copy select 
 yhocdata.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 yhocdata.com##+js(aopr, contentprotector)
-
-! https://github.com/uBlockOrigin/uAssets/issues/11615
-||thresholdforum.s3.us-east-2.amazonaws.com/arn:aws:s3:::thresholdforum/javascript_adblockdetector/$script
-
-! https://www.reddit.com/r/uBlockOrigin/comments/sla82r/how_to_fix_blurring_on_this_website/
-meteoblue.com##+js(set, mb.advertisingShouldBeEnabled, false)
 
 ! cristelageorgescu. ro anti right click, select, copy, f-key 
 cristelageorgescu.ro##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
@@ -4785,27 +5262,11 @@ investorvillage.com##+js(acs, update_visit_count)
 ! https://github.com/uBlockOrigin/uAssets/issues/11698
 crunchyscan.fr##+js(acs, document.oncontextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/issues/3068
-pornhub.*##+js(rc, hasAdAlert, header)
-pornhub.*###js-abContainterMain
-
-! https://github.com/uBlockOrigin/uAssets/issues/11762
-grandoldteam.com##+js(acs, $, test)
-
-! https://github.com/uBlockOrigin/uAssets/issues/11775
-gamingsinners.com##+js(acs, $, test)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/11788
 bike-parts-sym.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! eshentai. tv warning
-eshentai.tv##.aviso
-
 ! vumoo.vip devtools
 ||vumoo.vip/js/safe.ob.min.js
-
-! https://github.com/uBlockOrigin/uAssets/issues/11815
-pushsquare.com##+js(aopr, _sp_._networkListenerData)
 
 ! pobre. tv anti right click, f-keys
 pobre.tv##+js(aeld, contextmenu)
@@ -4815,10 +5276,6 @@ pobre.tv##+js(aeld, , keyCode)
 www-daftarharga.blogspot.com##+js(acs, document.oncontextmenu)
 www-daftarharga.blogspot.com##+js(aeld, , keyCode)
 www-daftarharga.blogspot.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! warning msg
-elitepvpers.com##+js(nostif, $)
-elitepvpers.com##+js(acs, $, Promise)
 
 ! filmpornoitaliano anti right click - select
 filmpornoitaliano.org##+js(aopr, document.oncontextmenu)
@@ -4831,9 +5288,6 @@ mocah.org##+js(ra, oncontextmenu)
 ! https://github.com/uBlockOrigin/uAssets/issues/12067
 ukrainashop.com##+js(aeld, contextmenu)
 ukrainashop.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/12119
-101soundboards.com##.blocked-notice-small
 
 ! https://github.com/uBlockOrigin/uAssets/issues/12132
 geeksforgeeks.org##+js(nostif, onscroll ,5500)
@@ -4862,10 +5316,6 @@ koszalincity.pl##+js(acs, document.onkeydown)
 ! https://github.com/uBlockOrigin/uAssets/issues/12297
 theghostinmymachine.com##+js(acs, document.oncontextmenu)
 
-! codehelppro.com anti-adblock
-@@||codehelppro.com^$ghide
-codehelppro.com##.adsbygoogle
-
 ! ilovevaldinon. it anti right click, select
 ilovevaldinon.it##+js(acs, document.oncontextmenu)
 ilovevaldinon.it##+js(aopr, disableSelection)
@@ -4883,13 +5333,6 @@ novelza.com##:not(input):not(textarea)::selection:style(background-color:Highlig
 aileen-novel.online##+js(acs, disable_hot_keys)
 aileen-novel.online##+js(acs, document.oncontextmenu)
 aileen-novel.online##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/12462
-coolwallpapers.me##+js(nosiif, dfgh-adsbygoogle)
-
-! https://github.com/AdguardTeam/AdguardFilters/issues/113837
-@@||freshersnow.com^$ghide
-freshersnow.com##.adsbygoogle
 
 ! playerx.stream devtools detector
 beastx.top,chillx.top,playerx.stream##+js(aopr, devtoolsDetector)
@@ -4957,14 +5400,8 @@ blueraindrops.com##+js(acs, document.oncontextmenu)
 ! cinemakottaga.top anti right click
 cinemakottaga.top##+js(aopr, document.oncontextmenu)
 
-! fnbrjp.com anti-adb
-fnbrjp.com##+js(nostif, 広告)
-
 ! https://www.thuthuatmoi.xyz/2021/07/bitdefender-total-security-2501458-64.html anti right click
 top1iq.com##+js(acs, shortcut)
-
-! allthingsvegas. com anti adb warning
-@@||allthingsvegas.com^$ghide
 
 ! https://tinyurl.com/y9mv9crw anti devtools
 itscybertech.com##+js(acs, check, debugger)
@@ -4972,14 +5409,6 @@ itscybertech.com##+js(acs, check, debugger)
 ! sekaikomik. live anti right click, select, ctrl-u
 sekaikomik.live##+js(acs, document.oncontextmenu)
 sekaikomik.live##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/12623
-valid.x86.fr##+js(rmnt, script, /setTimeout.*style/)
-valid.x86.fr##.fullwidth
-valid.x86.fr##.widget-advert
-
-! https://www.reddit.com/r/uBlockOrigin/comments/tydsev/adblocker_detected_on_unidiversfr/
-unidivers.fr##+js(no-xhr-if, googlesyndication)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/12652
 vidembed.me##+js(set, console.clear, undefined)
@@ -5007,14 +5436,8 @@ goodhub.xyz##+js(aeld, /contextmenu|keydown/)
 ! https://ww3.watchgintama.com/gintama-episode-367-subbed/ preroll video
 animecruzers.com##+js(set, Object.prototype.preroll, [])
 
-! waves4you. com anti adblock
-waves4you.com##+js(aost, String.prototype.charCodeAt, ai_)
-
 ! https://ph.apps2app.com/2020/04/1.html?m=1#?o=62fe713ec0bfa7ab0fe6da9e25795a82259121d83ea3c8a23d036b3bd1e7dd68f6d41ef25791c755 anti right click
 apps2app.com##+js(acs, document.oncontextmenu)
-
-! techus. website anti adb soft
-techus.website##+js(nostif, ai_)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/12765 anti right click
 descargatepelis.com##+js(aeld, /keydown|mousedown/)
@@ -5100,9 +5523,6 @@ bpcj.or.jp##+js(acs, document.oncontextmenu)
 ! https://fmovies.to/series/law-order-lxnqm/4-4 clear console
 videovard.*##+js(set, console.clear, undefined)
 
-! https://github.com/uBlockOrigin/uAssets/issues/13037
-@@||ruyamanga.com^$ghide
-
 ! https://github.com/uBlockOrigin/uAssets/pull/13040
 gmarket.co.kr##+js(set, document.oncontextmenu, noopFunc)
 gmarket.co.kr##+js(set, document.onmousedown, noopFunc)
@@ -5138,11 +5558,6 @@ dubznetwork.com##+js(acs, jQuery, keydown)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/117803 clear console
 justswallows.net##+js(set, console.clear, undefined)
 
-! light.gg soft anti-adb
-light.gg##.items-right-square
-light.gg##.remove-turtles
-light.gg###ad-blocker-nudge
-
 ! sdewery. me anti right click, drag, f-keys
 sdewery.me##+js(aopw, document.ondragstart)
 sdewery.me##+js(aopw, disableEnterKey)
@@ -5176,9 +5591,6 @@ flashplayer.org.ua##+js(aopr, document.oncontextmenu)
 flashplayer.org.ua##+js(aopr, document.onkeydown)
 flashplayer.org.ua##+js(aopr, disableSelection)
 
-! https://github.com/uBlockOrigin/uAssets/issues/13418
-/wp-content/themes/*/public/js/detect-adblock.js$script,1p
-
 ! asia2tv. cn anti right click
 asia2tv.cn##+js(aeld, contextmenu)
 
@@ -5196,9 +5608,6 @@ turbo1.co##*:style(-webkit-touch-callout: default !important; -webkit-user-selec
 
 ! https://www.ilovefreesoftware.com/18/featured/show-mouse-coordinates-desktop-screen.html anti select when right click
 ilovefreesoftware.com##+js(aost, getSelection, quoty-public)
-
-! anti adb warning leekduck. com
-leekduck.com##+js(nostif, abp)
 
 ! anti right click - open console
 futbollatam.com##+js(aeld, contextmenu)
@@ -5284,15 +5693,9 @@ gourmetscans.net##+js(acs, document.oncontextmenu)
 ! https://github.com/uBlockOrigin/uAssets/issues/15367 anti F12 and Ctrl+U
 gourmetscans.net##+js(acs, wccp_pro_iscontenteditable)
 
-! https://github.com/uBlockOrigin/uAssets/issues/14170
-minimum-wage.org##.alert-dismissible
-
 ! https://github.com/uBlockOrigin/uAssets/issues/14193
 oricon.co.jp##+js(ra, oncontextmenu|onmousedown|onselectstart, .all-lyrics)
 oricon.co.jp##.all-lyrics:style(-webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/14191
-morosedog.gitlab.io##+js(set, checkAds, noopFunc)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/14183
 awebstories.com##+js(acs, document.oncontextmenu)
@@ -5308,9 +5711,6 @@ zgbk.com##+js(acs, document.oncontextmenu)
 cataz.net##.premodal-share
 cataz.net##.modal-backdrop
 cataz.net##body:style(overflow: auto !important; padding-right: 0 !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/14306
-htforum.net##+js(nostif, show)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/14392 anti right click
 maxstream.video##+js(acs, document.body.oncontextmenu)
@@ -5400,19 +5800,8 @@ aberdeennews.com,alamogordonews.com,amarillo.com,amestrib.com,app.com,argusleade
 streamservicehd.click##+js(ra, oncontextmenu, body)
 streamservicehd.click##^script:has-text(document.oncontextmenu)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/129173
-craftpip.github.io##+js(nostif, adsok)
-
-! https://github.com/uBlockOrigin/uAssets/issues/14749
-modrinth.com##.info-wrapper[ethical-ads-big=""]
-modrinth.com##.content-wrapper[ethical-ads-big]
-modrinth.com##.info-wrapper[data-v-7cd21295]
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/x5zwmw/filter_to_enable_right_click_on_website_in_chrome/in5tqih/
 btvnovinite.bg##+js(aeld, contextmenu)
-
-! https://www.iphoneincanada.ca/ anti-adb
-iphoneincanada.ca##.slbElement
 
 ! https://github.com/uBlockOrigin/uAssets/issues/14807
 !#if env_mobile
@@ -5425,9 +5814,6 @@ epitesti.ro##+js(aopw, clickIE4)
 epitesti.ro##+js(aopw, document.oncontextmenu)
 epitesti.ro##+js(ra, oncontextmenu|ondragstart|onselectstart)
 epitesti.ro##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! www.dailyprincetonian.com anti-adb
-||blink.net/iframe.html$domain=dailyprincetonian.com
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/xbjszd/ anti right click
 allcryptoz.net,crewbase.net,crewus.net,shinbhu.net,shinchu.net,thumb8.net,thumb9.net,topcryptoz.net,uniqueten.net,ultraten.net##^script:has-text(document.onkeydown)
@@ -5454,10 +5840,6 @@ sweetslyrics.com##+js(aeld, copy, preventDefault)
 ! https://github.com/uBlockOrigin/uAssets/issues/14939
 portalcriatividade.com.br##+js(acs, disable_copy)
 portalcriatividade.com.br##+js(acs, nocontext)
-
-! www.anisearch.com ad reinjection
-@@||cdn.privacy-mgmt.com^$script,xhr,domain=anisearch.com
-||anisearch.com/*?p=1|$frame
 
 ! https://github.com/uBlockOrigin/uAssets/issues/14961
 delicateseliterare.ro##+js(acs, jQuery, contextmenu)
@@ -5505,9 +5887,6 @@ vercalendario.info##+js(aeld, copy, Source)
 getlatka.com##.MuiModal-root
 getlatka.com##[style^="filter: blur"]:style(filter: none !important)
 
-! https://www.reddit.com/r/uBlockOrigin/comments/xy6lh0/
-pixwox.com##+js(nostif, length, 3000)
-
 ! https://khohieu.com/ anti right click
 /wp-content/plugins/t42-content-protector/js/protector.min.js$script
 
@@ -5525,13 +5904,6 @@ fantasytagtree.com##+js(ra, oncontextmenu, img[oncontextmenu="return false;"], s
 
 ! bagaglioamano. io anti select
 bagaglioamano.io##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! www.lamusica.com anti-adb
-lamusica.com##.modal-open:style(overflow: auto !important;)
-lamusica.com##div[id$="___BV_modal_outer_"]
-
-! https://profreehost.com/ anti-adb
-||profreehost.com/includes/js/customBottom.js$script,1p
 
 ! https://github.com/uBlockOrigin/uAssets/issues/15446
 ||droetker.*/static/js/privacy-dialog/
@@ -5553,22 +5925,12 @@ stiridinromania.ro##*:style(-webkit-touch-callout: default !important; -webkit-u
 jamilacuisine.ro##+js(aost, document.oncontextmenu)
 jamilacuisine.ro##+js(aost, Object,  /(?=^(?!.*(jquery|inlineScript)))/)
 
-! https://www.slideshare.net/secret/r4TGJDeZF0s9jt anti adb, exit-modal
-slideshare.net##+js(acs, ab_tests)
-slideshare.net##+js(aeld, mouseleave, scribd_ad)
-
 ! https://coinsparty.com/9FYmRWQ anti right click
 coinsparty.com##+js(aeld, contextmenu)
-
-! https://github.com/uBlockOrigin/uAssets/issues/15598
-@@||startpage.com^$ghide
 
 ! https://github.com/uBlockOrigin/uAssets/issues/15654
 postype.com##+js(aeld, contextmenu)
 postype.com##+js(rc, disable-selection, body)
-
-! anti adb annoyance golfdigest.com
-golfdigest.com##+js(aost, document.createElement, admiral)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/15689
 ! https://github.com/uBlockOrigin/uAssets/issues/18077
@@ -5578,18 +5940,6 @@ lofter.com##+js(aeld, contextmenu)
 ! https://github.com/uBlockOrigin/uAssets/issues/15701
 poipiku.com##+js(aeld, /contextmenu|copy|drag|dragstart/)
 poipiku.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
-
-! https://www.duhoctrungquoc.vn/wiki/ja/%E3%83%A1%E3%82%A4%E3%83%B3%E3%83%9A%E3%83%BC%E3%82%B8 (wikipedia copy)
-duhoctrungquoc.vn###danger_adblock
-
-! tarnkappe. info anti adblock annoyance
-tarnkappe.info##+js(set, traffective, true)
-tarnkappe.info##.around-desktop-ad:upward(1)
-tarnkappe.info##div[style="min-height: 300px;"]
-tarnkappe.info##.interscroller-wrapper[style^="height: 700px; "]
-
-! https://github.com/uBlockOrigin/uAssets/issues/15784
-@@||discordbotlist.com^$ghide
 
 ! hentaihaven. xxx anti  right click
 hentaihaven.xxx##+js(aeld, contextmenu)
@@ -5724,25 +6074,11 @@ walkthrough-indo.blogspot.com##*:style(-webkit-touch-callout: default !important
 ! https://desijugar.net/ anti right click
 desijugar.net##+js(acs, document.onkeydown)
 
-! https://github.com/uBlockOrigin/uAssets/issues/16251
-memoryhackers.org##+js(acs, RegExp, googlebot)
-
-! technologyreview.jp soft paywall
-technologyreview.jp##+js(cookie-remover, kpwc)
-technologyreview.jp##.meter
-
 ! https://github.com/uBlockOrigin/uAssets/issues/16296
 */wp-content/plugins/content-copy-protection-disable-right-click/$script
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16297
 warning.or.kr##+js(ra, oncontextmenu)
-
-! grabify. link anti adb warning
-@@||grabify.link^$ghide
-
-! https://www.reddit.com/r/uBlockOrigin/comments/10acynj/
-steamcollector.com##+js(acs, document.querySelectorAll, adblock)
-steamcollector.com##.abg-card
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/10aif9c/
 ||vaultcdn.electricapps.net/lib/jquery-ui-min.js$script,domain=yourgamingshop.com
@@ -5780,21 +6116,6 @@ paidiatreio.gr##+js(acs, document.addEventListener, copy)
 ! gmx.co.uk "Are you sure you want to leave?" overlay
 gmx.co.uk,gmx.com##+js(aeld, mouseout, openLayer)
 
-! https://github.com/uBlockOrigin/uAssets/issues/16529
-textcleaner.net##+js(no-fetch-if, googlesyndication)
-
-! sneakernews.com anti-adb
-sneakernews.com##+js(aopr, sneakerGoogleTag)
-
-! https://github.com/uBlockOrigin/uAssets/issues/16545
-socialcounts.org##+js(no-fetch-if, googlesyndication)
-
-! https://github.com/uBlockOrigin/uAssets/issues/16570
-*$script,3p,redirect-rule=noopjs,domain=fflogs.com
-fflogs.com###bottom-banner, #top-banner
-fflogs.com##.ad-placement
-fflogs.com##.side-rail-ads
-
 ! https://github.com/uBlockOrigin/uAssets/issues/16576
 freestreams-live1.tv##+js(aopr, document.oncontextmenu)
 
@@ -5807,9 +6128,6 @@ ziare.com##+js(aeld, copy)
 ! agrointel. ro copy manipulation
 agrointel.ro##+js(aeld, copy)
 
-! freefilesync. org anti-blocker
-freefilesync.org#@#.adsbygoogle
-
 ! 01. org sticky header
 01.org##.o-header, .project-header-actions:style(position: initial !important;)
 01.org##main[class^="o-content"]:style(top: 0px !important;)
@@ -5819,19 +6137,8 @@ freefilesync.org#@#.adsbygoogle
 sflix.to##+js(nostif, devtools)
 sflix.to,sflix.is,sflix.ca,sflix2.to##+js(nosiif, /_0x|devtools/)
 
-! https://github.com/uBlockOrigin/uAssets/issues/5511#issuecomment-1425702549
-magiclen.org##.show.fade.modal
-magiclen.org##.show.fade.modal-backdrop
-magiclen.org##body:style(overflow: auto !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/16689
-virustotal.com##.alert-info
-
 ! heavyfetish.com autoplay
 heavyfetish.com##+js(set, flashvars.autoplay, '')
-
-! twitcasting.tv anti-adb (login needed)
-@@||ads.twitcasting.tv/js/env_test/ads.js$script,1p
 
 ! selfstudys.com right-click and text select
 selfstudys.com##+js(aeld, contextmenu, preventDefault)
@@ -5840,21 +6147,11 @@ selfstudys.com##+js(ra, onselectstart, body)
 ! https://github.com/uBlockOrigin/uAssets/issues/16736
 ||player.cnevids.com/interlude/gq*&rightRail=true$script
 
-! https://raider.io/ anti-adb
-||intergient.com^$script,domain=raider.io,redirect-rule=noopjs
-
 ! https://www.thizissam.in/2023/01/gta-v-online-164-shoot-vehicles-script.html overlay popup
 thizissam.in##+js(nostif, popupScreen)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/16781
 m.timesofindia.com##a[href^="https://timesofindia.onelink.me"]
-
-! jojoy.io anti-adb - triggered only on mobile
-jojoy.io###ad_block_reminder_dialog
-
-! https://github.com/uBlockOrigin/uAssets/issues/16896
-mgsm.pl##+js(acs, checkAdblockBait)
-mgsm.pl##^script:has-text(checkAdblockBait)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/11d2sql/adblock_detected_message_on_video_player/jaa953o/
 sbbrisk.com##+js(acs, check, debugger)
@@ -5916,9 +6213,6 @@ jpopsingles.eu##*:style(-webkit-touch-callout: default !important; -webkit-user-
 jpopsingles.eu##+js(acs, jQuery, contextmenu)
 jpopsingles.eu##+js(acs, document.addEventListener, keydown)
 
-! https://github.com/uBlockOrigin/uAssets/issues/4241#issuecomment-1468322284
-actiongame.com,brain-games.co.uk,classicgame.com,games-site.co.uk,hiddenobjectgames.com,mahjong.co.uk,mahjong.com,match3.co.uk,match3games.com,mindgames.com,neongames.co.uk,neongames.com,solitaireonline.com,timemanagementgame.com##.adBlocked,.banner
-
 ! two9success. com anti select
 two9success.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
 
@@ -5961,8 +6255,6 @@ verselemzes.hu##*:style(-webkit-touch-callout: default !important; -webkit-user-
 ! https://github.com/uBlockOrigin/uAssets/issues/17315
 skyozora.com##+js(aeld, copy)
 
-! zunda.site chat anti-adb
-zunda.site###ad_box:style(height: 50px !important;)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/17325
 dialectsarchive.com##+js(aopr, disableSelection)
@@ -5996,9 +6288,6 @@ dollarvr.com##+js(acs, document.oncontextmenu)
 dollarvr.com##+js(acs, document.ondragstart)
 dollarvr.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important;-moz-user-select: text !important;-ms-user-select: text !important;user-select: text !important;)
 
-! romviet.com anti adblock annoyance
-romviet.com##+js(noeval-if, AdBlocker)
-
 ! jk-market.com devtool
 jk-market.com##+js(acs, jQuery, devtool)
 
@@ -6027,16 +6316,10 @@ newsme.gr##*:style(-webkit-touch-callout: default !important; -webkit-user-selec
 ! https://github.com/uBlockOrigin/uAssets/issues/17546
 displayspecifications.com##body:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! squidboards.com anti-adb
-squidboards.com##.top_block
-
 ! https://github.com/uBlockOrigin/uAssets/issues/17624
 daily-tohoku.news##+js(acs, document.oncontextmenu)
 daily-tohoku.news##+js(acs, disableSelection)
 daily-tohoku.news##body:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/17632
-regex101.com##.yOGxa
 
 ! https://github.com/uBlockOrigin/uAssets/issues/17641
 savoriurbane.com##+js(aopw, document.oncontextmenu)
@@ -6133,10 +6416,6 @@ pepperlive.info,unbiasedsenseevent.com##+js(set, console.clear, noopFunc)
 ! https://darkhub-v4.maxt.church/ anti devtools
 maxt.church##+js(set, console.clear, noopFunc)
 
-! https://github.com/uBlockOrigin/uAssets/issues/14765#issuecomment-1527523594
-bluemediafile.*##+js(set, Time_Start, 0)
-bluemediafile.*##+js(nano-sib, i--, , 0.02)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/17935 
 ilife97.com##+js(aopw, document.oncontextmenu)
 ilife97.com##+js(aopw, document.ondragstart)
@@ -6154,12 +6433,6 @@ canalnatelinhaonline.blogspot.com##^script:has-text(document.onmousedown)
 ! https://github.com/uBlockOrigin/uAssets/issues/18037
 ontools.net##+js(acs, document.oncontextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/issues/18046
-@@||luckydesigner.space/adview_$xhr,1p
-
-! https://github.com/uBlockOrigin/uAssets/issues/18048
-neilpatel.com##+js(no-xhr-if, /hotjar|googletagmanager/)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/18040
 onlinegiftools.com,onlinejpgtools.com,onlinepngtools.com,onlinestringtools.com,onlinetexttools.com,onlinetools.com##+js(nano-sib, Clipboard, 1000, 0.001)
 
@@ -6167,10 +6440,6 @@ onlinegiftools.com,onlinejpgtools.com,onlinepngtools.com,onlinestringtools.com,o
 cool-etv.net##+js(aeld, contextmenu)
 cool-etv.net##+js(set, console.clear, noopFunc)
 ||cool-etv.net/ch/suppy.js$script,1p
-
-! Soft Anti-Blocker
-jsfiddle.net##+js(nostif, modal)
-regexr.com##div.hello
 
 ! https://snbc13.com/barrie-shooting-1-dead-2-officers-hurt-police-incident-in-innisfil-near-9th-line-alcona/ anti select
 ! https://publicwww.com/websites/%22secure-copy-content-protection-public.css%22/
@@ -6189,14 +6458,6 @@ scarysymptoms.com##+js(acs, document.oncontextmenu)
 scarysymptoms.com##+js(acs, wccp_pro_iscontenteditable)
 scarysymptoms.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 scarysymptoms.com##*::selection:style(background-color:#338FFF !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/18169
-ikorektor.pl##+js(nostif, ad)
-ikorektor.pl###ad-top-dsk
-ikorektor.pl##.adx1
-
-! https://github.com/uBlockOrigin/uAssets/issues/18180
-theonegenerator.com##+js(no-fetch-if, ads)
 
 ! https://vgembed.com/e/kKJVORWVgp53XDw anti devtools and right click
 vgembed.com##+js(nosiif, detect)
@@ -6249,9 +6510,6 @@ jpost.com##+js(rmnt, script, stopRefreshSite)
 ! https://github.com/uBlockOrigin/uAssets/issues/18528
 j91.asia##+js(aeld, contextmenu)
 
-! https://github.com/webcompat/web-bugs/issues/119017 (Firefox ESR and Opera)
-nppes.cms.hhs.gov##div#unsupportedBrowser
-
 ! https://github.com/uBlockOrigin/uAssets/issues/18538
 khou.com##+js(aeld, mouseout)
 
@@ -6264,9 +6522,6 @@ rodude.com##*:style(-webkit-touch-callout: default !important; -webkit-user-sele
 ! https://mehoathinh2.com/cau-hoc-sinh-moi-thieu-quyet-doan/tap-12-loi-to-tinh-trong-bua-tiec-giang-sinh anti devtools
 mehoathinh2.com##+js(set, forbiddenList, [])
 
-! goldenstateofmind.com anti adblock annoyance
-goldenstateofmind.com##+js(nostif, concertAds)
-
 ! https://0123movies.net/watch-star-trek-picard-2020/season-1/episode-1-0123movies-free.html anti right click
 kmo.to##+js(set, console.clear, undefined)
 
@@ -6275,16 +6530,6 @@ kmo.to##+js(set, console.clear, undefined)
 0123movies.ch##+js(set, document.onkeydown, trueFunc)
 0123movies.ch##+js(set, document.onselectstart, trueFunc)
 0123movies.ch##+js(set, document.onkeypress, trueFunc)
-
-! https://github.com/uBlockOrigin/uAssets/issues/18606
-9now.com.au##[id="toggle_notification_notification-ad-blocker"]:upward(1)
-
-! https://www.reddit.com/r/uBlockOrigin/comments/14gghvf/
-! https://github.com/easylist/easylist/issues/16421
-||pagead2.googlesyndication.com/pagead/show_ads.js$script,redirect=noopjs,domain=ageofconsent.net
-
-! https://github.com/uBlockOrigin/uAssets/issues/18641
-neoseeker.com##+js(nostif, whetherdo)
 
 ! https://teamkong.tk/forza-horizon-5-update-v1-594-508-0/ anti right click
 teamkong.tk##body * :not(input):not(textarea):style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
@@ -6301,9 +6546,6 @@ brutal.io,powerline.io##+js(set, document.oncontextmenu, true)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/18660
 wormate.io###mm-skin-over
-
-! https://github.com/uBlockOrigin/uAssets/issues/18667
-xeiaso.net##.adaptive
 
 ! https://github.com/uBlockOrigin/uAssets/issues/18693
 musicallyvideos.com##+js(acs, document.oncontextmenu)
@@ -6375,11 +6617,6 @@ tumblr.com##+js(nostif, Premium)
 oploverz.*##+js(rmnt, script, contextmenu)
 oploverz.*##+js(rmnt, style, user-select)
 
-! https://github.com/uBlockOrigin/uAssets/issues/19015
-lapresse.ca##.brz_msg_wall_body
-lapresse.ca##body > div[style]:has(.brz_msg_wall_body)
-lapresse.ca##body:style(overflow: auto !important)
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/154wyb0/
 zelka.org###description:style(user-select: initial !important;)
 
@@ -6448,12 +6685,6 @@ animesuge.to,aniwave.*,anix.*,flixhq.*,flixrave.to,hdtoday.so,hurawatch.bz,vidpl
 animesuge.to,aniwave.*,anix.*,bflix.io,flixhq.*,fmovies.*,f2movies.ru,hdtoday.so,hurawatch.bz,movies2watch.ru,putlockernew.vc,swatchseries.ru,vidplay.site,vid2faf.site,vidstream.pro,mcloud.to##+js(aost, console.clear)
 animesuge.to,aniwave.*,anix.*,flixrave.to,hdtoday.so,hurawatch.bz,vidplay.*,vid2faf.site##+js(set, DisDevTool, undefined)
 
-! https://github.com/uBlockOrigin/uAssets/issues/19271#issuecomment-1664958435
-161.97.70.5##+js(rmnt, script, isadb)
-
-! https://github.com/uBlockOrigin/uAssets/issues/19280
-zerogpt.net##+js(nostif, adsbygoogle)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/19282
 linkco.re##section.lyric_lyric:style(user-select: text !important; -webkit-user-select: text !important; -moz-user-select: text !important; -khtml-user-select: text !important; -webkit-user-drag: auto !important; -khtml-user-drag: auto !important; -webkit-touch-callout: auto !important; -moz-touch-callout: auto !important;)
 
@@ -6462,9 +6693,6 @@ txori.com##+js(aeld, contextmenu, _0x)
 
 ! https://team-octavi.com/ anti right click
 team-octavi.com##+js(aost, document.addEventListener, preventDeleteDialog)
-
-! https://github.com/uBlockOrigin/uAssets/issues/19370
-||mms.cnn.com^$1p
 
 ! https://github.com/uBlockOrigin/uAssets/issues/19421
 bypass.city,adbypass.org##+js(no-fetch-if, /googlesyndication|googletag/)
@@ -6476,9 +6704,6 @@ nicekkk.com##+js(rmnt, script, debugger)
 ! https://www.sgd.de/ right click blocked on images
 sgd.de##+js(aeld, contextmenu)
 
-! https://github.com/AdguardTeam/AdguardFilters/issues/159897
-*$script,1p,redirect-rule=noopjs,domain=punishworld.com
-
 ! https://github.com/uBlockOrigin/uAssets/issues/19470
 comikey.com##+js(aeld, contextmenu, undefined)
 
@@ -6487,16 +6712,6 @@ tuta.com##body > div > section.default:style(cursor: revert !important;)
 
 ! https://venturebeat.com/business/ghostery-a-web-tracking-blocker-that-actually-helps-the-ad-industry/
 venturebeat.com##div.body-container:style(cursor: revert !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/19472
-guildstats.eu##.gDiv
-
-! admiral
-aboutchromebooks.com,ancient.eu,comingsoon.net,daysoftheyear.com,edn.com,gearjunkie.com,harvardmagazine.com,lgbtqnation.com,majorgeeks.com,mangainn.net,medievalists.net,sherdog.com,sidereel.com,statesman.com,winhelponline.com##+js(aopr, googletag)
-boston.com,britannica.com,cattime.com,dogtime.com,download.mokeedev.com,freep.com,ijr.com,inquirer.net,knowyourmeme.com,nationalreview.com,nofilmschool.com,order-order.com,savvytime.com,techlicious.com,technicpack.net,thedraftnetwork.com,wrestlezone.com,xda-developers.com##+js(acs, document.createElement, admiral)
-majorgeeks.com##+js(acs, document.getElementById, undefined)
-legacy.com##+js(acs, document.getElementsByTagName, admiral)
-lazyadmin.nl##+js(set, admiral, noopFunc)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/19488
 saikaiscans.net##+js(aeld, contextmenu, [native code])
@@ -6585,18 +6800,10 @@ thejakartapost.com##+js(rmnt, script, /$.*ready.*setInterval/)
 ! oreilly. com leaving screen => pop-up
 oreilly.com##+js(aeld, mouseout, cookie)
 
-! https://github.com/uBlockOrigin/uAssets/issues/4747#issuecomment-1691485028
-! https://github.com/uBlockOrigin/uAssets/issues/26838
-fullxh.com,galleryxh.site,megaxh.com,movingxh.world,seexh.com,unlockxh4.com,valuexh.life,xhaccess.com,xhadult2.com,xhadult3.com,xhadult4.com,xhadult5.com,xhamster.*,xhamster1.*,xhamster10.*,xhamster11.*,xhamster12.*,xhamster13.*,xhamster14.*,xhamster15.*,xhamster16.*,xhamster17.*,xhamster18.*,xhamster19.*,xhamster20.*,xhamster2.*,xhamster3.*,xhamster4.*,xhamster42.*,xhamster46.com,xhamster5.*,xhamster7.*,xhamster8.*,xhamsterporno.mx,xhbig.com,xhbranch5.com,xhchannel.com,xhdate.world,xhday.com,xhday1.com,xhlease.world,xhmoon5.com,xhofficial.com,xhopen.com,xhplanet1.com,xhplanet2.com,xhreal2.com,xhreal3.com,xhspot.com,xhtotal.com,xhtree.com,xhvictory.com,xhwebsite.com,xhwebsite2.com,xhwebsite5.com,xhwide1.com,xhwide2.com,xhwide5.com##+js(set, initials.layout.layoutPromoProps.promoMessagesWrapperProps.shouldDisplayAdblockMessage, false)
-
-! https://github.com/uBlockOrigin/uAssets/issues/20084
-270towin.com##+js(set-session-storage-item, fs.adb.dis, 1)
-
 ! https://github.com/easylist/easylist/issues/15515
 tech.hindustantimes.com###credential_picker_container
 
 ! https://github.com/uBlockOrigin/uAssets/issues/20113
-photopea.com##.confirm:has-text(AdBlocker)
 ||photopea.com/img/pp_wide.png^$image,1p
 ||photopea.com/img/pp_tall.png^$image,1p
 photopea.com##+js(set, console.clear, noopFunc)
@@ -6616,29 +6823,11 @@ mathcrave.com##+js(rmnt, script, disable_show_error)
 ! https://github.com/uBlockOrigin/uAssets/issues/20189
 vrcmods.com##.showfreemethod
 
-! https://github.com/uBlockOrigin/uAssets/issues/20190
-cyanlabs.net#@#ins.adsbygoogle[data-ad-slot]
-cyanlabs.net#@#ins.adsbygoogle[data-ad-client]
-cyanlabs.net##ins.adsbygoogle:style(visibility: hidden !important;)
-
 ! Daily upload limit of 2 images - Sign up now and enjoy monthly free credits
 www.watermarkremover.io##+js(set-local-storage-item, WkdGcGJIbEpiV0ZuWlVSaGRHRT0=, $remove$)
 
-! https://github.com/uBlockOrigin/uAssets/issues/20228
-uploadvr.com##.force-load-ad
-
-! getemoji.com anti adblock annoyance
-getemoji.com##+js(set-session-storage-item, fs.adb.dis, 1)
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/17fhagl/comment/k6ady0d/
 ||dbx.molystream.org/assets/s.js$script
-
-! https://www.reddit.com/r/uBlockOrigin/comments/17g3pww/photocollage_com_detect_addblockers/
-2pdfconverter.com,annotation.com,changefaces.com,chartle.com,coloringonline.com,fakechatapp.com,files2zip.com,mapimage.com,maproute.com,mindclouds.com,phideo.com,photocollage.com,photoeditor.com,photoenlarger.com,photofilters.com,photoresizer.com,postermaker.com,qrapp.com,stripbackground.com,toonytool.com,wordclouds.com,youtubetrimmer.com##.banner
-
-! https://github.com/uBlockOrigin/uAssets/issues/20294
-marinetraffic.com##+js(set, mtGlobal.disabledAds, true)
-marinetraffic.com##.under-map-wrapper:upward(1)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/20306
 sportando.basketball##.select-none:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
@@ -6653,21 +6842,9 @@ myflixerz.to,putlocker.pe,theflixertv.to##+js(nosiif, _0x)
 movie4kto.net##+js(nosiif, /DevTools|_0x/)
 grostembed.online,megacloud.*,premiumembeding.cloud,venusembed.site##+js(set, console.clear, throwFunc)
 
-! https://github.com/uBlockOrigin/uAssets/issues/20341
-lethalpanda.com##+js(aopr, b2a)
-
-! https://www.reddit.com/r/uBlockOrigin/comments/17iihqp/anime_news_network_rolled_out_antiadblocker/
-animenewsnetwork.com##+js(set, ANN.ads.adblocked, false)
-
-! https://www.reddit.com/r/uBlockOrigin/comments/17mifyx/adblocker_detected_on_hackthebox_website/
-||hackthebox.com/build/assets/just-detect-adblock-$script,1p
-
 ! https://github.com/uBlockOrigin/uAssets/issues/20423
 amtraker.com##+js(no-fetch-if, cloudflareinsights.com)
 amtraker.com##.terrabanner
-
-! https://github.com/uBlockOrigin/uAssets/issues/20430
-heidisql.com##+js(rpnt, script, if(floovy()) {, if(false) {)
 
 ! https://romprovider.com/lava-yuva-2-pro-lzx408-firmware-flash-file-stock-rom/ - Blocked right-click and select
 romprovider.com##+js(aopw, document.oncontextmenu)
@@ -6687,11 +6864,6 @@ brokensilenze.net##*:style(cursor:unset!important;user-select:unset!important)
 ! https://seriesperu.com/2023/11/la-banda-del-chino-programa-03-11-23.html - anti right click
 seriesperu.com##+js(aeld, contextmenu, preventDefault)
 
-! https://www.concertarchives.org/concerts/queens-of-the-stone-age-39b3e73b-f1e1-4c2b-9f29-d1aa157b452d - anti-adb
-||pub.network^$script,3p,redirect=noopjs,domain=concertarchives.org
-concertarchives.org#@#[data-freestar-ad]
-concertarchives.org##.freestar-placement
-
 ! https://github.com/uBlockOrigin/uAssets/issues/20526
 ||userapi.com/impf/$image,uritransform=/^\/impf\/+//,domain=vk.com|vk.ru
 
@@ -6701,13 +6873,6 @@ web.telegram.org##div.Message.is-protected:style(-webkit-touch-callout: default 
 ! https://github.com/uBlockOrigin/uAssets/issues/20528
 galinos.gr##+js(nostif, pleaseSupportUs)
 
-! https://github.com/uBlockOrigin/uAssets/issues/20555
-bluesnews.com##+js(nostif, nn_mpu1, 5000)
-
-! https://github.com/uBlockOrigin/uAssets/issues/20574
-broncoshq.com##+js(rmnt, script, XF)
-broncoshq.com##+js(acs, $, btoa)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/20059#issuecomment-1806089143
 androidpolice.com,makeuseof.com,movieweb.com,xda-developers.com,thegamer.com,cbr.com,gamerant.com,screenrant.com,howtogeek.com,thethings.com,simpleflying.com,dualshockers.com##+js(remove-cookie, /articlesLimit|articlesRead|previousPage/, when, scroll keydown)
 androidpolice.com,makeuseof.com,movieweb.com,xda-developers.com,thegamer.com,cbr.com,gamerant.com,screenrant.com,howtogeek.com,thethings.com,simpleflying.com,dualshockers.com##+js(set, maxUnauthenicatedArticleViews, null)
@@ -6716,13 +6881,6 @@ androidpolice.com,makeuseof.com,movieweb.com,xda-developers.com,thegamer.com,cbr
 groundies.com##.cms-popup
 groundies.com##.modal-backdrop
 groundies.com##.modal-open:style(overflow:unset!important)
-
-! https://github.com/uBlockOrigin/uAssets/issues/20657
-alfred.camera##+js(aeld, DOMContentLoaded, ads)
-alfred.camera##+js(nosiif, ads)
-
-! https://github.com/uBlockOrigin/uAssets/issues/20725
-decider.com,nypost.com,pagesix.com##+js(aopr, googletag.cmd)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/166405
 habuteru.com##+js(aopw, document.oncontextmenu)
@@ -6802,9 +6960,6 @@ starzunion.com##+js(aeld, /^(contextmenu|mousedown|keydown)$/, preventDefault)
 ! nsfw247.biz
 nsfw247.biz###page:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! https://github.com/uBlockOrigin/uAssets/issues/21005
-cheersandgears.com##+js(rmnt, script, fetch)
-
 ! copy manipulation
 libertatea.ro##+js(aeld, copy)
 
@@ -6815,27 +6970,11 @@ sportea.online##+js(noeval-if, debugger)
 streamvid.net##+js(aeld, contextmenu)
 streamvid.net##+js(rmnt, script, debugger)
 
-! https://github.com/uBlockOrigin/uAssets/issues/21051
-moovitapp.com##+js(trusted-click-element, [data-automation="continue-to-ads-btn"], , 10000)
-moovitapp.com##.init.open
-moovitapp.com##.top-banner
-
-! https://github.com/uBlockOrigin/uAssets/issues/20886
-digminecraft.com##+js(set, placeAdsHandler, noopFunc)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/21088
 vidstreaming.xyz##+js(nosiif, devtoolsDetector)
 
-! https://github.com/uBlockOrigin/uAssets/issues/21072
-@@||iphoneincanada.ca^$ghide
-iphoneincanada.ca##.adthrive-ad
-
 ! firescans. xyz anti drag and drop, f-keys
 firescans.xyz##+js(acs, jQuery, hmwp_is_devtool)
-
-! https://github.com/uBlockOrigin/uAssets/issues/21255
-*$image,domain=peacocktv.com,redirect-rule=1x1.gif
-peacocktv.com##.playback-ad-blocker-notice
 
 ! cespun. eu anti right click, select, f-keys
 !#if cap_html_filtering
@@ -6854,19 +6993,9 @@ encurtandourl.com##+js(aopw, mensagem)
 ! https://github.com/uBlockOrigin/uAssets/issues/21318
 news.17173.com##+js(aeld, copy)
 
-! https://github.com/uBlockOrigin/uAssets/issues/21300
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=woomy-site.glitch.me
-
 ! https://github.com/uBlockOrigin/uAssets/issues/21319
 ||videos-cloudfront.jwpsrv.com^$media,domain=app.simpleclub.com
 ||cdn.jwplayer.com^$media,domain=app.simpleclub.com
-
-! https://github.com/uBlockOrigin/uAssets/issues/21352
-||ip.sb/assets/js/wwads_blocked.js
-
-! https://github.com/uBlockOrigin/uAssets/issues/21301
-! https://github.com/uBlockOrigin/uAssets/issues/24250
-arras.io,arras.netlify.app,arrax.io##+js(set, ramp.addUnits, noopFunc)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/21377
 freetvsports.xyz##+js(noeval-if, debugger)
@@ -6890,23 +7019,11 @@ netu.*,netuplayer.top,stbnetu.xyz##+js(set, devtoolsDetector.launch, noopFunc)
 ! stblion.xyz anti devtools
 stblion.xyz##+js(rmnt, script, while(!![]){try{var)
 
-! https://scenexe.io/ anti adblock
-scenexe.io##+js(set-local-storage-item, ad_blocker, false)
-
-! https://github.com/uBlockOrigin/uAssets/issues/21065
-@@||googlesyndication.com^$script,domain=cheatnetwork.eu
-@@||cheatnetwork.eu^$script,xhr,1p
-@@||cheatnetwork.eu^$ghide
-
 ! hdrez .com anti right click, f-keys
 hdrez.com##+js(aopw, document.oncontextmenu)
 
 ! sportsupa .com anti right click
 sportsupa.com##+js(ra, oncontextmenu)
-
-! https://github.com/uBlockOrigin/uAssets/issues/21424
-how-to-pc.info,programming-link.info##+js(set, pqdxwidthqt, false)
-@@||how-to-pc.info^$ghide
 
 ! emturbovid.com anti devtools
 emturbovid.com##+js(nostif, debugger)
@@ -6927,15 +7044,8 @@ hoca4u.com##+js(set, document.onmousedown, noopFunc)
 ! https://github.com/uBlockOrigin/uAssets/issues/21554
 lowcygier.pl##+js(aeld, error, browser-plugin)
 
-! https://community.brave.com/t/asheville-com-ad-appearing/522978
-asheville.com##+js(nostif, adblock)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/21577
 theasianparent.com##+js(acs, document.onselectstart, disableselect)
-
-! https://github.com/uBlockOrigin/uAssets/issues/21582
-maxroll.gg##+js(set, nitroAds.loaded, true)
-@@||s.nitropay.com/n.svg$xhr,domain=maxroll.gg
 
 ! https://github.com/uBlockOrigin/uAssets/issues/2031
 !#if cap_html_filtering
@@ -6992,9 +7102,6 @@ oceanplay.org##+js(nostif, devtool)
 ! https://bluphim.com/xem-phim/the-creator-3526/ anti-devtools
 bluphim.com,cdnmoviking.tech##+js(nosiif, console.clear)
 
-! https://mineskin.org/gallery banners
-mineskin.org##+js(aopw, ABB_config)
-
 ! https://github.com/uBlockOrigin/uAssets/discussions/17361#discussioncomment-8002410
 blog.cryptowidgets.net,blog.insurancegold.in,blog.wiki-topia.com##+js(acs, document.addEventListener, contextmenu)
 blog.cryptowidgets.net,blog.insurancegold.in,blog.wiki-topia.com##+js(rmnt, script, devtools)
@@ -7002,19 +7109,6 @@ blog.cryptowidgets.net,blog.insurancegold.in,blog.wiki-topia.com##+js(rmnt, scri
 ! https://github.com/uBlockOrigin/uAssets/discussions/17361#discussioncomment-7999398
 blog.coinsvalue.net,blog.cookinguide.net,blog.freeoseocheck.com##+js(acs, document.addEventListener, contextmenu)
 blog.coinsvalue.net,blog.cookinguide.net,blog.freeoseocheck.com##+js(rmnt, script, devtools)
-
-! https://github.com/uBlockOrigin/uAssets/issues/21812
-@@||sheffieldforum.co.uk^$xhr,1p
-
-! nsmb .com anti-adb
-nsmb.com##+js(no-xhr-if, googlesyndication)
-nsmb.com###header-banner
-
-! https://github.com/uBlockOrigin/uAssets/issues/21919
-afterclass.io##+js(set-session-storage-item, adblock, true)
-
-! https://github.com/uBlockOrigin/uAssets/issues/21991
-@@||hbstack.dev^$script,xhr,1p
 
 ! aventurainromania. ro anti right click, select
 aventurainromania.ro##+js(rmnt, script, document.oncontextmenu)
@@ -7024,9 +7118,6 @@ playingfire.com##body:style(user-select: text !important; -ms-user-select: text 
 
 ! https://saude.abril.com.br/medicina/impressao-3d-na-medicina-da-reconstrucao-de-partes-do-corpo-aos-curativos/
 abril.com.br##+js(aeld, copy)
-
-! https://github.com/uBlockOrigin/uAssets/issues/22140
-mcskinhistory.com##+js(no-fetch-if, ads)
 
 ! https://old.reddit.com/r/uBlockOrigin/comments/19cwuo4/ anti right click, f12, ctrl key, etc
 tv.bdix.app##+js(set, jh_disabled_options_data, null)
@@ -7047,12 +7138,6 @@ goodreads.com#@?#.Overlay--floating:has(> div.Overlay__window > div.Overlay__con
 ! shaalaa .com anti select
 shaalaa.com##*:style(cursor: revert !important; -webkit-touch-callout: default !important; -webkit-user-select: text !important; -khtml-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important;)
 
-! viewing .nyc banners
-viewing.nyc##+js(no-fetch-if, googlesyndication)
-
-! https://github.com/uBlockOrigin/uAssets/issues/22314
-tmz.com##.canvas-video-block--aside
-
 ! https://www.justspices.de/ofengemuese-gewuerzmix.html anti select
 justspices.de###maincontent:style(user-select: text !important; -webkit-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; -o-user-select: text !important;)
 
@@ -7063,16 +7148,10 @@ baumbet.ro##+js(rpnt, script, window.location.reload)
 op.gg##.adfree-td
 op.gg##.adfree-banner
 
-! notificationsounds .com anti-adb banners
-notificationsounds.com##+js(nostif, adsbygoogle, 2000)
-
 ! ncrtsolutions .in anti select, context menu
 ncrtsolutions.in##+js(aopr, document.body.onselectstart)
 ncrtsolutions.in##body:remove-attr(oncontextmenu)
 ncrtsolutions.in##body:style(cursor: revert !important;)
-
-! tweaking4all .com anti-adb banners
-tweaking4all.com##+js(nostif, adsbygoogle, 2000)
 
 ! studiestoday .com anti select, copy, context menu
 studiestoday.com##body:remove-attr(/onselectstart|oncopy|oncontextmenu/)
@@ -7080,9 +7159,6 @@ studiestoday.com##+js(aeld, /select|copy|contextmenu/)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/22369
 watch.lonelil.com##+js(set, navigator.userAgent, '')
-
-! hitokageproduction .com anti-adb banner
-hitokageproduction.com##+js(set, topMessage, noopFunc)
 
 ! thotsbay .tv anti right click, dev tools, f keys
 thotsbay.tv##+js(aeld, /contextmenu|keydown/)
@@ -7159,9 +7235,6 @@ dngz.net##+js(aopr, document.oncontextmenu)
 dngz.net##+js(aopr, document.onkeydown)
 dngz.net##+js(set, forbidDebug, noopFunc)
 
-! https://github.com/uBlockOrigin/uAssets/issues/22693
-vnexpress.net##+js(set, adblock, 2)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/22769
 vidsrc.*##+js(acs, RegExp.prototype.toString, .join(""))
 vidsrc.*##+js(aeld, keydown, 123)
@@ -7183,10 +7256,6 @@ mrbenne.com##+js(rmnt, script, /Clipboard|oncontextmenu|wpcp|keyCode/)
 mrbenne.com##+js(ra, oncontextmenu|ondragstart|onselectstart|onload|onblur)
 mrbenne.com##+js(rmnt, style, /-webkit-user-select|webkit-appearance/)
 
-! https://www.reddit.com/r/uBlockOrigin/comments/1b906te/pop_up_that_says_to_not_use_adblockers_on/
-d4armory.io,helldivers.io##+js(aopr, nitroAds)
-helldivers.io###gwvideo
-
 ! https://bongdaplus.vn/ - anti right click, select
 bongdaplus.vn##+js(aeld, mousedown, undefined, elements, body)
 bongdaplus.vn##+js(set, document.oncontextmenu, trueFunc)
@@ -7206,12 +7275,6 @@ ipphone-warehouse.com##+js(aeld, afterKeydown)
 ipphone-warehouse.com##+js(aeld, keydown, void)
 ipphone-warehouse.com##+js(aeld, copy, void)
 ipphone-warehouse.com##body:style(user-select: text !important; -ms-user-select: text !important; -moz-user-select: text !important; -khtml-user-select: text !important; -webkit-user-select: text !important; -webkit-touch-callout: default !important;)
-
-! fightful .com anti-adb modal
-fightful.com##+js(nosiif, getComputedStyle)
-
-! conservationmag .org anti-adb popup
-@@||conservationmag.org^$ghide
 
 ! https://teller.jp/ mobile-app
 teller.jp##+js(trusted-click-element, .z_share_popover div.gap_2 > button.mt_24px.rounded_100vh + button.text_tint.disabled\:opacity_0\.4.h_50px)
@@ -7236,20 +7299,10 @@ www-liverpoolecho-co-uk.translate.goog,www-themirror-com.translate.goog,www-foot
 ! techcrunch.com anti proxy (google translator)
 techcrunch-com.translate.goog##.loading-text:remove-class(loading-text)
 
-! https://github.com/uBlockOrigin/uAssets/pull/23279
-!#if cap_html_filtering
-xanimu.com,cosxplay.com##^script:has-text(adblock)
-!#else
-xanimu.com,cosxplay.com##+js(rmnt, script, adblock)
-!#endif
-
 ! https://github.com/AdguardTeam/AdguardFilters/issues/184080#issuecomment-2681098348
 !#if cap_html_filtering
 ||tver.jp/_next/static/chunks/pages/episodes/$script,replace=/e\.openQuestionnaireModal\?\?.+?\[e\.openQuestionnaireModal\,e\.controller\.play/e.controller.play)()}\,[e.controller.play/
 !#endif
-
-! https://github.com/EasyDutch-uBO/EasyDutch/issues/127
-solarmagazine.nl##+js(no-xhr-if, ads)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/23331 - anti select
 noicetranslations.blogspot.com##+js(rmnt, script, disableselect)
@@ -7259,12 +7312,6 @@ noicetranslations.blogspot.com##+js(rmnt, script, disableselect)
 
 ! https://www.bloomberglinea.com/latinoamerica/panama/la-historia-del-cierre-de-una-mina-de-cobre-de-us10000-millones-en-la-selva-de-panama/ copy manipulation
 bloomberglinea.com,bloomberglinea.com.br##+js(aeld, copy)
-
-! https://github.com/hogekai/ad-compass/tree/main
-||jsdelivr.net/npm/ad-compass@latest/dist/ad-compass.umd.js
-
-! https://github.com/uBlockOrigin/uAssets/issues/23472
-timeanddate.com##+js(aeld, load, ad-wrap)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/178173
 wear.jp##+js(trusted-set-session-storage-item, status_of_app_redirect_half_modal_on_coordinate_list, {"displayed":true})
@@ -7327,9 +7374,6 @@ radartest.com##+js(acs, document.onmousedown, disableclick)
 ! skuola.net anti copy & right click
 skuola.net##+js(aeld, /contextmenu|copy/)
 
-! https://github.com/uBlockOrigin/uAssets/issues/23773
-thehouseofportable.com###htp
-
 ! https://github.com/uBlockOrigin/uAssets/issues/23777
 ! https://github.com/uBlockOrigin/uAssets/issues/21830
 ! https://github.com/uBlockOrigin/uAssets/issues/26963#issuecomment-2614193847
@@ -7360,9 +7404,6 @@ weibo.com##+js(nowoif, &disp=popup, 1)
 ! https://github.com/uBlockOrigin/uAssets/issues/23864 - anti right click
 javjavhd.com##+js(acs, $, contextmenu)
 
-! https://www.reddit.com/r/uBlockOrigin/comments/1d204k4/antiadblock_message_at_httpswwwlcpdfrcom/
-lcpdfr.com##+js(aopr, FuckAdBlock)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/23872
 pronews.gr##.wrap-banner
 
@@ -7380,20 +7421,10 @@ prompthero.com##.sign-up-modal
 prompthero.com##.modal-backdrop
 prompthero.com##body:style(overflow:initial!important)
 
-! https://fancaps.net/anime/ adblock detection
-||a.pub.network/fancaps-net/pubfig.min.js$script,redirect=noopjs,domain=fancaps.net
-
-! https://www.reddit.com/r/uBlockOrigin/comments/1dmthrd/strange_thing_ive_been_noticing_not_sure_how_it/
-||web.archive.org/web/*/http://rpc.blogrolling.com/display.php?r=$1p,script
-
 ! https://github.com/AdguardTeam/AdguardFilters/issues/182108
 !#if env_mobile
 zutool.jp##+js(trusted-set-local-storage-item, zutoolweb_appbanner_close, $now$)
 !#endif
-
-! https://www.swagbucks.com/ - anti-adb
-swagbucks.com#@#.ad_warn
-swagbucks.com#@##topAd
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24251
 leetcode.cn##+js(aeld, copy, , elements, #__next)
@@ -7440,18 +7471,12 @@ mskmangaz.blogspot.com##div[oncopy]:remove-attr(/oncopy|oncut|onpaste/)
 mskmangaz.blogspot.com##+js(trusted-rpnt, style, '/\.novel-box \*:not\(a\)|@media print/g')
 !#endif
 
-! https://doubledouble.top/ - soft anti-adb
-doubledouble.top##.totally-not-an-ad
-
 ! monitoruldevrancea. ro contextmenu select
 monitoruldevrancea.ro##+js(rmnt, script, stopPrntScr)
 monitoruldevrancea.ro##+js(rmnt, style, selection)
 
 ! https://www.myntra.com/sweatshirts-men?extra_search_param=isautosuggestentry%3atrue%3a%3aid%3a2297-sweatshirts-men&rawQuery=Sweatshirts%20Men - anti right click
 myntra.com##body[oncontextmenu="return!1"]:remove-attr(oncontextmenu)
-
-! https://www.reddit.com/r/uBlockOrigin/comments/1dkss3r/readcomiconline_detecting_adblock/
-readcomiconline.li##+js(rmnt, script, checkAdsBlocked)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/183397
 abema.tv##+js(trusted-click-element, #com-onboarding-OnboardingWelcomeModal__title + div .com-a-Button--dark)
@@ -7460,9 +7485,6 @@ abema.tv##.com-onboarding-OnboardingModalContainerView--enter-done
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24462
 lookmovie2.*##+js(trusted-replace-xhr-response, /Timeout":\d+/, Timeout":0, /api/v)
-
-! https://www.autopareri.com/ - soft anti-adb
-autopareri.com##+js(no-fetch-if, googlesyndication)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/1e5ndpo/video_player_quality_720p1080p_locked_unless_i/
 /wp-content/plugins/wpshield-content-protector/dist/app.min.js$script
@@ -7492,20 +7514,11 @@ anime3s.com,animet1.net##+js(acs, Object.defineProperty, DisableDevtool)
 ! https://github.com/uBlockOrigin/uAssets/issues/24842 - anti right click
 repack-games.com##+js(acs, jQuery, contextmenu)
 
-! https://pokemonsleep.club soft anti-adb
-@@||pokemonsleep.club^$script,1p
-
 ! https://github.com/AdguardTeam/AdguardFilters/issues/185501
 gigazine.net##div[id^="donate"]
 
-! https://github.com/uBlockOrigin/uAssets/issues/24975
-||cined.com/content/plugins/abss-adblock
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/1f4xmez/prevent_page_detecting_inactive_tab_or_in/
 cnn.com##+js(aeld, visibilitychange, dispatch)
-
-! https://www.etools.ch anti-adb
-@@||etools.ch^$ghide
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/1fck0c8/read_more_at_copypaste_spam/
 kentucky.com##+js(aeld, copy, linkPrefixMessage)
@@ -7518,16 +7531,10 @@ curseforge.com##+js(no-fetch-if, googlesyndication)
 lowfuelmotorsport.com##+js(set, Object.prototype.auth.redirectToLogin, noopFunc)
 !#endif
 
-! https://www.reddit.com/r/uBlockOrigin/comments/1fnvf02/camspider_adblock_notice/
-camspider.com##+js(set-local-storage-item, adblockNoticePermaDismiss, true)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/25442
 ||jetv.xyz/assets/js/devtools-detector.js$script,1p
 jetv.xyz##+js(trusted-suppress-native-method, Function.prototype.constructor, '"debugger"', abort)
 jetv.xyz##+js(nosiif, devtoolsDetector)
-
-! https://github.com/uBlockOrigin/uAssets/issues/25437
-html5.gamedistribution.com###gd__adblocker__overlay
 
 ! https://github.com/uBlockOrigin/uAssets/issues/25465
 nullforums.net##+js(rmnt, script, contextmenu)
@@ -7538,9 +7545,6 @@ mangareader.to##+js(aeld, contextmenu, _0x)
 ! hansa-online.de anti right click, select
 hansa-online.de##.td-post-content, .td-post-title:style(user-select: text !important; -ms-user-select: text !important; -moz-user-select: text !important; -khtml-user-select: text !important; -webkit-user-select: text !important; -webkit-touch-callout: default !important;)
 hansa-online.de##+js(ra, oncontextmenu, body, complete)
-
-! https://zonatmo.com/ - anti-adb
-zonatmo.com##+js(nostif, adb-enabled)
 
 ! anicrush.to anti-devtools
 southcloud.tv##+js(set, console.clear, undefined)
@@ -7583,13 +7587,6 @@ volokit2.com##html:style(user-select: text !important; -ms-user-select: text !im
 ! duracell.de anti contextmenu
 duracell.de##+js(aeld, contextmenu)
 
-! https://github.com/uBlockOrigin/uAssets/issues/25846
-ajanstv.com.tr##+js(nostif, adblock)
-###kanews-modal-adblock
-
-! https://github.com/uBlockOrigin/uAssets/issues/25883
-manhwa18.cc##+js(nostif, detect_modal)
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/1gi648d/web_page_is_opening_trying_to_redirect/ - anti right click, selection
 japonhentai.com##+js(acs, addEventListener, ays_tooltip)
 !#if cap_html_filtering
@@ -7607,9 +7604,6 @@ karistudio.com##div.confuse:remove()
 ! https://github.com/uBlockOrigin/uAssets/issues/26023
 cyberalert.gr##+js(acs, document.onkeydown, disableCTRL)
 
-! https://github.com/uBlockOrigin/uAssets/issues/26042
-@@||time.is^$script,1p
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/1guhbo5/allow_f12_on_cyberdomblog/
 cyberdom.blog##+js(rmnt, script, keyCode)
 
@@ -7623,9 +7617,6 @@ partsnl.nl##*:style(user-select: text !important; -ms-user-select: text !importa
 ! rds. live anti (right click, select)
 rds.live##+js(rmnt, script, contextmenu)
 rds.live##*:style(user-select: text !important; -ms-user-select: text !important; -moz-user-select: text !important; -khtml-user-select: text !important; -webkit-user-select: text !important; -webkit-touch-callout: default !important;)
-
-! https://github.com/uBlockOrigin/uAssets/issues/26159
-@@||autoweek.nl^$script,1p
 
 ! https://github.com/uBlockOrigin/uAssets/issues/26192
 coomer.su,kemono.su##[href="https://github.com/easylist/easylist/issues"]
@@ -7645,10 +7636,6 @@ bestcam.tv##+js(aeld, /contextmenu|keydown/, preventDefault)
 
 ! https://t.17track.net/en?nums=[tracking number] - anti devtools
 t.17track.net##+js(trusted-suppress-native-method, Function.prototype.constructor, '"debugger"', abort)
-
-! https://www.thedarkblues.co.uk/ - anti-adb
-||thedarkblues.co.uk/applications/adsense/interface/js/adbd.js^$script,1p
-thedarkblues.co.uk##.add_slot_header
 
 ! ark-unity.com anti adblock
 ark-unity.com##+js(no-fetch-if, /adsbygoogle|ad-manager/)
@@ -7692,24 +7679,14 @@ fandom.com##+js(set-cookie, leftPanelOpen, 0)
 fandom.com##+js(set-cookie, mdpsc, 1)
 !#endif
 
-! https://github.com/uBlockOrigin/uAssets/issues/26435
-baomidou.com##astro-island[opts^="{\"name\":\"CheckAdBlocked\""]
-
 ! https://github.com/uBlockOrigin/uAssets/issues/26478
 wallpapercat.com##+js(nano-sib, counter, 1000, 0.001)
 
 ! https://media.cm/d/ezu1uydqcv8x anti devtools
 ||media.cm/dev.js
 
-! https://github.com/uBlockOrigin/uAssets/issues/26511
-||images.$frame,1p,domain=nintendolife.com|purexbox.com|pushsquare.com|timeextension.com
-nintendolife.com##.insert-blocker
-
 ! https://github.com/uBlockOrigin/uAssets/issues/26533
 pngitem.com##+js(aopr, document.oncontextmenu)
-
-! t3n.de anti adblock in articles
-||assets.t3n.de/t3n-de/assets/t3n/2018/scripts/abdtn-$script,1p
 
 ! https://github.com/uBlockOrigin/uBlock-issues/issues/3491
 !#if env_firefox
@@ -7754,9 +7731,6 @@ nihongoaz.com##body:style(-webkit-touch-callout: default !important; -webkit-use
 espressocafe.ro##+js(rmnt, script, contextmenu)
 espressocafe.ro##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -khtml-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important; -webkit-tap-highlight-color: revert !important; cursor: revert !important;)
 
-! https://github.com/uBlockOrigin/uAssets/issues/26840
-@@||u.gg^$ghide
-
 ! https://abstream.to/7u23aksi148u - anti-devtools
 ||abstream.to/js/devtools-detector.js
 abstream.to##+js(acs, document.onkeydown)
@@ -7765,10 +7739,6 @@ abstream.to##+js(acs, document.onkeydown)
 astoryofmasasstruggles.com##+js(rmnt, script, /contextmenu|reEnable/)
 astoryofmasasstruggles.com##*:style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -khtml-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important; -webkit-tap-highlight-color: revert !important; cursor: revert !important;)
 astoryofmasasstruggles.com##style:has-text(@media print):remove()
-
-! https://www.pokeos.com/ - anti-adb banners
-pokeos.com##+js(no-fetch-if, doubleclick)
-||pokeos.com/pokeos-uploads/ads/adblock/$image
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/156165
 lemon8-app.com##+js(trusted-click-element, .seo-landing-modal-cancel-btn .design-system-button-container, , 500)
@@ -7786,9 +7756,6 @@ loverslab.com##+js(nano-sib)
 easyjet.com,ing.nl##+js(cookie-remover, ak_bmsc, when, scroll keydown)
 !#endif
 
-! https://forums.lanik.us/viewtopic.php?t=48667-www-cowcotland-com
-cowcotland.com##+js(rmnt, script, /adbl/i)
-
 ! https://www.reddit.com/r/uBlockOrigin/comments/1ii8dfa/adblock_detection_on_httpswhoisnovelcom_using/
 whoisnovel.com##+js(acs, document.oncontextmenu)
 whoisnovel.com##*::selection:style(background-color:#338FFF!important)
@@ -7805,9 +7772,6 @@ zabawkahurtownia.pl##*:style(-webkit-touch-callout: default !important; -webkit-
 ! https://github.com/uBlockOrigin/uAssets/issues/27289
 ! https://zalukaj.io/filmy/the-gorge
 filiser.eu,wishflix.cc,zalukaj.io##+js(nostif, (!0), 8000)
-
-! https://github.com/uBlockOrigin/uAssets/issues/27309
-bloxd.io##.AdBanner
 
 ! wasserstoff-leitprojekte.de anti right click
 wasserstoff-leitprojekte.de##+js(ra, oncontextmenu, body, complete)
@@ -7846,12 +7810,5 @@ pawastreams.pro##+js(nostif, debugger)
 samurai.wordoco.com##+js(acs, nocontextmenu)
 samurai.wordoco.com##body * :not(input):not(textarea):style(-webkit-touch-callout: default !important; -webkit-user-select: text !important; -khtml-user-select: text !important; -moz-user-select: text !important; -ms-user-select: text !important; user-select: text !important; -webkit-tap-highlight-color: revert !important; cursor: revert !important;)
 
-! https://sporttotal.tv/ - anti-adb
-sporttotal.tv##+js(no-fetch-if, doubleclick)
-sporttotal.tv##+js(set, HTMLImageElement.prototype.onerror, undefined)
-
 ! https://bcs16.ro/ - anti-contextmenu
 bcs16.ro##+js(aopw, document.oncontextmenu)
-
-! kunststoffe.de anti adblock annoyance
-@@||kunststoffe.de/ads_tracking.js$xhr,1p


### PR DESCRIPTION
Some cleanup; From the discussion: https://github.com/uBlockOrigin/uAssets/discussions/27718

- Using the existing `! START: Anti-adblock` and `! END: Anti-adblock` segments.
- Take all the anti-adblock rules and put them into this section
- 1st step for to make it easier to unbloat annoyances-others.txt
- Just moved, no removal or updates to the existing rules, that can be done later.
- If there is no issue, we can then create a new file and just copy/pasta START/END section into `annoyances-antiadblock.txt`

The list of rules (for a cleaner read) 30days expiry 29/03/2025
https://send.bitwarden.com/#iXBTQgBYx0GPfrKuADCiLg/olLq5IcDAkfnrQwIihG5VA