### PR TITLE
Update rules for streamelements

### DIFF
--- a/filters/ubo-link-shorteners.txt
+++ b/filters/ubo-link-shorteners.txt
@@ -1333,9 +1333,11 @@ fuckingfast.*##+js(acis, JSON.parse, localStorage._d)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/1g59yxn/adblock_detection_on_streamelementscom/ (https://strms .net/callofdragons_zelderler)
 ! https://link.streamelements.com/startrek_ribenchi anti-adb
-streamelements.com##+js(trusted-set, google_srt, json:0.61234)
-streamelements.com##+js(set, sensorsDataAnalytic201505, {})
+streamelements.com,strms.net##+js(trusted-set, google_srt, json:0.61234)
+streamelements.com,strms.net##+js(set, sensorsDataAnalytic201505, {})
+streamelements.com,strms.net##+js(set, vizier, {})
 ||validate.strms.net/*adblock%3Dtrue$doc,uritransform=/adblock%3Dtrue/adblock%3Dfalse/
+||validate.strms.net/*2ndcheck%3Dtrue$doc,uritransform=/2ndcheck%3Dtrue/2ndcheck%3Dfalse/
 *$script,3p,redirect-rule=noop.js,domain=streamelements.com|strms.net
 
 ! shortylink. store popup


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://landing.streamelements.com/p/fcf6b321-f861-4861-8896-1fe8b227599b?destination=https%3A%2F%2Ffnd.foundation.game%2Fpc%2Fentry-2%3Fms%3Dstreamelements%26utm_campaign%3Dfcf6b321-f861-4861-8896-1fe8b227599b%26transaction_id%3D019c57bb-bc77-7065-8790-224d842d4a5f&se_clid=019c57bb-bc77-7065-8790-224d842d4a5f&se_name=` 
Click `I want to stay anonymous` 

### Describe the issue

Anti-adblock

### Screenshot(s)

n/a

### Versions

- Browser/version: Firefox
- uBlock Origin version: 1.69.0

### Settings

n/a

### Notes




Clicking on `I want to stay anonymous`  redirects to

<details><summary>Long URL</summary>https://validate.strms.net/?destination=https%3A%2F%2Flanding.streamelements.com%2Fp%2Ffcf6b321-f861-4861-8896-1fe8b227599b%3Fdestination%3Dhttps%253A%252F%252Ffnd.foundation.game%252Fpc%252Fentry-2%253Fms%253Dstreamelements%2526utm_campaign%253Dfcf6b321-f861-4861-8896-1fe8b227599b%2526transaction_id%253D019ca754-7fd6-7dbe-a540-76e7be0e3427%26se_clid%3D019ca754-7fd6-7dbe-a540-76e7be0e3427%26se_name%3D%262ndcheck%3Dfalse&se_clid=019ca754-7fd6-7dbe-a540-76e7be0e3427&se_name=&return_to=https%3A%2F%2Flanding.streamelements.com%2Fp%2Ffcf6b321-f861-4861-8896-1fe8b227599b%3Fdestination%3Dhttps%253A%252F%252Ffnd.foundation.game%252Fpc%252Fentry-2%253Fms%253Dstreamelements%2526utm_campaign%253Dfcf6b321-f861-4861-8896-1fe8b227599b%2526transaction_id%253D019ca754-7fd6-7dbe-a540-76e7be0e3427%26se_clid%3D019ca754-7fd6-7dbe-a540-76e7be0e3427%26se_name%3D%262ndcheck%3Dfalse</details>

Which uses a short anti-adblock script (`https://validate.strms.net/assets/index-B2COBCj5.js`) that has apparently been updated since these filters were added

BTW, the user might actually want to disable their adblocker here, since this is a referral link to support a specific streamer, and the referral will probably not "work" (the tracking/attribution is probably blocked) with uBO enabled. So there is maybe a small argument to removing these, but since they were already added, I suppose someone already made a call on that.