### PR TITLE
Exempt docs.fingerprint.com from Mintlify endpoint blocking

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -527,7 +527,7 @@ mindbodygreen.com##+js(set-local-storage-item, segmentDeviceId, $remove$)
 ||fingerprint.com^$strict3p,domain=fingerprint.com|~dev.fingerprint.com|~docs.fingerprint.com|~dashboard.fingerprint.com
 ||dashboard.fingerprint.com^$strict3p,xhr,domain=dashboard.fingerprint.com
 fingerprint.com,~dev.fingerprint.com,~docs.fingerprint.com##+js(no-xhr-if, method:POST)
-||fingerprint.com/_mintlify/api/v1/e
+||fingerprint.com/_mintlify/api/v1/e$domain=fingerprint.com|~docs.fingerprint.com
 ||fingerprint.com/Vtu1bhY5s/
 
 ! lightboxcdn.com


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://docs.fingerprint.com`

### Describe the issue

After PR #31913 exempted `docs.fingerprint.com` from fingerprint blocking, a new rule was added in commit `19570b11d9` that blocks the Mintlify analytics endpoint:

`||fingerprint.com/_mintlify/api/v1/e`

This rule has no domain restriction, so it blocks `/_mintlify/api/v1/e` globally — including on `docs.fingerprint.com`, which uses Mintlify as its documentation platform. This partially undoes the exemption granted in #31913.

The fix adds a domain restriction to scope the block to `fingerprint.com` while excluding `docs.fingerprint.com`, consistent with the existing exceptions in the same filter block (issue #17652).

### Screenshot(s)

<img width="978" height="212" alt="image" src="https://github.com/user-attachments/assets/d4d1f678-e1b8-4e13-b126-5249fc210dc6" />

### Notes

Related to https://github.com/uBlockOrigin/uAssets/issues/17652 and PR #31913. The new rule was added in commit `19570b11d9` on Feb 20, shortly after #31913 was merged.