### PR TITLE
gitads.dev

### DIFF
--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -36,3 +36,8 @@ justwatch.com##.vpn-link
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/1q67xts/help_with_this_site/
 pornincest.net##+js(rmnt, script, /overlay/i)
+
+! gitads.dev is a site putting ads on github repos
+||gitads.dev^
+! github proxies images, but leaves the real src as an attribute
+github.com##.markdown-body *[data-canonical-src*="gitads.dev"]


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://github.com/hotheadhacker/awesome-selfhost-docker?tab=readme-ov-file

### Describe the issue

gitads.dev is a site that adds ads to github repos. I added 2 filters to fix this, one to block the domain itself, and one to block github proxied images that link to the site in markdown bodies

### Screenshot(s)

<img width="2864" height="1588" alt="image" src="https://github.com/user-attachments/assets/3d96717d-5ec8-4821-ac1d-355441da7504" />

### Versions

- Browser/version: Microsoft Edge 144.0.3719.59 (Official build) beta (arm64)
- uBlock Origin version: 1.68.0

### Settings

i added the filters to my own personal filter list and it works

### Notes

i am trying to get it into easylist but clearly its a slow process? they have a weird forum?