### PR TITLE
Remove sponsored articles from carrefour.fr

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7691,5 +7691,8 @@ zeustranslations.blogspot.com##+js(acs, alert, location.href)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/209195
 yuuki.me##+js(nostif, adsbygoogle)
 
+! carrefour.fr remove sponsored articles
+carrefour.fr##li:has(article:has(.product-list-card-plp-grid__sponsored))
+
 ! autodoc - unlock autoscrolling with the middle mouse button
 auto-doc.*,autodoc.*,autodoc24.*,topautoosat.fi,autoteiledirekt.de,autoczescionline24.pl,tuttoautoricambi.it,onlinecarparts.co.uk,autoalkatreszek24.hu,autodielyonline24.sk,reservdelar24.se,pecasauto24.pt,reservedeler24.co.no,piecesauto24.lu,rezervesdalas24.lv,besteonderdelen.nl,recambioscoche.es,antallaktikaexartimata.gr,piecesauto.fr,teile-direkt.ch##+js(aeld, mousedown, function(t))


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://www.carrefour.fr/s?q=chips

### Describe the issue

Remove the sponsored articles

### Screenshot(s)

<img width="664" height="336" alt="Pasted Image" src="https://github.com/user-attachments/assets/d0fe4077-d182-4926-946f-028104acff8b" />

### Versions

- Browser/version: Firefox/140
- uBlock Origin version: 1.64.0

### Settings

No changes

### Notes

None
