### PR TITLE
Fix uBlockOrigin#31296

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -11480,7 +11480,7 @@ premid.app##ins.adsbygoogle
 thejobsmovie.com##+js(nostif, adsBlocked)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/53238
-@@||techdracula.com^$ghidee
+@@||techdracula.com^$ghide
 techdracula.com##ins.adsbygoogle
 
 ! https://github.com/uBlockOrigin/uAssets/issues/31296


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`http://www.gamesfree.com/game/shop_empire_rampage.html`

### Describe the issue

Removed preroll ad, black screen expected if you don't have flash or ruffle extension installed to  make flash games work again.

### Screenshot(s)

<img width="912" height="745" alt="Képernyőkép_20251223_130208" src="https://github.com/user-attachments/assets/ab6d8bcb-3c32-45a4-87c7-7c1b5b27bdc4" />
<img width="912" height="745" alt="Képernyőkép_20251223_130217" src="https://github.com/user-attachments/assets/3a1b6a43-6ac2-4043-bd3a-3811f3a7cb17" />
<img width="912" height="745" alt="Képernyőkép_20251223_130222" src="https://github.com/user-attachments/assets/0b384cd8-7c0a-4356-8783-4b50d58f3f49" />


### Versions

- Browser/version:  Firefox 146.0.1
- uBlock Origin version: 1.67.0

### Settings

- [List here all the changes you made to uBO's default settings]

### Notes


First, the preroll ad needs to be removed, then the game window needs to be unhidden.