### PR TITLE
heise.de, kleinanzeigen.de: switch from accepting cookies to reject

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -4145,9 +4145,6 @@ winparts.eu,winparts.ie,winparts.se##+js(trusted-click-element, a.aanvaarden.gre
 sportano.*##+js(trusted-click-element, button.button--preferences, , 900)
 sportano.*##+js(trusted-click-element, button.button--confirm, , 1100)
 
-accept-wall
-kleinanzeigen.de##+js(trusted-click-element, button#gdpr-banner-accept, , 1000)
-
 ! reject
 crocs.*##+js(trusted-click-element, button.js-btn-reject-all, , 1300)
 

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -1885,11 +1885,7 @@ privacy.maennersache.de##+js(trusted-click-element, button[title="Einwilligen un
 lovo.ai##+js(trusted-set-cookie, cookieConsent, '{"essential":true,"analytical":false,"functional":false,"marketing":false}')
 
 ! Agree (cookie-wall consent)
-cmp.heise.de,cmp.am-online.com,cmp.motorcyclenews.com,consent.newsnow.co.uk,cmp.todays-golfer.com##+js(trusted-click-element, button[title="Agree"], , 1500)
-! https://www.heise.de/bestenlisten/testbericht/ugreen-nexode-pro-65w-im-test-usb-c-ladegeraet-noch-kleiner-als-der-vorgaenger/2mxgq5n 
-! Accept
-cmp.heise.de##+js(trusted-click-element, button[title="Zustimmen"], , 1000)
-heise.de##+js(trusted-click-element, button.sp_choice_type_11)
+cmp.am-online.com,cmp.motorcyclenews.com,consent.newsnow.co.uk,cmp.todays-golfer.com##+js(trusted-click-element, button[title="Agree"], , 1500)
 
 ! accept
 koeser.com,shop.schaette-pferd.de,schaette.de##+js(trusted-click-element, a.cookie-permission--accept-button, , 1600)
@@ -4141,9 +4137,6 @@ winparts.eu,winparts.ie,winparts.se##+js(trusted-click-element, a.aanvaarden.gre
 sportano.*##+js(trusted-click-element, button.button--preferences, , 900)
 sportano.*##+js(trusted-click-element, button.button--confirm, , 1100)
 
-! accept-wall
-kleinanzeigen.de##+js(trusted-click-element, button#gdpr-banner-accept, , 1000)
-
 ! reject
 crocs.*##+js(trusted-click-element, button.js-btn-reject-all, , 1300)
 
@@ -4812,3 +4805,14 @@ helsenorge.no##+js(trusted-set-cookie, HN-Cookie-Consent, base64:eyJWaWRlb0Nvb2t
 
 ! https://github.com/uBlockOrigin/uAssets/issues/29898
 imaios.com##+js(trusted-click-element, div#continueWithoutAccepting, , 1000)
+
+! https://www.heise.de/bestenlisten/testbericht/ugreen-nexode-pro-65w-im-test-usb-c-ladegeraet-noch-kleiner-als-der-vorgaenger/2mxgq5n 
+! Reject all possible providers
+cmp.heise.de##button.sp_choice_type_SAVE_AND_EXIT:watch-attr(disabled):remove-attr(disabled)
+cmp.heise.de##div.pur-buttons-container button:style(visibility: initial !important; pointer-events: initial !important)
+cmp.heise.de##+js(trusted-click-element, button[aria-label="Einstellungen"],, 500)
+cmp.heise.de##+js(trusted-click-element, 'div.pm-main > div:nth-child(1) div.stack-row > div > button:nth-child(2), div.message-component.message-column.cmp-buttons-accept > button',, 500,)
+
+! Reject, kleinanzeigen.de does A/B testing with consent banner, should work with all 3 types
+kleinanzeigen.de##+js(trusted-click-element, #gdpr-banner-cmp-button,, 1000)
+kleinanzeigen.de##+js(trusted-click-element, button[aria-label="Datenschutzbestimmungen und Einstellungen ablehnen"],, 1200)

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -526,6 +526,10 @@ everyeye.it##+js(trusted-click-element, #pubtech-cmp button[aria-label="Continue
 ! https://github.com/uBlockOrigin/uAssets/issues/29900
 godtlevert.no##+js(trusted-set-local-storage-item, reduxStore, '{"tracking":{"consents":{"All":false,"functional":false,"Segment.io":false},"dialog":{"open":false,"dirty":false},"isConfigured":true},"loyalty":{"hasSeenLoyaltyPage":false}}')
 
