### PR TITLE
fix-AG#203928

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -1595,9 +1595,9 @@ derstandard.at,derstandard.de,faz.net##+js(trusted-click-element, button[title="
 
 ! iubenda-cs-accept-btn
 ! https://github.com/uBlockOrigin/uAssets/pull/24738
-ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,macitynet.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net##+js(trusted-click-element, button.iubenda-cs-accept-btn, , 1000)
-ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,macitynet.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net###iubenda-cs-banner:style(visibility: hidden !important;)
-ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,macitynet.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net##html:style(overflow: auto !important;)
+automoto.it,ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,macitynet.it,moto.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net##+js(trusted-click-element, button.iubenda-cs-accept-btn, , 1000)
+automoto.it,ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,macitynet.it,moto.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net###iubenda-cs-banner:style(visibility: hidden !important;)
+automoto.it,ansa.it,delladio.it,huffingtonpost.it,internazionale.it,lastampa.it,macitynet.it,moto.it,movieplayer.it,multiplayer.it,repubblica.it,tomshw.it,spaziogames.it,tuttoandroid.net,tuttotech.net##html:style(overflow: auto !important;)
 ! https://github.com/uBlockOrigin/uAssets/pull/25606
 ! https://github.com/uBlockOrigin/uAssets/pull/25324
 ilgazzettino.it,ilmessaggero.it,ilsecoloxix.it###iubenda-cs-banner:style(visibility: hidden !important;)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs


```
www.moto.it
www.automoto.it
```

### Describe the issue

AG issue:
https://github.com/AdguardTeam/AdguardFilters/issues/203928#event-17472042339

AG fix:
https://github.com/AdguardTeam/AdguardFilters/commit/b2963d8fbe509309a7b10abea4d0d4bb2f28b0b4

### Screenshot(s)

<details>
<img width="1116" alt="moto" src="https://github.com/user-attachments/assets/5c0a7dce-2f18-43ec-b333-a31b25a3471d" />
</details>

### Versions

- Browser/version: 138.0.1
- uBlock Origin version: 1.63.2

### Settings

<details>

```yaml
uBlock Origin: 1.63.2
Firefox: 138.0.1
filterset (summary):
 network: 196208
 cosmetic: 191491
 scriptlet: 54021
 html: 2629
listset (total-discarded, last-updated):
 added:
  adguard-generic: 102147-4248, now
  adguard-social: 23982-49, now
  adguard-cookies: 34101-65, now
  ublock-cookies-adguard: 4405-63, now
  adguard-popup-overlays: 29341-2143, now
  adguard-mobile-app-banners: 6079-96, now
  adguard-other-annoyances: 14915-392, now
  adguard-widgets: 2949-19, now
  ublock-annoyances: 6006-207, now
  ITA-0: 6273-72, now
 default:
  user-filters: 0-0, never
  ublock-filters: 40707-114, now
  ublock-badware: 11842-12, now
  ublock-privacy: 2772-4, now
  ublock-unbreak: 2672-1, now
  ublock-quick-fixes: 385-21, now
  easylist: 70693-1264, now
  easyprivacy: 54197-142, now
  urlhaus-1: 37620-1, now
  plowe-0: 3441-937, now
filterset (user): [empty]
userSettings:
 userFiltersTrusted: true
hiddenSettings:
 trustedListPrefixes: ublock- user-
supportStats:
 allReadyAfter: 1621 ms
 maxAssetCacheWait: 1120 ms
 cacheBackend: indexedDB
popupPanel:
 blocked: 5
 network:
  b-cdn.net: 1
  doubleclick.net: 1
  google.com: 1
  googletagmanager.com: 1
  publytics.net: 1
 extended:
  ##.app-masthead
  ##.crm-unit-bx1
  ##.crm-unit-bx2
  ##.crm-unit-bx3
  ##.crm-unit-bx4
  ##.crm-unit-mh
  ##.hpblock.linkedimage
  ##.mit-skin-spacer
  ###fb-root:not(body):not(html)
  ##.OUTBRAIN
  ###credential_picker_container
  ##+js(prevent-fetch, googlesyndication)
  ##+js(prevent-fetch, pagead2.googlesyndication.com)
```
</details>

### Notes
Not sure if `##html:style(overflow: auto !important;)` is needed as well.
