### PR TITLE
Suppressing the wistia.com cookie message

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5367,3 +5367,7 @@ maxjeune-tgvinoui.sncf##+js(trusted-click-element, #didomi-notice-agree-button)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/32077
 gold.ac.uk##+js(trusted-click-element, button.ccc-accept-button)
+
+! Functional
+! https://github.com/brave-experiments/cookiecrumbler-issues/issues/367
+wistia.com##+js(trusted-set-local-storage-item, wistia_cookie_consent, '{"ad_storage":"denied","analytics_storage":"denied","functionality_storage":"granted","personalization_storage":"denied","security_storage":"granted","ad_user_data":"denied","ad_personalization":"denied"}')


### PR DESCRIPTION
URL(s) where the issue occurs
`https://wistia.com/`

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.87.191 (Official Build)
uBlock Origin version: uBlock Origin Lite 2026.301.2014

Settings
Added trusted local storage variable to suppress the notification

Notes
Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/367