### PR TITLE
fix: false-positive orcaslicer.com

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -5549,9 +5549,7 @@ webflow.io##html.w-mod-js:not(.wf-active) > body:not([class]):not([id]) > a[clas
 ! https://github.com/uBlockOrigin/uAssets/issues/26052
 ! https://github.com/uBlockOrigin/uAssets/issues/27270
 ! https://github.com/uBlockOrigin/uAssets/issues/28259
-||orcaslicer.$doc,to=~orcaslicer.com
 ||orca-slicer.$doc
-||ocraslicer.$doc
 ||orca3dslicer.$doc
 ||orcaslice.$doc
 ||orcaslicer3d.$doc


### PR DESCRIPTION
Official notice: www.orcaslicer.com is the only official OrcaSlicer site. Beware of fake domains (e.g., orca-slicer.com, orcaslicer.net). 

https://github.com/SoftFever/OrcaSlicer <-- please see

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://*.orcaslicer.com/*`

### Describe the issue

orcaslicer.com is the official website of OrcaSlicer, but uBO blocks it.

### Screenshot(s)

<img width="706" height="508" alt="image" src="https://github.com/user-attachments/assets/99ee022e-b409-4155-bb00-0588294ff585" />

### Versions

- Browser/version: Brave/1.83.118
- uBlock Origin version: 1.66.4

### Settings

- Removed orcaslicer.com from badware

### Notes

Please see https://www.orcaslicer.com/ and https://github.com/SoftFever/OrcaSlicer?tab=readme-ov-file#official-links-and-community
