### PR TITLE
remove *.pages.dev/robots.txt

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -5790,9 +5790,6 @@ webflow.io##html.w-mod-js:not(.wf-active) > body:not([class]):not([id]) > a[clas
 ! https://app.any.run/tasks/5972a8c5-5b87-4579-9cc5-8bc268abd6c0
 ://booking.*.com/sign-in?op_token=$doc
 
-! https://urlscan.io/search/#hash%3A45e39853c41558c4922ff1b0895547a99e378f136ec3d9d2f4df15cc269485fa
-||pages.dev/robots.txt$doc
-
 ! https://urlscan.io/result/0196c759-fc83-741d-9af3-70ffd2d7b443/
 ||drdosurvey.info^$all
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://85968461.yolkdata.pages.dev/robots.txt` (safe; static robots.txt)

### Describe the issue

pages.dev is the Cloudflare Pages static default host domain. This rule applies to ALL sites on cloudflare, including non-malicious sites trying to use robots.txt (which blocked me from testing my robots.txt, for some reason).

### Screenshot(s)

<img width="511" height="102" alt="image" src="https://github.com/user-attachments/assets/6200abd9-5765-49ea-baa7-a931b490d58f" />

Ignore the \n, I hate `echo`

### Versions

- Browser/version: Chrome 131
- uBlock Origin version: uBO 1.67.0

### Notes

The commit name that ADDED this was:

```
address https://urlscan.io/search/#hash%3A45e39853c41558c4922ff1b0895547a99e378f136ec3d9d2f4df15cc269485fa
```

I'm unaware what this addresses, it only blocks legitimate Pages sites.
