### PR TITLE
support.huawei.com: breakage

### DIFF
--- a/filters/lan-block.txt
+++ b/filters/lan-block.txt
@@ -181,7 +181,7 @@
 @@||127.0.0.1^$domain=vpn.mozilla.org
 
 ! https://github.com/uBlockOrigin/uAssets/pull/30430
-@@/^ws:\/\/(127.0.0.1|localhost):\d{4,5}\/icslite\/websocket\//$websocket,domain=support.huawei.com
+@@/^ws:\/\/(127\.0\.0\.1|localhost):\d{4,5}\/icslite\/websocket\//$websocket,domain=support.huawei.com
 
 !
 ! ——— END


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://support.huawei.com/enterprise/en/software/264916260-ESW2001346134`

### Describe the issue

Huawei has its own download manager called "Huawei ICS Lite" for firmware updates, documentation downloads, ...
The website support.huawei.com communicates over a websocket with the local ICS Lite installation to trigger the downloads.

### Screenshot(s)

<img width="980" height="445" alt="image" src="https://github.com/user-attachments/assets/d3ac7902-33e8-48eb-b9e7-f0b057b63cce" />

### Versions

- Browser/version: Chrome 141.0.7390.108 (Official Build) (64-bit)
- uBlock Origin version: uBlock Origin Lite 2025.1012.1712