### PR TITLE
petbarn.com.au: block inline ads

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -11520,6 +11520,9 @@ thejobsmovie.com##+js(nostif, adsBlocked)
 @@||techdracula.com^$ghide
 techdracula.com##ins.adsbygoogle
 
+! Ads inline with search results.
+petbarn.com.au##[class^="ProductList"] > [class^="RecommendationBanner"]:upward(1)
+
 !#include filters-general.txt
 
 ! As of 2020-04-09, new filters will be added to year-based sublists


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.petbarn.com.au/c/dogs/dog-supplies/travel-carriers/carriers`

### Describe the issue

There's ads inline within the item listings.

### Screenshot(s)

No filter:
<img width="2806" height="1670" alt="Screenshot 2025-10-21 at 18-16-10 Dog Carriers Petbarn" src="https://github.com/user-attachments/assets/6b6dc9ec-827d-480f-aeca-220db9001dc3" />

Filter:
<img width="2806" height="1670" alt="Screenshot 2025-10-21 at 18-20-36 Dog Carriers Petbarn" src="https://github.com/user-attachments/assets/d0552d29-413a-4a0d-8a4f-c70ebc1c0185" />


### Versions

- Browser/version: Firefox 143.0.4
- uBlock Origin version: 1.66.4

### Settings

- N/A

### Notes

I'm a beginner at creating filter rules. This seemed to do the trick though.
