### PR TITLE
Rejecting unnecessary cookies on bonanza.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5364,3 +5364,7 @@ camaramar.com##+js(trusted-click-element, button.button.accept, , 2000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/32054
 maxjeune-tgvinoui.sncf##+js(trusted-click-element, #didomi-notice-agree-button)
+
+! Reject
+! https://github.com/brave-experiments/cookiecrumbler-issues/issues/694
+bonanza.com##+js(trusted-set-cookie, okb, reject)


### PR DESCRIPTION
URL(s) where the issue occurs
`https://www.bonanza.com/`

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.87.191 (Official Build)
uBlock Origin version: uBlock Origin Lite 2026.301.2014
Settings
Added trusted cookie to suppress the notification and reject non-essential cookies
Notes
Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/694