### PR TITLE
badware: paradlgm.com is phishing

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6324,3 +6324,7 @@ $doc,ipaddress=185.216.143.121
 ! https://github.com/uBlockOrigin/uAssets/issues/30149
 /^https://gitcoin-[a-z]{1,}\.com/?$/$all,reason="Blatant scammers who are not related to GitHub or Gitcoin whatsoever."
 /^https://[a-z]{1,}-gitcoin\.com/?$/$all,reason="Blatant scammers who are not related to GitHub or Gitcoin whatsoever."
+
+
+! https://safeweb.norton.com/report?url=paradlgm.com
+||paradlgm.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`paradlgm.com`

### Describe the issue

Homograph attack targeting `paradigm.xyz` users. Phishing as reported by both Norton and Cloudflare.

### Screenshot(s)

<img height="200" alt="Cloudflare result" src="https://github.com/user-attachments/assets/ca33d4c2-f836-4a42-8c5c-2a239bb91e4b" />

<img  height="200" alt="Norton result" src="https://github.com/user-attachments/assets/9c2d47eb-b4d8-4ed3-a3bb-d23b606b04c6" />

