### PR TITLE
dxvk.org is impersonation

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6334,3 +6334,7 @@ sport.elwatannews.com##+js(aost, Array.prototype.indexOf, isWin)
 ||trustwallet-app.io^$all
 ||trustwallet-com.to^$all
 ||trustwallet-pc.to^$all
+
+
+! https://github.com/doitsujin/dxvk/issues/5380#issuecomment-3643361297
+||dxvk.org^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`dxvk.org/*`

### Describe the issue

Maintainer of the dxvk project confirms that this domain is not under their control.

More info can be found in [this issue](https://github.com/doitsujin/dxvk/issues/5380#issuecomment-3643361297).