### PR TITLE
Fix hurriyet.com.tr

### DIFF
--- a/filters/filters-mobile.txt
+++ b/filters/filters-mobile.txt
@@ -170,3 +170,6 @@ outlook.live.com##main > div[style] .vPfg_:has(.wOYnU) ~ *:style(transform: tran
 dailymotion.com##+js(xml-prune, [breakId], , _VMAP_)
 dailymotion.com##+js(json-prune-fetch-response, advertising, , propsToMatch, /player/metadata)
 dailymotion.com##+js(json-prune-xhr-response, advertising, , propsToMatch, .json)
+
+!Fixes adleftover
+hurriyet.com.tr##.mobileMasthead


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://www.hurriyet.com.tr/video/marmarada-5-buyuklugundeki-deprem-ani-kamerada-42969598

### Describe the issue
There is a adleftover at mobile view. Didnt see it on adguard extension


### Screenshot(s)

<details>

![Screenshot_20251003_165251_Firefox Nightly](https://github.com/user-attachments/assets/e08b9adb-ca18-417d-baed-8c14b0c9b8d2)

</details>

### Versions

- Browser/version: 143.0.3
- uBlock Origin version: 1.66.4

### Settings

Adgaurd Annoyances
Adguard Social
Adguard Cookies
Adguard Turkish

### Notes

except for the default filters, the enabled ones are listed above
