### PR TITLE
Update badware.txt with new malicious entries

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6399,3 +6399,5 @@ sport.elwatannews.com##+js(aost, Array.prototype.indexOf, isWin)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/31351
 ||designrigoroso.com^$all,reason=malicious
+
+||https://www.pie.org^&all


### PR DESCRIPTION
Added new badware entry for `designrigoroso.com` and `pie.org`.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://designrigoroso.com/`  
`https://designrigoroso.com/*`  
`https://www.pie.org/`  
`https://www.pie.org/*`

### Describe the issue

Both `designrigoroso.com` and `pie.org` exhibit behavior consistent with badware and privacy-invasive activity.

The domains load third-party scripts that perform aggressive tracking and fingerprinting immediately on page load, before any meaningful user interaction or consent. Network inspection shows requests related to user profiling and telemetry collection.

`pie.org` is associated with an adblock-related service that presents itself as privacy-focused, while engaging in data collection practices that contradict those claims. This creates a deceptive scenario where users may believe their browsing activity is protected when it is not.

The behavior is reproducible across reloads and clean sessions and stops once the domains are blocked, indicating the issue originates from these domains.

### Screenshot(s)

Screenshots attached showing network requests, third-party tracking endpoints, and script execution occurring prior to user consent, along with blocked requests after adding the domains to the badware list.

### Versions

- Browser/version: Chrome 143.0.7499.169 (Linux x86_64)
- uBlock Origin version: 1.65 (stable)

### Settings

- Default uBlock Origin settings
- Default filter lists enabled
- No changes made to default configuration

### Notes

Investigation performed using browser developer tools (Network and Sources tabs). Tracking and fingerprinting scripts were consistently observed originating from these domains on page load. The issue is reproducible and independent of custom uBO settings. Blocking the domains via the badware list prevents the unwanted behavior.
