### PR TITLE
preisjaeger.at: typo

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -531,7 +531,7 @@ everyeye.it###pubtech-cmp
 ! https://github.com/uBlockOrigin/uAssets/issues/29900
 godtlevert.no##+js(trusted-set-local-storage-item, reduxStore, '{"tracking":{"consents":{"All":false,"functional":false,"Segment.io":false},"dialog":{"open":false,"dirty":false},"isConfigured":true},"loyalty":{"hasSeenLoyaltyPage":false}}')
 ! https://github.com/uBlockOrigin/uAssets/pull/29946
-reisjaeger.at,mydealz.de,pepper.pl,dealabs.com,hotukdeals.com,chollometro.com##+js(trusted-click-element, button[data-t="rejectAll"], , 1000)
+preisjaeger.at,mydealz.de,pepper.pl,dealabs.com,hotukdeals.com,chollometro.com##+js(trusted-click-element, button[data-t="rejectAll"], , 1000)
 ! https://github.com/uBlockOrigin/uAssets/pull/29935
 ! Reject, kleinanzeigen.de does A/B testing with consent banner, should work with all 3 types
 kleinanzeigen.de##+js(trusted-click-element, #gdpr-banner-cmp-button,, 1000)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.preisjaeger.at/`

### Describe the issue

https://github.com/uBlockOrigin/uAssets/commit/203151a9d826a08ef808fcf0d64dfa89e771b864 changed the matching URL from `preisjaeger.at` to `reisjaeger.at`. The latter one does not exist and reintroduces the cookie notice for `preisjaeger.at`. I assume it was a typo and set it back to `preisjaeger.at`. Then the removal of the cookie notice works again.

### Versions

- Browser/version: FF 146.0.1
- uBlock Origin version: 1.68.0

### Settings

- Enable "uBlock filters – Cookie Notices"