### PR TITLE
upd igg

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -3556,6 +3556,8 @@ pcgamestorrents.org##[href*="/gameadult/"][href$=".php"]
 ||pcgamestorrents.com/*.gif$image
 pcgamestorrents.com,pcgamestorrents.org##a[href^="https://pcgamestorrents."][href*="/cuskilo"]
 pcgamestorrents.com,pcgamestorrents.org##a[href][aria-label="awed"]
+igg-games.com,pcgamestorrents.org,pcgamestorrents.com##div.uk-margin-medium-top > div
+igg-games.com##[id^="post-"] > div > [href]
 
 ! https://github.com/uBlockOrigin/uAssets/issues/2458
 pornrabbit.com##+js(nowoif)


### PR DESCRIPTION
ads

`https://igg-games.com/grounded-2-free-download.html`
`https://pcgamestorrents.com/grounded-2-2.html`
`https://pcgamestorrents.org/grounded-2-2.html`

oh, and you could maybe merge megaup.net with igg-games filters for simplicity's sake - IGG-Games seems to own it.