+! Reject, kleinanzeigen.de does A/B testing with consent banner, should work with all 3 types
+kleinanzeigen.de##+js(trusted-click-element, #gdpr-banner-cmp-button,, 1000)
+kleinanzeigen.de##+js(trusted-click-element, button[aria-label="Datenschutzbestimmungen und Einstellungen ablehnen"],, 1200)
+
 !! Needs additional cookies
 
 ! Aceepting most cookies are required to view the content without payment
@@ -1885,7 +1889,11 @@ privacy.maennersache.de##+js(trusted-click-element, button[title="Einwilligen un
 lovo.ai##+js(trusted-set-cookie, cookieConsent, '{"essential":true,"analytical":false,"functional":false,"marketing":false}')
 
 ! Agree (cookie-wall consent)
-cmp.am-online.com,cmp.motorcyclenews.com,consent.newsnow.co.uk,cmp.todays-golfer.com##+js(trusted-click-element, button[title="Agree"], , 1500)
+cmp.heise.de,cmp.am-online.com,cmp.motorcyclenews.com,consent.newsnow.co.uk,cmp.todays-golfer.com##+js(trusted-click-element, button[title="Agree"], , 1500)
+! https://www.heise.de/bestenlisten/testbericht/ugreen-nexode-pro-65w-im-test-usb-c-ladegeraet-noch-kleiner-als-der-vorgaenger/2mxgq5n 
+! Accept
+cmp.heise.de##+js(trusted-click-element, button[title="Zustimmen"], , 1000)
+heise.de##+js(trusted-click-element, button.sp_choice_type_11)
 
 ! accept
 koeser.com,shop.schaette-pferd.de,schaette.de##+js(trusted-click-element, a.cookie-permission--accept-button, , 1600)
@@ -4137,6 +4145,9 @@ winparts.eu,winparts.ie,winparts.se##+js(trusted-click-element, a.aanvaarden.gre
 sportano.*##+js(trusted-click-element, button.button--preferences, , 900)
 sportano.*##+js(trusted-click-element, button.button--confirm, , 1100)
 
+accept-wall
+kleinanzeigen.de##+js(trusted-click-element, button#gdpr-banner-accept, , 1000)
+
 ! reject
 crocs.*##+js(trusted-click-element, button.js-btn-reject-all, , 1300)
 
@@ -4805,14 +4816,3 @@ helsenorge.no##+js(trusted-set-cookie, HN-Cookie-Consent, base64:eyJWaWRlb0Nvb2t
 
 ! https://github.com/uBlockOrigin/uAssets/issues/29898
 imaios.com##+js(trusted-click-element, div#continueWithoutAccepting, , 1000)
-
-! https://www.heise.de/bestenlisten/testbericht/ugreen-nexode-pro-65w-im-test-usb-c-ladegeraet-noch-kleiner-als-der-vorgaenger/2mxgq5n 
-! Reject all possible providers
-cmp.heise.de##button.sp_choice_type_SAVE_AND_EXIT:watch-attr(disabled):remove-attr(disabled)
-cmp.heise.de##div.pur-buttons-container button:style(visibility: initial !important; pointer-events: initial !important)
-cmp.heise.de##+js(trusted-click-element, button[aria-label="Einstellungen"],, 500)
-cmp.heise.de##+js(trusted-click-element, 'div.pm-main > div:nth-child(1) div.stack-row > div > button:nth-child(2), div.message-component.message-column.cmp-buttons-accept > button',, 500,)
-
-! Reject, kleinanzeigen.de does A/B testing with consent banner, should work with all 3 types
-kleinanzeigen.de##+js(trusted-click-element, #gdpr-banner-cmp-button,, 1000)
-kleinanzeigen.de##+js(trusted-click-element, button[aria-label="Datenschutzbestimmungen und Einstellungen ablehnen"],, 1200)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

kleinanzeigen.de
heise.de

### Describe the issue

at the moment cookies are accepted, would be better to reject

### Versions

- Browser/version: FF 142.0.1
- uBlock Origin version: 1.65.0

### Settings

- Add almost all lists (for regional only German list)

### Notes

Additionally unlocked the decline button on heise.de
kleinanzeigen.de does A/B testing with the consent banner, solution should cover all types at the moment.
