### PR TITLE
fix anti-adblock for tarnkappe.info

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -5437,10 +5437,9 @@ poipiku.com##*:style(-webkit-touch-callout: default !important; -webkit-user-sel
 duhoctrungquoc.vn###danger_adblock
 
 ! tarnkappe. info anti adblock annoyance
-tarnkappe.info##+js(set, traffective, true)
-tarnkappe.info##.around-desktop-ad:upward(1)
-tarnkappe.info##div[style="min-height: 300px;"]
-tarnkappe.info##.interscroller-wrapper[style^="height: 700px; "]
+tarnkappe.info##[style*="filter: blur"]:style(filter: none !important; pointer-events: initial !important;)
+tarnkappe.info##[class^="adblock-card-overlay"]
+tarnkappe.info##[class^="adblock-post-overlay"]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/15784
 @@||discordbotlist.com^$ghide


### PR DESCRIPTION
### URL(s) where the issue occurs

`tarnkappe.info`

### Describe the issue

tarnkappe.info has updated their anti-adblock methods. They are now blurring all content and displaying a banner over the top.

### Versions

- Browser/version: Firefox/140.0.4
- uBlock Origin version: 1.65.0
