### PR TITLE
Update filters-2023.txt

### DIFF
--- a/filters/filters-2023.txt
+++ b/filters/filters-2023.txt
@@ -1534,7 +1534,7 @@ wirtualnemedia.pl##.wp-screening-placeholder-container
 wirtualnemedia.pl##body div[class]:not([id]):has(> img[src="/staticfiles/wm-placeholder.png"])
 wirtualnemedia.pl##.py-12:not([data-testid="screening-main"]):has(img[src="/staticfiles/wm-placeholder.png"])
 ! https://github.com/uBlockOrigin/uAssets/issues/30894
-dobreprogramy.pl##+js(trusted-edit-inbound-object, Object.keys, 0, [?.context.bidRequestId].*)
+www.dobreprogramy.pl##+js(trusted-edit-inbound-object, Object.keys, 0, [?.context.bidRequestId].*)
 !#if env_chromium
 dobreprogramy.pl##+js(trusted-replace-argument, RegExp.prototype.test, 0, json:"wirtualnemedia", condition, /^dobreprogramy$/)
 !#endif


### PR DESCRIPTION
#30908 / #30894 

I haven't tested the second filter for e.g. mobile Edge[^1] if needs to be fixed in same way, I don't want to be overly cautious when it's harmless on Chrome.

[^1]: The only browser that makes sense to check on Android after Firefox.
