### PR TITLE
fix: add filter for haxmac.cc

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6269,5 +6269,5 @@ comix.to##+js(json-edit-fetch-response, .result.items.*[?.content*="'+'"], props
 ! https://github.com/uBlockOrigin/uAssets/issues/31877
 ||gamesirs.com^$all
 
-!https://github.com/uBlockOrigin/uAssets/issues/31898
+! https://github.com/uBlockOrigin/uAssets/issues/31898
 haxmac.cc##a[onclick*="5anhw90hg140825oa.cfd"]


### PR DESCRIPTION
Closes https://github.com/uBlockOrigin/uAssets/issues/31898

This PR adds a filter to hide a fake download button on `haxmac.cc`.

### URL(s) where the issue occurs

`https://haxmac.cc/4k-video-downloader-crack-mac/`

### Describe the issue

The button mimics the site's design but uses an inline `onclick` event to trigger a popup to a spam domain (`5anhw90hg140825oa.cfd`) rather than a legitimate download.

### Screenshot(s)

Before:
<img width="493" height="651" alt="Snímek obrazovky 2026-02-18 v 12 01 45" src="https://github.com/user-attachments/assets/5663e889-e126-421c-836e-c45950140032" />

After:
<img width="493" height="607" alt="Snímek obrazovky 2026-02-18 v 11 59 50" src="https://github.com/user-attachments/assets/009f64cd-5a75-4bfb-aef4-d0b0bf06d618" />

### Versions

- Browser/version: Google Chrome 144.0.7559.133
- uBlock Origin version: uBlock Origin Lite 2026.215.1801

### Settings

- None

### Notes

The fake download button uses generic inline styles and lacks a unique class or ID, making it hard to target with standard CSS selectors.

I inspected the element and found it uses an inline `onclick` event to open a popup to `5anhw90hg140825oa.cfd`. I used an attribute selector targeting this domain to ensure the rule is robust and avoids false positives on legitimate download buttons.

Verified on Chrome with default uBO settings; the fake button is successfully hidden.
