### PR TITLE
explainxkcd ad frame fix

### DIFF
--- a/filters/filters-2025.txt
+++ b/filters/filters-2025.txt
@@ -1775,6 +1775,10 @@ anime3rb.com##div[x-data*="countdown"]
 ! https://github.com/uBlockOrigin/uAssets/issues/28548
 gadgetbond.com##+js(no-fetch-if, adsbygoogle)
 
+! https://www.explainxkcd.com (explainxkcd incomplete ad frame)
+www.explainxkcd.com###p-Ads
+
+
 ! https://github.com/uBlockOrigin/uAssets/issues/28531
 updateroj24.com##+js(no-fetch-if, adsbygoogle)
 updateroj24.com##.ad-container


### PR DESCRIPTION
### URL(s) where the issue occurs

https://explainxkcd.com

### Describe the issue

the version without this patch leaves a residual "ad" text around the blocked google ad

### Screenshot(s)


### Versions

- Browser/version: Firefox 139 beta, but not really relevant in this issue, as exact fix is provided
- uBlock Origin version: issue persists since ~2022

### Settings

full change to the ruleset proposed

### Notes

modified MediaWiki, one might want to expand this filter rule into more instances
used uBO's "create rule" tool and painstakingly identified the element to be deleted to remove the residual around the blocked ad frame
