### PR TITLE
Restore Chess.com broken sidebar for premium users with uBlock enabled

### DIFF
--- a/filters/filters-2025.txt
+++ b/filters/filters-2025.txt
@@ -3480,7 +3480,7 @@ rfi.fr##div[id$="main-ad"]
 iptvpulse.top##+js(no-fetch-if, /googlesyndication|doubleclick|adsterra/)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/31282
-chess.com##.sidebar-component:style(width:190%!important)
+chess.com##body.with-und .sidebar-component:style(width:190%!important)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/31255
 aether.mom##+js(trusted-replace-argument, String.prototype.split, this, , condition, 'null,http')


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.chess.com/puzzles` (must be logged in with a premium subscription)

### Describe the issue
Earlier this week, https://github.com/uBlockOrigin/uAssets/issues/31282 was released and is causing issues for premium users at chess.com. `.sidebar-component` was proposed to be increased to 190%, which ensures that if an ad is present on the page (but removed due to uBlockOrigin), the main sidebar takes up the resulting dead space. 

An unintended consequence of this change is that premium users, who don't have an ad and whose sidebar already takes up the full amount of space, end up with a sidebar that extends to the right of their viewport, causing a horizontal scrollbar. 

Here some examples of complaining users who have uBlock installed (in some form or fashion) and who are also premium chess.com users: 

```
https://www.chess.com/clubs/forum/view/why-is-the-game-review-screen-horizontally-elongated
https://www.chess.com/fr/forum/view/help-support/probleme-dinterface
https://www.chess.com/clubs/forum/view/the-bar-at-the-bottom-of-the-screen
```

### Screenshot(s)
Example of what the changes at https://github.com/uBlockOrigin/uAssets/issues/31282 are causing: 

<img width="1526" height="788" alt="phpcjplcseaab12fTWObsJ" src="https://github.com/user-attachments/assets/bf80321f-d1d4-4216-b24e-b151f47f3e2d" />

### Versions

- Browser/version: Chromium Engine Version 143.0.7499.170
- uBlock Origin version: latest (where can I get this info precisely?) 

### Settings
- n/a

### Notes
Chess.com engineering has discussed the situation internally and would love to get the proper sidebar UI restored to our premium users without resorting to cat-and-mouse with DOM selector changes. 🙏 Thanks! 