### PR TITLE
Phishing sites impersonating ibisPaint

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6359,3 +6359,8 @@ comix.to##+js(json-edit-fetch-response, .result.items.*[?.content*="'+'"], props
 ! https://github.com/uBlockOrigin/uAssets/issues/31731
 ! https://www.virustotal.com/gui/url/adb9235105a5f16ed33071d4afdb684b8fe21f69a6b623bca09b4210606b3da0
 ||subscriptionprocess.im^$all
+
+! https://github.com/uBlockOrigin/uAssets/issues/31733
+||acc-verification.world^$all
+||l1ve-com.444774.shop^$all
+


### PR DESCRIPTION
### URL(s) where the issue occurs
`https://acc-verification.world`
`https://l1ve-com.444774.shop/`

### Describe the issue
These are phishing scams impersonating **ibisPaint**.  
The pages pretend to be official ibisPaint-related sites (such as account verification, login, or service notices) and attempt to trick users into providing credentials or other personal information.

### Screenshot(s)
[Attach screenshots showing the phishing pages impersonating ibisPaint. Required for visual confirmation.]
https://private-user-images.githubusercontent.com/144515909/544778900-458edd27-fa18-4626-b7df-fa6e83c631e1.jpg?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzAxODg2NTUsIm5iZiI6MTc3MDE4ODM1NSwicGF0aCI6Ii8xNDQ1MTU5MDkvNTQ0Nzc4OTAwLTQ1OGVkZDI3LWZhMTgtNDYyNi1iN2RmLWZhNmU4M2M2MzFlMS5qcGc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwMjA0JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDIwNFQwNjU5MTVaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1kYjFiNGMxOTA5NTk3NzFjNzFiMGRmOGNlZGU2MjA3MGRhYzUwYTFlYjUwMjAzODYzNWYyMjczNGYxYmRmMjQwJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.5w9EORilznFxqonIcj-gG-IMMbbpdq1J_wufu0gS1Og

### Versions
- Browser/version: Firefox 147.0.2
- uBlock Origin version: 1.69.0

### Settings
- Default settings (no changes)

### Notes
- These sites are not operated by ibisPaint or ibis inc.
- The domains are unrelated to the official ibisPaint website.
- Page content, layout, and behavior indicate an attempt to impersonate the ibisPaint service.
- This appears to be a targeted phishing attempt abusing the ibisPaint brand.
