### PR TITLE
add urlskip filter for physicsandmathstutor.com to access pdf files d…

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7914,6 +7914,3 @@ simptown.su##.juice_ban
 
 ! https://labreakfastburrito.com/ - pie adblock
 labreakfastburrito.com##+js(aopr, PieScriptConfig)
-
-! https://github.com/uBlockOrigin/uAssets/pull/28192
-||physicsandmathstutor.com/pdf-pages$urlskip=?pdf

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7915,5 +7915,5 @@ simptown.su##.juice_ban
 ! https://labreakfastburrito.com/ - pie adblock
 labreakfastburrito.com##+js(aopr, PieScriptConfig)
 
-! https://github.com/uBlockOrigin/uAssets/pulls/[PLACEHOLDER SO I CAN GET A PR NUMBER]
+! https://github.com/uBlockOrigin/uAssets/pull/28192
 ||physicsandmathstutor.com/pdf-pages$urlskip=?pdf

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7914,3 +7914,6 @@ simptown.su##.juice_ban
 
 ! https://labreakfastburrito.com/ - pie adblock
 labreakfastburrito.com##+js(aopr, PieScriptConfig)
+
+! https://github.com/uBlockOrigin/uAssets/pulls/[PLACEHOLDER SO I CAN GET A PR NUMBER]
+||physicsandmathstutor.com/pdf-pages$urlskip=?pdf

--- a/filters/filters-2025.txt
+++ b/filters/filters-2025.txt
@@ -1576,3 +1576,6 @@ asianboy.fans##+js(trusted-suppress-native-method, DOMTokenList.prototype.add, '
 
 ! https://github.com/uBlockOrigin/uAssets/issues/28189
 @@||seelen.io^$script,1p
+
+! https://github.com/uBlockOrigin/uAssets/pull/28192
+||physicsandmathstutor.com/pdf-pages$urlskip=?pdf


### PR DESCRIPTION
…irectly

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Any URL of the form
`https://www.physicsandmathstutor.com/pdf-pages/?pdf=[some URL-escaped URL]`
For example:
`https://www.physicsandmathstutor.com/pdf-pages/?pdf=https%3A%2F%2Fpmt.physicsandmathstutor.com%2Fdownload%2FPhysics%2FA-level%2FPast-Papers%2FCAIE%2FPaper-5%2FQP%2FJune%202008%20QP.pdf`

### Describe the issue

The website uses a wrapper page to display PDF files alongside advertisements, by iframing the PDF based on a url parameter.  The PDF file can be accessed directly from the URL in said parameter, which removes the sidebar.

uBO already removes the adverts from the sidebar, but the sidebar itself remains.  This pull request adds a filter to remove the sidebar by redirecting requests to the pdf iframe page to the referenced pdf.

### Screenshot(s)

Note that the issue most likely does not occur on mobile or safari (see note 3)

Without the filter, a (blank with uBO, advertising-filled without uBO) sidebar appears, and the file referenced in the `pdf` parameter is loaded in an iframe:
![2025-05-06T11:28:22,701862875+01:00](https://github.com/user-attachments/assets/96892f87-ad4d-4a60-8a45-6d40db5ff11f)

With the filter, the pdf file is loaded directly by the browser (and thus no sidebar) (in Firefox, this is equivalent to right-clicking the PDF, hovering over "This Frame" in the context menu, and clicking "Show Only This Frame"
![2025-05-06T11:32:05,548153923+01:00](https://github.com/user-attachments/assets/28d7a606-1969-4e52-8e62-42ab0023bcea)



### Versions

- Browser/version: Firefox 135.0.1 (64-bit), from Fedora 41 repositories
- uBlock Origin version: 1.63.2

### Settings

- Custom filters for specific websites, including the filter added by this PR
  - I have tested without these filters and the issue still occurs
- All "Annoyances" filters enabled (issue still occurs regardless of whether or not they are enabled)

### Notes

1)The issue can also be corrected using a cosmetic filter (namely `www.physicsandmathstutor.com##.pdf-sidebar`), but this is less optimal since using `urlskip` reduces the total volume of data transferred (by not loading the HTML for the page as well as the PDF) - therefore I decided not to propose that as a solution.
2)The pages in question are not tracking redirects or similar (as would typically merit a `urlskip` filter as far as I can tell), since they generally don't perform any redirect (see note 3 for the exception), but instead exist to display advertising in a sidebar alongside a PDF.
3)The pages contain inline javascript (in the DOM inspector it is contained in a `<script>` block at the very end of the `<body>`) that serves to determine if the user is using Safari (via user-agent) or a mobile browser (via some heuristics involving determining if the browser has touch support in JS as well as the display width), in which case it sets `window.location.href` to the value of the decoded url parameter `pdf`.  If none of those conditions were met, it instead sets the `src` attribute of an `<iframe>` to this url parameter value (so that the PDF is displayed with the browsers native viewer but the page can still display advertising).
4)You can actually put an arbitrary URL in the `pdf` parameter and it will load in the iframe (and as far as I can tell it will also get redirected to on mobile) since this is not prevented by the pages CSP (or any validation in the inline JS).  Therefore, the urlskip filter does not seem like it would meaningfully weaken security (as arbitrary redirect is already possible).