### PR TITLE
Exempt docs.fingerprint.com from fingerprint blocking

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -523,10 +523,10 @@ mindbodygreen.com##+js(set-local-storage-item, segmentDeviceId, $remove$)
 *$ping,domain=webnovel.com
 
 ! https://github.com/uBlockOrigin/uAssets/issues/17652
-*$xhr,3p,denyallow=github.com|stripe.com|fpjs.pro,domain=fingerprint.com|~dev.fingerprint.com
-||fingerprint.com^$strict3p,domain=fingerprint.com|~dev.fingerprint.com|~dashboard.fingerprint.com
+*$xhr,3p,denyallow=github.com|stripe.com|fpjs.pro,domain=fingerprint.com|~dev.fingerprint.com|~docs.fingerprint.com
+||fingerprint.com^$strict3p,domain=fingerprint.com|~dev.fingerprint.com|~docs.fingerprint.com|~dashboard.fingerprint.com
 ||dashboard.fingerprint.com^$strict3p,xhr,domain=dashboard.fingerprint.com
-fingerprint.com,~dev.fingerprint.com##+js(no-xhr-if, method:POST)
+fingerprint.com,~dev.fingerprint.com,~docs.fingerprint.com##+js(no-xhr-if, method:POST)
 
 ! lightboxcdn.com
 ||lightboxcdn.com^$domain=androidauthority.com|variety.com


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://docs.fingerprint.com/reference/server-api-get-event?playground=open`

### Describe the issue

Currently uBlock Origin blocks XHR requests from docs.fingerprint.com.

This causes the API request widget embedded in the documentation site to fail when users attempt to execute requests directly from the docs (e.g. “Get event by request ID”). The browser shows: “An error occurred while making the request: unable to complete request.”

The issue appears to be related to the following rule:

`fingerprint.com,~dev.fingerprint.com##+js(no-xhr-if, method:POST)
`

Previously, the documentation was served from dev.fingerprint.com, which is explicitly excluded in the filter. The documentation has since moved to docs.fingerprint.com, which is not excluded and therefore has its POST XHR requests blocked.

Disabling the ad blocker allows the requests to succeed. The same requests also succeed via Postman and curl, indicating this is caused by client-side filtering.

To restore the intended behavior, docs.fingerprint.com should be added to the exception list (similarly to dev.fingerprint.com).

### Screenshot(s)

<img width="1372" height="491" alt="image" src="https://github.com/user-attachments/assets/53eaff5a-e724-40c8-8c06-996e8d0fba97" />