### PR TITLE
threads.com rules no longer needed

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7657,12 +7657,6 @@ simptown.su##.juice_ban
 ! https://labreakfastburrito.com/ - pie adblock
 labreakfastburrito.com##+js(aopr, PieScriptConfig)
 
-! https://github.com/uBlockOrigin/uAssets/issues/28389
-!#if env_mobile
-threads.com##+js(trusted-set-cookie-reload, cb, 5_2030_01_01_1)
-threads.com##+js(set-session-storage-item, barcelona_mobile_upsell_state, 1)
-!#endif
-
 ! https://github.com/uBlockOrigin/uAssets/issues/28415
 bangbros.com##+js(set-cookie, iAgree, 1)
 


### PR DESCRIPTION
Causing endless loading.

Fixed upstream https://github.com/easylist/easylist/commit/801cf5bf9d140471b35de6fd3aa0f7ede299c161