### PR TITLE
Suppressing the lenovo.com/gb cookie message

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5357,3 +5357,6 @@ itavisen.no##+js(trusted-click-element, [id="qc-cmp2-ui"] button[class*="css-"]:
 
 ! https://github.com/uBlockOrigin/uAssets/issues/31960
 camaramar.com##+js(trusted-click-element, button.button.accept, , 2000)
+
+! necessary
+lenovo.com##+js(trusted-set-cookie, _evidon_suppress_notification_cookie, '{"date":"$currentISODate$","suppressed":true}')


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.lenovo.com/gb/en/`

### Describe the issue

Cookie popup is loaded on page load. It needs to be suppressed.

### Versions

- Browser/version: Brave 1.87.191 (Official Build)
- uBlock Origin version: uBlock Origin Lite 2026.301.2014

### Settings

- Added trusted cookie to suppress the notification (similar to how forum.lenovo.com was handled)

### Notes

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2196
