### PR TITLE
Updated mydealz/preisjaeger cookie reject

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -2638,9 +2638,6 @@ womex.com##+js(trusted-set-cookie, cookieConsent, '{"essential":1,"statistics":0
 ! functional, date=1
 oem.ee##+js(trusted-set-cookie, cookieConsent, functional=1&analytics=0&marketing=0&updated=1, , , reload, 1)
 
-! continueWithoutAccepting
-pepper.it,pepper.pl,preisjaeger.at,mydealz.de,dealabs.com,hotukdeals.com,chollometro.com##+js(trusted-click-element, button[data-t="continueWithoutAccepting"], , 1000)
-
 ! reject
 makelaarsland.nl##+js(trusted-click-element, button.si-cookie-notice__button--reject, , 1000)
 
@@ -4812,3 +4809,7 @@ helsenorge.no##+js(trusted-set-cookie, HN-Cookie-Consent, base64:eyJWaWRlb0Nvb2t
 
 ! https://github.com/uBlockOrigin/uAssets/issues/29898
 imaios.com##+js(trusted-click-element, div#continueWithoutAccepting, , 1000)
+
+! continueWithoutAccepting
+pepper.pl,dealabs.com,hotukdeals.com,chollometro.com##+js(trusted-click-element, button[data-t="continueWithoutAccepting"], , 1000)
+preisjaeger.at,mydealz.de##+js(trusted-click-element, button[data-t="rejectAll"], , 1000)

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -526,6 +526,10 @@ everyeye.it##+js(trusted-click-element, #pubtech-cmp button[aria-label="Continue
 ! https://github.com/uBlockOrigin/uAssets/issues/29900
 godtlevert.no##+js(trusted-set-local-storage-item, reduxStore, '{"tracking":{"consents":{"All":false,"functional":false,"Segment.io":false},"dialog":{"open":false,"dirty":false},"isConfigured":true},"loyalty":{"hasSeenLoyaltyPage":false}}')
 
+! continueWithoutAccepting
+pepper.pl,dealabs.com,hotukdeals.com,chollometro.com##+js(trusted-click-element, button[data-t="continueWithoutAccepting"], , 1000)
+preisjaeger.at,mydealz.de##+js(trusted-click-element, button[data-t="rejectAll"], , 1000)
+
 !! Needs additional cookies
 
 ! Aceepting most cookies are required to view the content without payment
@@ -4810,6 +4814,3 @@ helsenorge.no##+js(trusted-set-cookie, HN-Cookie-Consent, base64:eyJWaWRlb0Nvb2t
 ! https://github.com/uBlockOrigin/uAssets/issues/29898
 imaios.com##+js(trusted-click-element, div#continueWithoutAccepting, , 1000)
 
-! continueWithoutAccepting
-pepper.pl,dealabs.com,hotukdeals.com,chollometro.com##+js(trusted-click-element, button[data-t="continueWithoutAccepting"], , 1000)
-preisjaeger.at,mydealz.de##+js(trusted-click-element, button[data-t="rejectAll"], , 1000)


### PR DESCRIPTION

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

preisjaeger.at,mydealz.de

### Describe the issue

New cookie banner

### Versions

- Browser/version: FF 142
- uBlock Origin version: 1.65.0

### Notes

removed pepper.it (service canceled)
