### PR TITLE
Fix the comment above the `archive.today` filters in `resource-abuse.txt`

### DIFF
--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -198,5 +198,5 @@ dlhd.*>>,~chatango.com##+js(rmnt, script, sendFakeRequest)
 ||bg-gledai.video/wp-content/plugins/crypto-converter-widget/$script,1p
 ||cdn.jsdelivr.net/gh/dejurin/crypto-converter-widget$script,domain=bg-gledai.video
 
-! https://social.coop/@eb/115902323900229756h
+! https://social.coop/@eb/115902323900229756
 archive.fo,archive.is,archive.li,archive.md,archive.ph,archive.today,archive.vn,btdig.com##+js(nosiif, fetch)


### PR DESCRIPTION
The link contained an extra `h` that prevented it from linking to a valid Mastodon post. This PR fixes that.