### PR TITLE
Reject unnecessary cookies for service-public.gouv.fr

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5364,3 +5364,7 @@ camaramar.com##+js(trusted-click-element, button.button.accept, , 2000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/32054
 maxjeune-tgvinoui.sncf##+js(trusted-click-element, #didomi-notice-agree-button)
+
+! Necessary
+! https://github.com/brave-experiments/cookiecrumbler-issues/issues/1393
+service-public.gouv.fr##+js(set-cookie, SP_RGPD_OREJIME, '{"internal-tracker":true,"eulerian":false,"ab-tasty":false,"streaming-video":false}')


### PR DESCRIPTION
URL(s) where the issue occurs
`service-public.gouv.fr`

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.87.191 (Official Build)
uBlock Origin version: uBlock Origin Lite 2026.301.2014

Settings
Added trusted cookie to suppress the notification and reject non-essential cookies

Notes
Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1393
