### PR TITLE
Remove Amplitude proxy endpoint from fingerprint blocking

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -528,7 +528,6 @@ mindbodygreen.com##+js(set-local-storage-item, segmentDeviceId, $remove$)
 ||dashboard.fingerprint.com^$strict3p,xhr,domain=dashboard.fingerprint.com
 fingerprint.com,~dev.fingerprint.com,~docs.fingerprint.com##+js(no-xhr-if, method:POST)
 ||fingerprint.com/_mintlify/api/v1/e
-||fingerprint.com/Vtu1bhY5s/
 
 ! lightboxcdn.com
 ||lightboxcdn.com^$domain=androidauthority.com|variety.com


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://fingerprint.com`

### Describe the issue

A new blocking rule was recently added in commit `1b4e7a55ee` targeting an internal endpoint on fingerprint.com:

`||fingerprint.com/Vtu1bhY5s/`

This endpoint is used internally by `fingerprint.com` for core site functionality. Blocking it causes failed network requests that result in uncaught errors in the browser console, which can interfere with normal page behavior (e.g. navigation, form submissions, and interactive elements that depend on successful request lifecycles).

The existing rules in this block (issue #17652) already effectively neutralize fingerprint-related tracking via:

- `*$xhr,3p,denyallow=...` — blocks third-party XHR requests
- `||fingerprint.com^$strict3p` — blocks strict third-party requests
- `##+js(no-xhr-if, method:POST)` — blocks POST XHR requests

These rules are sufficient to prevent cross-site tracking. The additional endpoint-specific block is redundant for privacy purposes but causes breakage on the first-party website.

### Screenshot(s)

<img width="996" height="88" alt="image" src="https://github.com/user-attachments/assets/198e13c8-b379-4125-b4bd-a3445117c655" />

### Notes

Related to https://github.com/uBlockOrigin/uAssets/issues/17652 and PR #31913. The rule was added in commit `1b4e7a55ee` on Feb 20. The existing filter rules in this block already cover fingerprint tracking prevention without needing endpoint-specific blocks that cause first-party site breakage.