### PR TITLE
Allow pasting 2FA code for TD Canada

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -7935,3 +7935,6 @@ thestudentroom.co.uk##+js(set-cookie, _tsr_pc, 0)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/31841
 ft.com##+js(aeld, copy, clipboardData)
+
+! https://github.com/uBlockOrigin/uAssets/pull/31883
+authentication.td.com###code:remove-attr(/ondrop|onpaste|onselectstart|ondrag|oncopy|oncut/)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://authentication.td.com/uap-ui/?consumer=easyweb&locale=en_CA#/uap/login`

### Describe the issue

The "Enter Security Code" field does not allow pasting or selection (though this seems to be broken on Firefox so only pasting is disallowed). This screen is only triggered when signing in from an unknown IP address from the first time.

Pasting is denied via attributes on the element with id `code`, through this code:
`onpaste="return false;"`, `onselectstart="return false"`, etc.

### Screenshot(s)

<img width="1920" height="1146" alt="Pasted image" src="https://github.com/user-attachments/assets/a75a1400-9397-478a-837f-ac4e4be45897" />


I'm assuming I don't need the rest of the template since this is a pull request!