### PR TITLE
address #28025 (macitynet.it: nuisance)

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -1594,9 +1594,9 @@ derstandard.at,derstandard.de,faz.net##+js(trusted-click-element, button[title="
 
 ! iubenda-cs-accept-btn
 ! https://github.com/uBlockOrigin/uAssets/pull/24738
-ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net##+js(trusted-click-element, button.iubenda-cs-accept-btn, , 1000)
-ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net###iubenda-cs-banner:style(visibility: hidden !important;)
-ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net##html:style(overflow: auto !important;)
+ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,macitynet.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net##+js(trusted-click-element, button.iubenda-cs-accept-btn, , 1000)
+ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,macitynet.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net###iubenda-cs-banner:style(visibility: hidden !important;)
+ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,macitynet.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net##html:style(overflow: auto !important;)
 ! https://github.com/uBlockOrigin/uAssets/pull/25606
 ! https://github.com/uBlockOrigin/uAssets/pull/25324
 ilgazzettino.it,ilmessaggero.it,ilsecoloxix.it###iubenda-cs-banner:style(visibility: hidden !important;)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.macitynet.it/`

### Describe the issue

This pull could address the issue https://github.com/uBlockOrigin/uAssets/issues/28025

### Screenshot(s)

<details>
<img width="1129" alt="Image" src="https://github.com/user-attachments/assets/b1b62abf-fdac-4d32-a3ab-b37c69756819" />
</details>

### Versions

- Browser/version: Firefox 137.0.2
- uBlock Origin version: 1.63.2

### Settings

<details>

```yaml
uBlock Origin: 1.63.2
Firefox: 120
filterset (summary):
 network: 194778
 cosmetic: 190561
 scriptlet: 53640
 html: 2621
listset (total-discarded, last-updated):
 added:
  adguard-generic: 105660-547, now
  adguard-social: 23899-49, now
  adguard-cookies: 33928-63, now
  ublock-cookies-adguard: 4265-60, now
  adguard-popup-overlays: 29204-2140, now
  adguard-mobile-app-banners: 6008-96, now
  adguard-other-annoyances: 14847-394, now
  adguard-widgets: 2936-19, now
  ublock-annoyances: 5988-207, now
  ITA-0: 6258-72, 1m
 default:
  user-filters: 0-0, never
  ublock-filters: 40719-3584, 1m Δ
  ublock-badware: 11706-132, 1m Δ
  ublock-privacy: 2761-9, now
  ublock-unbreak: 2622-81, 1m Δ
  ublock-quick-fixes: 260-42, 1m Δ
  easylist: 68934-1256, now
  easyprivacy: 53937-140, 1m Δ
  urlhaus-1: 34380-0, 1m
  plowe-0: 3447-941, now
filterset (user): [empty]
userSettings:
 userFiltersTrusted: true
hiddenSettings:
 trustedListPrefixes: ublock- user-
supportStats:
 allReadyAfter: 472 ms (selfie)
 maxAssetCacheWait: 335 ms
 cacheBackend: indexedDB
popupPanel:
 blocked: 10
 network:
  macitynet.it: 4
  cloudflareinsights.com: 1
  googletagmanager.com: 1
  iubenda.com: 1
  mailerlite.com: 2
  onesignal.com: 1
 extended:
  ##img[width="300"]
  ##.td-a-rec
  ##.adv-300
  ##.td-adspot-title
```
</details>

### Notes

AdGuard fix for the same issue:
`macitynet.it#%#//scriptlet('trusted-click-element', '.iubenda-cs-visible .iubenda-cs-accept-btn')`
