### PR TITLE
Fix inconsistent youtube cookie consent: reject all cookies

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -734,8 +734,9 @@ nordax.com##+js(trusted-set-cookie, cookie_consent, %7B%22allowEssentials%22%3At
 ! https://www.reddit.com/r/uBlockOrigin/comments/1693mka/
 ! https://github.com/uBlockOrigin/uAssets/issues/20586#issuecomment-2357294152
 ! youtube.com##+js(trusted-set-cookie, SOCS, CAISNQgDEitib3FfaWRlbnRpdHlmcm9udGVuZHVpc2VydmVyXzIwMjMwODI5LjA3X3AxGgJlbiADGgYIgJnPpwY, , , reload, 1, domain, youtube.com)
-www.youtube.com##+js(trusted-click-element, ytd-button-renderer.ytd-consent-bump-v2-lightbox + ytd-button-renderer.ytd-consent-bump-v2-lightbox button[aria-label], , 1000)
-m.youtube.com##+js(trusted-click-element, ytm-button-renderer.eom-accept button, , 2000)
+! Reject all = first button
+www.youtube.com##+js(trusted-click-element, .eom-buttons button[aria-label], , 1000)
+m.youtube.com##+js(trusted-click-element, ytm-button-renderer.eom-reject button, , 2000)
 ! GDPR dialog when moving from Google to Youtube
 ! https://github.com/uBlockOrigin/uAssets/discussions/18598#discussioncomment-7362961
 consent.youtube.com##+js(trusted-click-element, form[action] button[jsname="tWT92d"])


### PR DESCRIPTION
Reject all cookies from GDPR YouTube cookie consent, instead of currently sometimes accepting them.

See https://github.com/uBlockOrigin/uAssets/issues/30157#issuecomment-3809310153

### URL(s) where the issue occurs

- www.youtube.com: cookies accepted
- consent.youtube.com (e.g. redirected from any channel, like www.youtube.com/@youtube): cookies rejected

### Describe the issue
YouTube GDPR cookie consent is currently inconsistent in the Cookie Notices list:
https://github.com/uBlockOrigin/uAssets/blob/1c90eb0783c75b53569ea3dcf0e2887946f8f66d/filters/annoyances-cookies.txt#L737-L744
- youtube.com: accept all with second button (`ytm-button-renderer + ytm-button-renderer`)
- m.youtube.com: accept all with `ytm-button-renderer.eom-accept`
- consent.youtube.com: reject all with `button[jsname="tWT92d"]`

YouTube page reloads again after the click on accept all.

### Versions

- Browser/version: Firefox 147.0.1
- uBlock Origin version: 1.68.0

### Settings

- [x] uBlock filters - Cookie Notices

## Notes about changes

I tested the proposed changes with a custom filter and default settings (Cookie Notices disabled) under Firefox Desktop and Android (Fennec).

Rejecting the cookies by default has the following benefits:
- shorter load time, since the YouTube page reloads when clicking "Accept all", but not on "Reject all"
- less tracking with less cookies and no search/play history ("Your YouTube history is off")
- following GDPR default behavior to reject non-essential cookies without explicit consent
- especially useful for users who delete cookies regularly, thus getting the cookie message with every new session

### Enable additional features like play history tracking
With "uBlock filters - Cookie Notices" enabled (now  rejecting cookies):
- Change the setting explicitly, e.g. from www.youtube.com:
  <img width="616" height="208" alt="image" src="https://github.com/user-attachments/assets/7a2e3421-9b57-4560-b75a-4e051eed7686" />
- do not delete cookies for YouTube (browser settings) to keep settings between sessions

Alternative: overwrite the new default behavior with the following custom rules:
- [x] Allow custom filters requiring trust
```
! YoutTube: Accept all cookies = second button
www.youtube.com##+js(trusted-click-element, .eom-buttons > ytd-button-renderer:nth-of-type(2) button[aria-label], , 1000)
m.youtube.com##+js(trusted-click-element, ytm-button-renderer.eom-reject button, , 2000)
consent.youtube.com##+js(trusted-click-element, form[action] button[jsname="b3VHJd"])
consent.youtube.com##[data-p*="/consent.youtube.com"]:has(button[jsname="b3VHJd"])
```