### PR TITLE
shutterstock.com: breakage fix

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1285,9 +1285,6 @@ bostonscally.com##+js(remove-cookie, /__ta_|_shopify_y/, when, scroll keydown)
 4game.ru##+js(trusted-set-cookie, trk, , 0, , domain, .4game.ru)
 4game.com,4game.ru##+js(set-local-storage-item, /fingerprint|trackingEvents/, $remove$)
 ||sdk.optimove.net^
-! https://www.shutterstock.com/ja
-shutterstock.com##+js(remove-cookie, /sstk_|stck_|htjs_anonymous_id/, when, scroll keydown)
-shutterstock.com##+js(set-local-storage-item, /htjs_|stck_|statsig/, $remove$)
 ! https://mobalytics.gg/
 mobalytics.gg##+js(set-local-storage-item, /mixpanel/, $remove$)
 ! https://it.investing.com/


### PR DESCRIPTION
This reverts commit 29f4b0fc5280f7800b3fec3db6fd8dbdd04878d5.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://www.shutterstock.com/

### Describe the issue


I'm one of the maintainers of https://github.com/shutterstock and I'm a developer for the shutterstock.com website.

We found that our site was showing error messages to our users who use Brave, and other extensions that use filters/privacy.txt after this commit https://github.com/uBlockOrigin/uAssets/commit/29f4b0fc5280f7800b3fec3db6fd8dbdd04878d5. We weren't able to find an issue with more context on https://www.reddit.com/r/uBlockOrigin Here is our cookies page if that helps explain our necessary cookies https://www.shutterstock.com/cookies On Fri Sep 19 23:33 UTC we made these cookies optional but we need to put it back as soon as we can to distinguish between legitimate users and bots. Here is the PR to fix if that helps you guys for #30262 



### Screenshot(s)

<details>

<img width="1113" height="745" alt="Image" src="https://github.com/user-attachments/assets/8af0d860-6498-400a-8154-54c531ab6c30" />

<img width="1765" height="369" alt="Image" src="https://github.com/user-attachments/assets/4b67aecc-20df-49bb-b052-41d44060c62c" />

</details>

Steps to reproduce 

(When our code that requires the cookies was live on Sept 16)
1. Login on our site
2. Click on buttons
3. Observe Something went wrong


### Versions

- Browser/version: Brave 1.82.173 (Official Build) (arm64)
- uBlock Origin version: [here]

### Settings

None

### Notes

We breakpointed and noticed our first party cookies are removed on scroll. 

<details>

<img width="1327" height="811" alt="Screenshot 2025-10-02 at 12 32 26" src="https://github.com/user-attachments/assets/410f832c-9db1-497d-8e7d-f91ac4349053" />


<img width="2404" height="1526" alt="breakpoint" src="https://github.com/user-attachments/assets/3428323b-8305-42ff-ae09-d381ed1a8646" />

</details>