### PR TITLE
Add rules to block Maxroll adblocker popups

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7879,3 +7879,13 @@ liddread.com##*:style(-webkit-touch-callout: default !important; -webkit-user-se
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/223238
 canuckaudiomart.com##+js(rmnt, script, as_init)
+
+! Maxroll Adblocker Popup
+maxroll.gg##+js(set-constant, adblock, false)
+
+! Maxroll Adblocker Popup
+maxroll.gg##+js(aeld, adblock)
+
+! Maxroll Adblocker Popup
+||cdn.ziffstatic.com/jst/zdconsent.js$script,redirect=noopjs,domain=maxroll.gg
+||assets.maxroll.gg/*/adblock/*$image,redirect=1x1.png,domain=maxroll.gg


### PR DESCRIPTION
Added rules to block Maxroll adblocker popups and scripts.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://maxroll.gg/poe`

### Describe the issue

Adblock detection widget with a 15s timeout before the user can proceed.

### Screenshot(s)

<img width="1278" height="924" alt="image" src="https://github.com/user-attachments/assets/579c2e2e-4a34-41e0-8d55-476901c95d6d" />

### Versions

- Browser/version: Firefox 147
- uBlock Origin version: 1.68.0

### Settings

None

### Notes

Investigated the adblocker detection mechanism and implemented an update to the annoyances filter that prevents it from triggering.
