### PR TITLE
CleanUp 1337x.to

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -138,60 +138,14 @@ xvideos.com,xvideos2.com##+js(aeld, click, ShouldShow)
 xvideos.com##a[href*="/go.php?"][href*="&ad="]
 /vast.php?idzone=
 
-! https://github.com/uBlockOrigin/uAssets/issues/163
-! https://github.com/uBlockOrigin/uAssets/issues/534
-! https://github.com/uBlockOrigin/uAssets/issues/1286
-! https://github.com/uBlockOrigin/uAssets/commit/ebbef70dba69e38946329793dc00d988d1cbb85e#commitcomment-34299631
-1337x.*##+js(rmnt, script, style)
-1337x.*##+js(aost, document.createElement, _0x)
-1337x.*,x1337x.*##+js(nowoif, , 1)
-1337x.*##+js(aopr, afScript)
-1337x.*##+js(nostif, adb)
-1337x.*##^script:has-text(admc)
-x1337x.*##+js(acs, setTimeout, admc)
-x1337x.*##+js(aopr, Adcash)
-1337x.*,x1337x.*##.stream-torrent
-1337x.*,x1337x.*##.link-info-stream
-1337x.*##.download-links-dontblock > LI:has-text(Anon)
-1337x.*##.download-links-dontblock > LI:has-text(Stream)
-1337x.*##a[href^="/redirectmusic.php"]
-1337x.*##a[href^="/spyoff"]
-1337x.*##a[href*="//steepto.com/"]
-1337x.*##[href*="vpn"]
-1337x.*##[onclick*="vpn"]
-1337x.*##[href^="/anoy"]
-1337x.*,x1337x.*##.no-top-radius div > a[href]:has-text(VPN)
-/^https:\/\/x?1337x\.(?:[0-9a-z]{3,9}\.)?[a-z]{2,4}\/(?:css\/)?(?:images\/)?[0-9a-zA-Z]+\.(?:gif|jpe?g|png)/$image,1p,domain=1337x.*|1337x.g3g.*|x1337x.*|unblockit.*
-||1337x.*/sw.js^
-! https://github.com/uBlockOrigin/uAssets/issues/635
-! https://www.reddit.com/r/uBlockOrigin/comments/81hcu5/1337xto_annoying_popup/
-! https://www.reddit.com/r/uBlockOrigin/comments/bpm1l9/trying_to_download_something_from_13377x_and_keep/
-13377x.*##+js(acs, decodeURI, decodeURIComponent)
-1337x.*,x1337x.*##+js(nowebrtc)
-x1337x.eu##.mgbox
-! https://github.com/uBlockOrigin/uAssets/issues/6606
-1337x.*##+js(aopr, AaDetector)
-@@||torrage.info/torrent.php$popup,domain=1337x.to
-! https://github.com/uBlockOrigin/uAssets/issues/23025
-1337x.*,x1337x.*##+js(aeld, popstate)
-! https://github.com/uBlockOrigin/uAssets/issues/23093
-! https://github.com/uBlockOrigin/uAssets/issues/24117
-! https://www.reddit.com/r/uBlockOrigin/comments/1dz8i4c/irritating_as_hell_invisible_overlay_on_1337to/
 ! https://github.com/uBlockOrigin/uAssets/issues/24485
-1337x.*,x1337x.*##+js(aost, navigator, FingerprintJS)
-1337x.*,x1337x.*##+js(aost, localStorage, /https:\/\/x?1337x\.[a-z]+\/\S+\.js/)
-1337x.*,x1337x.*##+js(aost, onload, /https:\/\/x?1337x\.[a-z]+\/\S+\.js/)
-/ma.js^$script,domain=1337x.*|x1337x.*
-/mm.js^$script,domain=1337x.*|x1337x.*
-! https://github.com/AdguardTeam/AdguardFilters/issues/190816
-x1337x.*##+js(aopw, Adcash)
-! https://www.reddit.com/r/uBlockOrigin/comments/1gmaf49/how_to_get_rid_of_this_vpn_ad_on/
+1337x.*,x1337x.*,1337x.ninjaproxy1.com##[onclick*="vpn"]
+1337x.*,x1337x.*##+js(nowebrtc)
 !#if cap_html_filtering
-1337x.ninjaproxy1.com##^script:has-text(/h=decodeURIComponent|popundersPerIP/)
+1337x.*,x1337x.*,1337x.ninjaproxy1.com##^script:has-text(/h=decodeURIComponent|popundersPerIP/)
 !#else
-1337x.ninjaproxy1.com##+js(rmnt, script, /h=decodeURIComponent|popundersPerIP/)
+1337x.*,x1337x.*,1337x.ninjaproxy1.com##+js(rmnt, script, /h=decodeURIComponent|popundersPerIP/)
 !#endif
-1337x.ninjaproxy1.com##div[onclick^="location.href='https://1337x.onlyvpn.site/"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7273
 cheatcloud.cc,cheater.ninja,cheatermad.com,cheatsquad.gg##+js(nano-sib, clearInterval)

--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -142,9 +142,9 @@ xvideos.com##a[href*="/go.php?"][href*="&ad="]
 1337x.*,x1337x.*,1337x.ninjaproxy1.com##[onclick*="vpn"]
 1337x.*,x1337x.*##+js(nowebrtc)
 !#if cap_html_filtering
-1337x.*,x1337x.*,1337x.ninjaproxy1.com##^script:has-text(/h=decodeURIComponent|popundersPerIP/)
+1337x.ninjaproxy1.com##^script:has-text(/h=decodeURIComponent|popundersPerIP/)
 !#else
-1337x.*,x1337x.*,1337x.ninjaproxy1.com##+js(rmnt, script, /h=decodeURIComponent|popundersPerIP/)
+1337x.ninjaproxy1.com##+js(rmnt, script, /h=decodeURIComponent|popundersPerIP/)
 !#endif
 
 ! https://github.com/uBlockOrigin/uAssets/issues/7273

--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -139,8 +139,11 @@ xvideos.com##a[href*="/go.php?"][href*="&ad="]
 /vast.php?idzone=
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24485
+/ma.js^$script,domain=1337x.*|x1337x.*|1337x.ninjaproxy1.com
+/mm.js^$script,domain=1337x.*|x1337x.*|1337x.ninjaproxy1.com
+1337x.*,x1337x.*,1337x.ninjaproxy1.com##[href*="vpn"]
 1337x.*,x1337x.*,1337x.ninjaproxy1.com##[onclick*="vpn"]
-1337x.*,x1337x.*##+js(nowebrtc)
+1337x.*,x1337x.*,1337x.ninjaproxy1.com##+js(nowebrtc)
 !#if cap_html_filtering
 1337x.ninjaproxy1.com##^script:has-text(/h=decodeURIComponent|popundersPerIP/)
 !#else


### PR DESCRIPTION
Removed all obsolete rules
Please do verify if everything if fine or not
One of the important rule is in filters-general
`1337x.*##^script:has-text(adserverDomain)`
```
1337x.to