### PR TITLE
Fix inconsistent youtube cookie consent: accept all cookies

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -734,14 +734,15 @@ nordax.com##+js(trusted-set-cookie, cookie_consent, %7B%22allowEssentials%22%3At
 ! https://www.reddit.com/r/uBlockOrigin/comments/1693mka/
 ! https://github.com/uBlockOrigin/uAssets/issues/20586#issuecomment-2357294152
 ! youtube.com##+js(trusted-set-cookie, SOCS, CAISNQgDEitib3FfaWRlbnRpdHlmcm9udGVuZHVpc2VydmVyXzIwMjMwODI5LjA3X3AxGgJlbiADGgYIgJnPpwY, , , reload, 1, domain, youtube.com)
+! Accept all = 2nd button
 www.youtube.com##+js(trusted-click-element, ytd-button-renderer.ytd-consent-bump-v2-lightbox + ytd-button-renderer.ytd-consent-bump-v2-lightbox button[aria-label], , 1000)
 m.youtube.com##+js(trusted-click-element, ytm-button-renderer.eom-accept button, , 2000)
 ! GDPR dialog when moving from Google to Youtube
 ! https://github.com/uBlockOrigin/uAssets/discussions/18598#discussioncomment-7362961
-consent.youtube.com##+js(trusted-click-element, form[action] button[jsname="tWT92d"])
+consent.youtube.com##+js(trusted-click-element, form[action] button[jsname="b3VHJd"])
 ! https://github.com/DandelionSprout/adfilt/discussions/932#discussioncomment-8170867
 ! https://github.com/uBlockOrigin/uAssets/discussions/18598#discussioncomment-8618202
-consent.youtube.com##[data-p*="/consent.youtube.com"]:has(button[jsname="tWT92d"])
+consent.youtube.com##[data-p*="/consent.youtube.com"]:has(button[jsname="b3VHJd"])
 
 ! https://www.empik.com/ - Functional + Social
 empik.com##+js(trusted-set-cookie, cad, $now$)


### PR DESCRIPTION
Alternative solution to PR #31660: accepting youtube cookies instead of rejecting them to enable full functionality by default, including watch history.

### Affected URLs
| URL | previous cookie choice | new cookie choice |
| ----| -- | -- |
| www.youtube.com | accept | accept |
| consent.youtube.com * | reject | accept |

*: getting redirected from e.g. any channel URL, like [www.youtube.com/@youtube](http://www.youtube.com/@youtube) (with cleared cookies)

### Notes about chosen solution
#### Overview of youtube cookie behavior
| cookies              | accept / save                   | reject / delete             |
| -------------------- | ------------------------------- | --------------------------- |
| YT history           | on                              | off                         |
| personalized content | yes                             | no                          |
| banner is shown      | once (choice saved with cookie) | after every cookie deletion |
| page reloads         | at least once                   | no                          |
| change choice without deleting cookies | only when logged in (account settings) | use "Update Settings" from message "Your YouTube history is off" (e.g. on www.youtube.com) |

Choosing "Accept all" cookies to enable full youtube functionality, which most users would expect.

### How to overwrite the cookie consent choice
To reject all youtube cookies instead, a user can add the following custom filter, with
- [x] Allow custom filters requiring trust
```adb
! Youtube cookies: disable accept all filters
www.youtube.com#@#+js(trusted-click-element, ytd-button-renderer.ytd-consent-bump-v2-lightbox + ytd-button-renderer.ytd-consent-bump-v2-lightbox button[aria-label], , 1000)
m.youtube.com#@#+js(trusted-click-element, ytm-button-renderer.eom-accept button, , 2000)
consent.youtube.com#@#+js(trusted-click-element, form[action] button[jsname="b3VHJd"])
! reject all
www.youtube.com##+js(trusted-click-element, .eom-buttons button[aria-label], , 1000)
m.youtube.com##+js(trusted-click-element, ytm-button-renderer.eom-reject button, , 2000)
consent.youtube.com##+js(trusted-click-element, form[action] button[jsname="tWT92d"])
```