### PR TITLE
Fix #29152

### DIFF
--- a/filters/filters-general.txt
+++ b/filters/filters-general.txt
@@ -2207,6 +2207,7 @@ servers-mc.net##.ads
 servers-mc.net###popup
 
 ! https://github.com/uBlockOrigin/uAssets/issues/29152
+||www.unibilgi.net/wp-content/uploads/2024/07/temu-indirim-kodu-30.png
 unibilgi.net##[href*="adset"]
 unibilgi.net##.ays-pb-modals
 


### PR DESCRIPTION

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
https://www.unibilgi.net/buro-yonetimi-ve-yonetici-asistanligi-taban-puanlari-ve-basari-siralamalari/

### Describe the issue

Fix a missing ad

### Screenshot(s)
![Screenshot_20250819_123904_Firefox](https://github.com/user-attachments/assets/bcfbcb78-84dc-484a-8aaa-5a6fd88865b5)

### Versions

- Browser/version: [141]
- uBlock Origin version: [1.65.0]

### Settings

- [Same as default settings]

### Notes

[There is no ad in adguard extension with adguard filters.]
