### PR TITLE
Fix missed banner and text ads in modrinth descriptions and changelogs

### DIFF
--- a/filters/filters-2024.txt
+++ b/filters/filters-2024.txt
@@ -2507,16 +2507,19 @@ myp2p.*##a[rel="sponsored"]
 game8.co##.js-side-ads-movie-container:remove()
 
 ! https://github.com/uBlockOrigin/uAssets/discussions/24177#discussioncomment-9821526
-modrinth.com##section.normal-page__content a[href*="/redirect/"] img
+modrinth.com##.normal-page__content a[href*="/redirect/"] img
 ! https://github.com/uBlockOrigin/uAssets/issues/24130
-modrinth.com##section.normal-page__content [href^="https://bisecthosting.com/"] img
-modrinth.com##section.normal-page__content :is([href^="https://ModdersAgainstBlockers.github.io"],[href*="/kinetic/"],[href*="/creeperhost"],[href^="https://fxco.ca/assets/"],[href^="https://rb.gy/"]) > img
-modrinth.com##section.normal-page__content p > img[alt^="Use code"]
+modrinth.com##.normal-page__content a:is([href*="bisecthosting"], [href*="ember.host"])
+modrinth.com##.normal-page__content :is([href^="https://ModdersAgainstBlockers.github.io"],[href*="bisecthosting"],[href*="ember-referral"],[href*="/kinetic/"],[href*="/creeperhost"],[href^="https://fxco.ca/assets/"],[href^="https://rb.gy/"]) > img
+modrinth.com##.normal-page__content p > img[alt^="Use code"]
 curseforge.com##:is(.project-description,div.project-detail__content) [href^="/linkout?remoteUrl=http"]:is([href*="fxco.ca"]) > img
 ||i.imgur.com/h4556XW.gif$image,3p
 ||i.imgur.com/GgSxkKv.png$image,3p
 curseforge.com##:is(.project-description,div.project-detail__content) p > img[alt^="Use code"]
 modrinth.com,curseforge.com##+js(rmnt, h2, /creeperhost/i)
+modrinth.com/mod/euphoria-patches##h2:has-text("Ember Host")
+modrinth.com/mod/euphoria-patches##h2:has-text("Ember Host") ~ p
+modrinth.com##.normal-page__content h2:has(a:is([href*="bisecthosting"], [href*="ember.host"])) + p
 
 ! https://arenascan.com/ anti-adb
 arenascan.com##+js(aost, document.getElementById, adsBlocked)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

1: `https://modrinth.com/datapack/clifftree`
2: `https://modrinth.com/mod/time-on-display`
3: `https://modrinth.com/mod/resourcify`
4: `https://modrinth.com/mod/euphoria-patches`
5: `https://modrinth.com/mod/loot-refill`

### Describe the issue

Banner and text ads in descriptions and changelogs.

### Screenshot(s)

<details>

1: <img width="1976" height="2030" alt="1" src="https://github.com/user-attachments/assets/c0d93fcd-4b54-4de0-86a4-867ed6dbd3c2" />

2: <img width="1912" height="3398" alt="2" src="https://github.com/user-attachments/assets/df3b263f-ba68-446e-bc77-1bbb92c1e517" />

3: <img width="2124" height="1498" alt="3" src="https://github.com/user-attachments/assets/24f92fdf-4393-4dfe-87d2-fdc80b17ff1e" />

4: <img width="1934" height="1796" alt="4" src="https://github.com/user-attachments/assets/6d8b93fb-fb4c-418f-a017-0cbcc38c0cc3" />

5: <img width="1946" height="1360" alt="5" src="https://github.com/user-attachments/assets/1ad1bfa1-4b68-4bf9-ad0c-d39e45caf97d" />

</details>

### Versions

- Browser/version: firefox 141.0 (64-bit)
- uBlock Origin version: 1.65.0

### Settings

-

### Notes

Note that the filter needs to be come more general to cover these cases. `section` needed to be removed since in the changelogs the tag is `div`. The `href` match is now `*=` since there's redirect domains. Images and ad text is wrapped in various tags for obfuscation, so the filters need to ignore the exact structure. We may want to consolidate the filters into just one line and remove the `> img`.
Whether we want to block text ads is another question, up to the maintainers to decide. Ads integrated into the prose are both less intrusive and harder to block, so blocking them would only happen on a case-by-case basis and with greater effort. I've included an example.
