### PR TITLE
Remove SoundCloud Banner Ad Space

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -6599,6 +6599,7 @@ streamhentaimovies.com##+js(nostif, pum-open)
 ||soundcloud.com/audio-ad$1p,xhr
 ||soundcloud.com/promoted$1p,xhr
 soundcloud.com##.soundList__item:has(.sc-promoted-icon-medium)
+soundcloud.com##.bannerAd
 
 ! as suggested https://github.com/uBlockOrigin/uAssets/issues/5153
 ! https://github.com/uBlockOrigin/uAssets/issues/5157


### PR DESCRIPTION
SoundCloud has started using banner ads. The ads themselves are blocked, but there is a huge block of space which is wasteful, so I have added it to the filter list.

### URL(s) where the ads occur

https://soundcloud.com

### Screenshot(s)

<img width="779" height="153" alt="image" src="https://github.com/user-attachments/assets/377cb735-9a38-4f57-a3b1-4bb49e87c6d9" />

### What I did
- Filter out the class that is being used, which is .bannerAd.