### PR TITLE
Fix detection on bilinovel.com / linovelib.com

### DIFF
--- a/filters/filters-2025.txt
+++ b/filters/filters-2025.txt
@@ -1697,3 +1697,7 @@ thelinuxcode.com##+js(set-cookie, pum-44957, true)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/28401
 feedly.com##.SponsorPrompt
+
+! https://github.com/uBlockOrigin/uAssets/issues/28436#issuecomment-2898063180
+bilinovel.com##+js(acs, checkAndHandleAdBlock)
+linovelib.com##+js(acs, checkAndHandleAdBlock)


### PR DESCRIPTION
Fixed #28436

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

- `https://www.bilinovel.com/novel/3345/catalog`
- `https://www.bilinovel.com/novel/{book-id}/catalog`

### Describe the issue

The `checkAndHandleAdBlock()` function checks for divs with ads and see if they are empty, and if so, flags adblock is enabled. A random class name and a corresponding style is generated, which will be then inserted to hide page contents. 

To block such classes with random names, I just aborted whole function. It might be possible to use cosmetic filters but I figured blocking the whole function (along with the inefficient loop) would be better.

### Screenshot(s)
Debugger:
<details>

![image](https://github.com/user-attachments/assets/8b942862-a5c4-4c18-a6d8-f6ce01be0387)

</details>

Before: 
<details>

![image](https://github.com/user-attachments/assets/b8332cc0-1fc8-4454-b707-56803b1f7e74)

</details>

After:
<details> 

![image](https://github.com/user-attachments/assets/dfc5f469-9c8f-464b-af7f-ba39b1f50ac6)

</details>

### Versions

- Browser/version: Firefox/138.0.4 Chrome/136.0
- uBlock Origin version: 1.64.0

### Settings

- _None, Checked after resetting to default configs_

### Notes

A breakpoint is set for the div with id `catelogX`, which revealed `https://www.bilinovel.com/themes/zhmb/js/newread.js?cs-1.7` is the culprit. This script however does more things than adblock detection, so I just defused the offending function instead of blocking the whole script. 
