### PR TITLE
Fix khanpc.com

### DIFF
--- a/filters/filters-2025.txt
+++ b/filters/filters-2025.txt
@@ -1356,3 +1356,6 @@ streamup.ws##+js(set, detectSandbox, noopFunc)
 
 ! animenexus.in ad popups
 animenexus.in##+js(nowoif, _blank)
+
+! https://khanpc.com/cascadeur-incl-patch/ fake download button
+khanpc.com##a[href^="https://guidepaper.website/"]


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://khanpc.com/cascadeur-incl-patch/`

### Describe the issue

fake download button

### Screenshot(s)

<details><summary>Screenshot:</summary>
<p>

![image](https://github.com/user-attachments/assets/3df45347-684f-464e-bc06-d65ff9c057a7)

</p>
</details> 

### Versions

- Browser/version: Chrome 135
- uBlock Origin version: 1.63.2

### Settings

none

### Notes
