### PR TITLE
Phishing scam impersonating ci-en

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6348,6 +6348,7 @@ sport.elwatannews.com##+js(aost, Array.prototype.indexOf, isWin)
 comix.to##+js(json-edit-fetch-response, .result.items.*[?.content*="'+'"], propsToMatch, /comments)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/31697
+! https://info.eisys.co.jp/cien/de28df8064d7974d
 ||paid-task.com^$all
 
 ! https://github.com/uBlockOrigin/uAssets/issues/31696


### PR DESCRIPTION
### URL(s) where the issue occurs
`ci-en.paid-task.com`


### Describe the issue
This is a phishing scam impersonating **ci-en**.
The page pretends to be an official ci-en login or notification page and attempts to steal user credentials or personal information.

### Screenshot(s)
[Attach screenshots showing the phishing page impersonating ci-en. Required for visual confirmation.]

### Versions
- Browser/version: Firefox 147.0.2
- uBlock Origin version: 1.69.0

### Settings
- [List all changes made from uBO default settings, or state "Default settings"]

### Notes
- The page is not operated by ci-en.
- The domain and page structure differ from the official ci-en website.
- This appears to be a targeted phishing attempt abusing the ci-en brand.
https://info.eisys.co.jp/cien/de28df8064d7974d?locale=default
https://x.com/y_asm/status/2017926400548933840