### PR TITLE
remove buzzheavier.com first click ad

### DIFF
--- a/filters/filters-2025.txt
+++ b/filters/filters-2025.txt
@@ -1873,3 +1873,6 @@ nontonx.com##+js(rmnt, script, getComputedStyle)
 
 ! https://pelisflix20.biz/ - ads
 pelisflix20.*>>##+js(nowoif, /^ [-\d]/)
+
+! https://buzzheavier.com/ - first click ad
+buzzheavier.com##+js(set, window.adLink, null)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`[At least one URL for a web page where the clearly described issue occurs is **mandatory**. The backticks surrounding the URLs is important, it prevents the URL from being clickable. Warn with "NSFW" where applicable.]`
`https://buzzheavier.com/a7v3g2l0m79i`

### Describe the issue

[Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder.]
Buzzheavier shows an ad on the first click, and setting window.adLink to null stops it from showing the ad.

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: Brave/1.79.123
- uBlock Origin version: 1.64.0

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
