### PR TITLE
Correct comment for DPG Media cookie walls

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -3578,12 +3578,6 @@ georgjensen.com##+js(trusted-click-element, button[onclick="CookieInformation.de
 ! necessary
 jobsireland.ie##+js(trusted-set-cookie, cconsent, '{"version":1,"categories":{"necessary":{"wanted":true},"Microsoft":{"wanted":false},"Google":{"wanted":false},"Facebook":{"wanted":false},"YouTube":{"wanted":false}},"services":["Microsoft","analytics","facebook","YouTube"]}')
 
-! DPG Media owns lots of sites which redirect to one of these domains to ask for consent - reject all
-! Sample pages: hln.be, nu.nl, tweakers.net
-myprivacy.dpgmedia.nl,myprivacy.dpgmedia.be,www.dpgmediagroup.com##+js(trusted-click-element, '#pg-host-shadow-root >>> button#pg-configure-btn, #pg-host-shadow-root >>> #purpose-row-SOCIAL_MEDIA input[type="checkbox"], #pg-host-shadow-root >>> button#pg-save-preferences-btn')
-! Clicking doesn't work on myprivacy.dpgmediagroup.net, reloading the page once redirects to www.dpgmediagroup.com, where clicking works
-myprivacy.dpgmediagroup.net##+js(set-cookie, dummy, 1, , reload, 1)
-
 ! https://www.moviepass.com/ - essential only
 moviepass.com##+js(trusted-set-cookie, consent-policy, '{"ess":1,"func":0,"anl":0,"adv":0,"dt3":0}')
 
@@ -4816,3 +4810,9 @@ helsenorge.no##+js(trusted-set-cookie, HN-Cookie-Consent, base64:eyJWaWRlb0Nvb2t
 
 ! https://github.com/uBlockOrigin/uAssets/issues/29898
 imaios.com##+js(trusted-click-element, div#continueWithoutAccepting, , 1000)
+
+! DPG Media owns lots of sites which redirect to one of these domains to ask for consent - embedded social media only
+! Sample pages: hln.be, nu.nl, tweakers.net
+myprivacy.dpgmedia.nl,myprivacy.dpgmedia.be,www.dpgmediagroup.com##+js(trusted-click-element, '#pg-host-shadow-root >>> button#pg-configure-btn, #pg-host-shadow-root >>> #purpose-row-SOCIAL_MEDIA input[type="checkbox"], #pg-host-shadow-root >>> button#pg-save-preferences-btn')
+! Clicking doesn't work on myprivacy.dpgmediagroup.net, reloading the page once redirects to www.dpgmediagroup.com, where clicking works
+myprivacy.dpgmediagroup.net##+js(set-cookie, dummy, 1, , reload, 1)


### PR DESCRIPTION
Since my PR from a while ago with these filters was adjusted to include embedded social media (i.e. review videos hosted on YouTube) the comment "reject all" became false and it has bothered me ever since 😅 This should fix that.

ps I see a lot of descriptors that may or may not be applicable here: `basic`, `necessary`, `functional`, `video`. I think we need a guideline in CONTRIBUTING.md if we want to adhere to some standard way of tagging things.