### PR TITLE
Update badware.txt

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6248,3 +6248,5 @@ weightlossdiet.top##+js(acs, open, executeCode)
 ||talent-applications.com^$all
 ||talents-application.com^$all
 ||com^$doc,ipaddress=38.114.120.167
+
+||ctent.povvverz.one/jshexo.hj*


### PR DESCRIPTION
### New filter added

`||ctent.povvverz.one/jshexo.hj*`

### URL(s) where the issue occurs

Proof of malicious activity: `https://ctent.povvverz.one/jshexo.hj?lb=2&tgt=22&z=22&abl=1`
Example powvideo URL where behaviour is observed: `https://powcloud.one/sl5vsmp9s1fz`

### Describe the issue

This is a script that embeds malicious URLs onto the pop-ups served by powvideo (`powcloud.one`)

### Versions

- Browser/version: Brave 138 (138.0.0.0) macOS x86_64
- uBlock Origin version: 1.65.0

### Malicious activity - Detailed explanation

Inspecting that script will lead to `https://s0-greate.net/p/696170?c=zc_696170`, which after simple deobfuscation using tools like webcrack and b64 decoders, will show it's just an adware injector, as seen in [this pastebin](https://www.codebin.cc/code/cmd3wtjap0001kz034ey9pcyd:7fSY2qCFm6guMT5JnwVxB5ZV5q2acR5rC8ryqS84FwDX).