### PR TITLE
Suppressing the fes.de cookie message

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -571,6 +571,9 @@ antallaktikaonline.gr,auto-onderdelen24.nl,autoalkatreszonline24.hu,autodeler.co
 antallaktikaonline.gr,auto-onderdelen24.nl,autoalkatreszonline24.hu,autodeler.co.no,automobilovedily24.cz,autonvaraosat24.fi,autoparti.it,autopecasonline24.pt,autopieseonline24.ro,avtochastionline24.bg,bildelaronline24.se,bildeleshop.dk,buycarparts.co.uk,czesciauto24.pl,onderdelen24.be,pieces24.be,piecesauto24.com,pkwteile.at,pkwteile.ch,pkwteile.de,recambioscoches.es##+js(trusted-click-element, button[data-cookies="disallow_all_cookies"])
 ! https://github.com/uBlockOrigin/uAssets/pull/32051
 lenovo.com##+js(trusted-set-cookie, _evidon_suppress_notification_cookie, '{"date":"$currentISODate$","suppressed":true}', , , domain, .lenovo.com)
+! https://github.com/brave-experiments/cookiecrumbler-issues/issues/2208
+fes.de##+js(trusted-set-cookie, cookie_consent, '%7B%22consent%22:true,%22options%22:%5B%5D%7D')
+
 
 !! Needs additional cookies
 
@@ -5361,6 +5364,3 @@ camaramar.com##+js(trusted-click-element, button.button.accept, , 2000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/32054
 maxjeune-tgvinoui.sncf##+js(trusted-click-element, #didomi-notice-agree-button)
-
-! https://github.com/brave-experiments/cookiecrumbler-issues/issues/2208
-fes.de##+js(trusted-set-cookie, cookie_consent, %7B%22consent%22:true,%22options%22:%5B%5D%7D)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.fes.de/`

### Describe the issue

Cookie popup is loaded on page load. It needs to be suppressed.

### Versions

- Browser/version: Brave 1.87.191 (Official Build)
- uBlock Origin version: uBlock Origin Lite 2026.301.2014

### Settings

- Added trusted cookie to suppress the notification (note: this value is URL-encoded)

### Notes

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2208
