### PR TITLE
filters: block the duckduckgo browser ad

### DIFF
--- a/filters/filters-2025.txt
+++ b/filters/filters-2025.txt
@@ -1633,3 +1633,6 @@ l2crypt.com##+js(noeval-if, ads)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/28317
 brawlify.com##+js(rmnt, script, /adb/i)
+
+! duckduckgo browser ad
+duckduckgo.com##[data-testid=serp-popover-promo]


### PR DESCRIPTION
### URL(s) where the issue occurs
https://duckduckgo.com/?q=frogs&ia=web
or any other search query

### Describe the issue
the ddg browser ad is shown on the search results page from time to time. easily reproducible with clear local storage & cookies. it's not blocked by the current ad-blocking filters.

### Screenshot(s)
<img width="403" alt="image" src="https://github.com/user-attachments/assets/3331d8b9-7ee1-44c4-8b9f-d859f2c11b9e" />

### Versions
- Browser/version: Chromium 136.0.7103.92
- uBlock Origin version: 1.63.2

### Settings
default uBo filters