### PR TITLE
lan-block - add wyze router to lan-block

### DIFF
--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -129,6 +129,7 @@
 ||unifi.localdomain^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||web.setup^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 ||web.setup.home^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
+||www.wyzerouter.com^$3p,domain=~localhost|~127.0.0.1|~[::1]|~0.0.0.0|~[::]|~local
 !
 ! ——— EXCEPTIONS
 !


### PR DESCRIPTION
Add www.wyzerouter.com to lan-block.

(Wyze Mesh Router and Mesh Router Pro - source:
https://support.wyze.com/hc/en-us/articles/9356595645979-How-do-I-access-my-router-s-local-UI )
