### PR TITLE
Fix Modrinth banner ads

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2665,6 +2665,7 @@ modrinth.com##section.normal-page__content :is([href^="https://ModdersAgainstBlo
 modrinth.com##section.normal-page__content p > img[alt^="Use code"]
 curseforge.com##:is(.project-description,div.project-detail__content) [href^="/linkout?remoteUrl=http"]:is([href*="fxco.ca"]) > img
 ||i.imgur.com/h4556XW.gif$image,3p
+||i.imgur.com/GgSxkKv.png$image,3p
 curseforge.com##:is(.project-description,div.project-detail__content) p > img[alt^="Use code"]
 modrinth.com,curseforge.com##+js(rmnt, h2, /creeperhost/i)
 


### PR DESCRIPTION
remove additional qualification of having a url parameter since the format has changed.
promo codes no longer use the url parameter and instead just some path.

Also updated some direct imgur includes.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://modrinth.com/mod/spelunkery`
`https://modrinth.com/mod/immediatelyfast`

### Describe the issue

Banner ads are visible again

### Screenshot(s)

![image](https://github.com/user-attachments/assets/15a826a6-e7b0-49ce-8aef-99b5ee2ca745)
![image 2](https://github.com/user-attachments/assets/e1ec8e74-bfa0-4490-94c4-3b056ce9aaa6)

### Versions

- Browser/version: Firefox 137.0.2 (64-bit)
- uBlock Origin version: 1.63.2

### Settings

-

### Notes

