### PR TITLE
Remove obsolete rule for `theporndude.com`

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -4470,7 +4470,6 @@ noor-book.com##+js(no-fetch-if, ads)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/19002
 theporndude.com##+js(trusted-set-cookie, wallpaper, click)
-theporndude.com##body::before
 
 ! https://github.com/uBlockOrigin/uAssets/issues/15802
 @@||planhub.ca^$ghide


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://theporndude.com/`

### Describe the issue

Obsolete rule that blocks a page background.

### Screenshot(s)

<details><summary>Screenshot:</summary>

![image](https://github.com/user-attachments/assets/feb08f1a-d6fd-4510-b1ae-330bebae36f2)

</details>

### Versions

- Browser/version: Chrome 134
- uBlock Origin version: 1.63.2

### Settings

- n/a

### Notes
