### PR TITLE
Remove outdated rule for `visitmama.com`

### DIFF
--- a/filters/filters-2020.txt
+++ b/filters/filters-2020.txt
@@ -2033,9 +2033,6 @@ dafideff.com##+js(acs, addEventListener, google_ad_client)
 ! https://github.com/NanoMeow/QuickReports/issues/4530
 4players.de##+js(set, adBlockerDetected, false)
 
-! https://github.com/uBlockOrigin/uAssets/issues/7789
-@@||visitmama.com^$ghide
-
 ! https://github.com/NanoMeow/QuickReports/issues/4536
 ! world4ufree. plus antiadblock
 world4ufree.*##+js(aeld, , _0x)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.visitmama.com/games-like-being-a-dik-y/`

### Describe the issue

This rule prevents from blocking share buttons with  https://github.com/AdguardTeam/AdguardFilters/blob/38e37a1b71c4289698cf954dc2f73f39d7689bcf/SocialFilter/sections/general_elemhide.txt#L1052

### Screenshot(s)

<details><summary>Screenshot:</summary>

![image](https://github.com/user-attachments/assets/ddc340bf-1b53-4964-884a-feae4d7f0e51)

</details>

### Versions

- Browser/version: Chrome 135
- uBlock Origin version: 1.63.2

### Settings

none

### Notes
