### PR TITLE
 cambro.tv fix video player popunder

### DIFF
--- a/filters/filters-2025.txt
+++ b/filters/filters-2025.txt
@@ -116,6 +116,9 @@ camhub.cc##.asside-link
 camhub.cc##.link-offer
 camhub.cc##+js(set, openPop, noopFunc)
 
+! https://github.com/uBlockOrigin/uAssets/issues/6825
+cambro.*##+js(trusted-set-local-storage-item, kvsplayer_popunder_open, 9999999999999)
+
 ! https://github.com/uBlockOrigin/uAssets/issues/723
 xmoviesforyou.*##+js(acs, WebAssembly, Promise)
 


### PR DESCRIPTION
### URL(s) where the issue occurs

**NSFW warning**:
https://www.cambro.tv/1958176/kenalialuv-catgirl-rides-the-milk-out-of-you/

### Describe the issue

It's an old issue https://github.com/uBlockOrigin/uAssets/issues/6825.
If open any page with video and click on it pop-under event follows. It happens only first time. After script saves timestamp at `localStorage.kvsplayer_popunder_open` and event will reoccurs again only in 15+ minutes.

### Versions

- Browser/version: Firefox 144.0.2
- uBlock Origin version: 1.67.0

### Notes

New filter prevents pop-under event.