### PR TITLE
Remove Brave browser download suggestion (Brave Search)

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7760,3 +7760,6 @@ bhaskar.com##+js(aost, Array.prototype.findIndex, isWithinLimits)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/30132
 modxvm.com##+js(trusted-set-local-storage-item, xvmDialogLastShown, $now$)
+
+! remove brave browser download suggestion
+search.brave.com##.download-cta


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://search.brave.com/`

### Describe the issue

Currently when opening Brave Search a Brave Browser download suggestion is displayed.

### Screenshot(s)

<img width="1260" height="645" alt="bug" src="https://github.com/user-attachments/assets/5f03c4e8-1485-45fe-bc2a-ec6363bb026d" />

### Versions

- Browser/version: Zen Browser 1.16.1b (Firefox 143.0.1)
- uBlock Origin version: 1.66.4

### Settings

- added rule to remove `.download-cta` elements from Brave Search domain

### Notes

A similar rule is already available in Easylist Annoyances but it seems outdated and (currently) targets nothing:

https://github.com/uBlockOrigin/uAssets/blob/a2bf8415e4c4f6ea696c91a0bd0d3b5406719d98/thirdparties/easylist/easylist-annoyances.txt#L1878