### PR TITLE
spaziogames.it: nuisance

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -1592,9 +1592,9 @@ derstandard.at,derstandard.de,faz.net##+js(trusted-click-element, button[title="
 
 ! iubenda-cs-accept-btn
 ! https://github.com/uBlockOrigin/uAssets/pull/24738
-ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,tuttoandroid.net,tuttotech.net##+js(trusted-click-element, button.iubenda-cs-accept-btn, , 1000)
-ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,tuttoandroid.net,tuttotech.net###iubenda-cs-banner:style(visibility: hidden !important;)
-ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,tuttoandroid.net,tuttotech.net##html:style(overflow: auto !important;)
+ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net##+js(trusted-click-element, button.iubenda-cs-accept-btn, , 1000)
+ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net###iubenda-cs-banner:style(visibility: hidden !important;)
+ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net##html:style(overflow: auto !important;)
 ! https://github.com/uBlockOrigin/uAssets/pull/25606
 ! https://github.com/uBlockOrigin/uAssets/pull/25324
 ilgazzettino.it,ilmessaggero.it,ilsecoloxix.it###iubenda-cs-banner:style(visibility: hidden !important;)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.spaziogames.it/articoli/nintendo-switch-2-faq`

### Describe the issue

cookie warning

### Screenshot(s)

<img width="1131" src="https://github.com/user-attachments/assets/7695ce38-af1c-496c-916f-e9ee1ed7b193" />

### Versions

- Browser/version: Firefox: 137
- uBlock Origin version: 1.63.2

### Settings

<details>

```yaml
filterset (summary):
 network: 194411
 cosmetic: 190193
 scriptlet: 53407
 html: 2623
listset (total-discarded, last-updated):
 added:
  adguard-generic: 105479-4256, 1m
  adguard-social: 23896-52, 1m
  adguard-cookies: 33782-62, 1m
  ublock-cookies-adguard: 4183-60, 1m
  adguard-popup-overlays: 29082-2137, 1m
  adguard-mobile-app-banners: 5982-96, 1m
  adguard-other-annoyances: 14790-395, 1m
  adguard-widgets: 2926-19, 1m
  ublock-annoyances: 5904-189, 1m
  ITA-0: 6402-71, 1m
 default:
  user-filters: 1-0, never
  ublock-filters: 40740-123, 1m
  ublock-badware: 11640-7, 1m
  ublock-privacy: 2778-21, 1m
  ublock-unbreak: 2623-1, 1m
  ublock-quick-fixes: 323-13, 1m
  easylist: 69254-1465, 1m
  easyprivacy: 53875-138, 1m
  urlhaus-1: 33895-0, 1m
  plowe-0: 3455-943, 1m
filterset (user): [array of 1 redacted]
userSettings:
 userFiltersTrusted: true
hiddenSettings:
 trustedListPrefixes: ublock- user-
supportStats:
 allReadyAfter: 1956 ms
 maxAssetCacheWait: 1033 ms
 cacheBackend: indexedDB
popupPanel:
 blocked: 2
 network:
  googletagmanager.com: 1
  iubenda.com: 1
 extended:
  ##.customads
  ##.items-center > aside:has(> a[aria-label^="Condividi"])
  ###sticky_ads
  ##div[style="min-height: 280px"]
  ##a[href^="whatsapp://send"]
  ##a[href^="https://twitter.com/intent/tweet?"]
  ##a[href^="https://telegram.me/share/url?"]
  ##a[href^="https://www.facebook.com/sharer/sharer.php"]
  ##a[href^="https://www.linkedin.com/shareArticle"]
  ###taboola-below-article-thumbnails
  ##+js(abort-current-script, $, .test)
  ##+js(abort-current-script, EventTarget.prototype.addEventListen…
  ##+js(abort-on-property-read, anOptions)
```
</details>

### Notes

Existing rules seems working well.
