### PR TITLE
fix #31697

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6346,3 +6346,6 @@ sport.elwatannews.com##+js(aost, Array.prototype.indexOf, isWin)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/31644
 comix.to##+js(json-edit-fetch-response, .result.items.*[?.content*="'+'"], propsToMatch, /comments)
+
+! https://github.com/uBlockOrigin/uAssets/issues/31697
+||fantia.paid-task.com^$all


### PR DESCRIPTION
### URL(s) where the issue occurs
`fantia.paid-task.com`

### Describe the issue
This is a scam/fraud site pretending to be affiliated with Fantia. It tries to trick users into paying or submitting personal information. 

### Screenshot(s)
[Optional: include a screenshot showing the scam site]

### Versions
- Browser/version: Firefox 147.0.2
- uBlock Origin version: 1.69.0

### Settings
- Default uBlock Origin settings
- Other extensions used: Dark Reader

### Notes
The domain `fantia.paid-task.com` is not affiliated with Fantia and is clearly fraudulent. Recommend adding it to badware.txt:
||fantia.paid-task.com^
