### PR TITLE
OrcaSlicer + NVCleanstall phishing

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -5565,6 +5565,7 @@ webflow.io##html.w-mod-js:not(.wf-active) > body:not([class]):not([id]) > a[clas
 ||orcaslicers.$doc
 ||theorcaslicer.$doc
 
+! https://www.techpowerup.com/download/techpowerup-nvcleanstall/
 ||nvcleanstall.$doc
 ||nvcleanstal.$doc
 


### PR DESCRIPTION
- OrcaSlicer
  - Official: [orcaslicer.com](https://www.orcaslicer.com/)
  - Phishing:
    - ocraslicer.com
    - orca3dslicer.com
    - orcaslice.com
    - orcaslicer.app
    - orcaslicer.cn
    - orcaslicer.co
    - orca-slicer.com
    - orca-slicer.com.co
    - orcaslicer.download
    - orcaslicer.net
    - orca-slicer.net
    - orcaslicer.online
    - orcaslicer.org
    - orca-slicer.org
    - orcaslicer.pro
    - orcaslicer.us
    - orcaslicer.vip
    - orcaslicer3d.com
    - orcaslicerdownload.com
    - orcaslicerofficial.com
    - orcaslicerr.com
    - orcaslicers.com
    - orcaslicers.netify.app
    - orcaslicers.org
    - theorcaslicer.com
- NVCleanstall
  - Official: [TechPowerUp/NVCleanstall](https://www.techpowerup.com/download/techpowerup-nvcleanstall/)
  - Phishing:
    - nvcleanstal.com
    - nvcleanstall.net
    - nvcleanstall.org