### PR TITLE
change from accept to reject cookie consent for nike.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -2222,7 +2222,7 @@ postfinance.ch##+js(trusted-set-cookie, consent_settings, '{"consentAnalytics":f
 lcp.fr##+js(trusted-set-cookie, cookiesjsr, '%7B%22functional%22:false,%22gtag%22:false,%22recaptcha%22:false,%22addtoany%22:false,%22twitter%22:true,%22video%22:true,%22vimeo%22:true%7D')
 
 ! https://github.com/uBlockOrigin/uAssets/issues/11232#issuecomment-2599709662
-nike.com##+js(trusted-click-element, .modal-actions-accept-btn, , 2000)
+nike.com##+js(trusted-click-element, .modal-actions-decline-btn, , 2000)
 consent.fastcar.co.uk,tapmaster.ca##+js(trusted-click-element, button[aria-label="Accept All"], , 1000)
 
 ! essential only


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

nike.com

### Describe the issue

reject cookies in first place

### Versions

- Browser/version: FF 145.0.1
- uBlock Origin version: 1.67.0

### Settings

- uBlock filters – Cookie Notices
