### PR TITLE
add spotify to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,7 +17,7 @@ body:
       description: |
         **IMPORTANT:** Answer carefully and truthfully.
       options:
-        - label: This is **NOT** a [_YouTube_](https://www.github.com/uBlockOrigin/uAssets/issues/30157), [_Facebook_](https://www.github.com/uBlockOrigin/uAssets/issues/3367), [_Twitch_](https://www.github.com/uBlockOrigin/uAssets/issues/5184) or [_a shortener/hosting site_](https://www.github.com/uBlockOrigin/uAssets/discussions/27472) report. _These sites MUST be reported by clicking their **respective links**_.
+        - label: This is **NOT** a [_YouTube_](https://www.github.com/uBlockOrigin/uAssets/issues/30157), [_Facebook_](https://www.github.com/uBlockOrigin/uAssets/issues/3367), [_Twitch_](https://www.github.com/uBlockOrigin/uAssets/issues/5184), [_Spotify_](https://github.com/uBlockOrigin/uAssets/issues/22198) or [_a shortener/hosting site_](https://www.github.com/uBlockOrigin/uAssets/discussions/27472) report. _These sites MUST be reported by clicking their **respective links**_.
           required: true
         - label: I read and understand the [policy about what is a valid filter issue](https://github.com/uBlockOrigin/uAssets/blob/master/README.md#uassets).
           required: true

--- a/.github/ISSUE_TEMPLATE/report_from_ubo.yml
+++ b/.github/ISSUE_TEMPLATE/report_from_ubo.yml
@@ -17,7 +17,7 @@ body:
       description: |
         **IMPORTANT:** Answer carefully and truthfully.
       options:
-        - label: This is **NOT** a [_YouTube_](https://www.github.com/uBlockOrigin/uAssets/issues/30157), [_Facebook_](https://www.github.com/uBlockOrigin/uAssets/issues/3367), [_Twitch_](https://www.github.com/uBlockOrigin/uAssets/issues/5184) or [_a shortener/hosting site_](https://www.github.com/uBlockOrigin/uAssets/discussions/27472) report. _These sites MUST be reported by clicking their **respective links**_.
+        - label: This is **NOT** a [_YouTube_](https://www.github.com/uBlockOrigin/uAssets/issues/30157), [_Facebook_](https://www.github.com/uBlockOrigin/uAssets/issues/3367), [_Twitch_](https://www.github.com/uBlockOrigin/uAssets/issues/5184), [_Spotify_](https://github.com/uBlockOrigin/uAssets/issues/22198) or [_a shortener/hosting site_](https://www.github.com/uBlockOrigin/uAssets/discussions/27472) report. _These sites MUST be reported by clicking their **respective links**_.
           required: true
         - label: I read and understand the [policy about what is a valid filter issue](https://github.com/uBlockOrigin/uAssets/blob/master/README.md#uassets).
           required: true

--- a/.github/ISSUE_TEMPLATE/specific_report_from_ubo.yml
+++ b/.github/ISSUE_TEMPLATE/specific_report_from_ubo.yml
@@ -17,7 +17,7 @@ body:
       description: |
         **IMPORTANT:** Answer carefully and truthfully.
       options:
-        - label: This is **NOT** a [_YouTube_](https://www.github.com/uBlockOrigin/uAssets/issues/30157), [_Facebook_](https://www.github.com/uBlockOrigin/uAssets/issues/3367), [_Twitch_](https://www.github.com/uBlockOrigin/uAssets/issues/5184) or [_a shortener/hosting site_](https://www.github.com/uBlockOrigin/uAssets/discussions/27472) report. _These sites MUST be reported by clicking their **respective links**_.
+        - label: This is **NOT** a [_YouTube_](https://www.github.com/uBlockOrigin/uAssets/issues/30157), [_Facebook_](https://www.github.com/uBlockOrigin/uAssets/issues/3367), [_Twitch_](https://www.github.com/uBlockOrigin/uAssets/issues/5184), [_Spotify_](https://github.com/uBlockOrigin/uAssets/issues/22198) or [_a shortener/hosting site_](https://www.github.com/uBlockOrigin/uAssets/discussions/27472) report. _These sites MUST be reported by clicking their **respective links**_.
           required: true
         - label: I read and understand the [policy about what is a valid filter issue](https://github.com/uBlockOrigin/uAssets/blob/master/README.md#uassets).
           required: true

--- a/.github/ISSUE_TEMPLATE/specific_report_from_ubol.yml
+++ b/.github/ISSUE_TEMPLATE/specific_report_from_ubol.yml
@@ -18,7 +18,7 @@ body:
       description: |
         **IMPORTANT:** Answer carefully and truthfully.
       options:
-        - label: This is **NOT** a [_YouTube_](https://www.github.com/uBlockOrigin/uAssets/issues/30158), [_Facebook_](https://www.github.com/uBlockOrigin/uAssets/issues/3367), [_Twitch_](https://www.github.com/uBlockOrigin/uAssets/issues/5184) or [_a shortener/hosting site_](https://www.github.com/uBlockOrigin/uAssets/discussions/27472) report. _These sites MUST be reported by clicking their **respective links**_.
+        - label: This is **NOT** a [_YouTube_](https://www.github.com/uBlockOrigin/uAssets/issues/30158), [_Facebook_](https://www.github.com/uBlockOrigin/uAssets/issues/3367), [_Twitch_](https://www.github.com/uBlockOrigin/uAssets/issues/5184), [_Spotify_](https://github.com/uBlockOrigin/uAssets/issues/22198) or [_a shortener/hosting site_](https://www.github.com/uBlockOrigin/uAssets/discussions/27472) report. _These sites MUST be reported by clicking their **respective links**_.
           required: true
         - label: I read and understand the [policy about what is a valid filter issue](https://github.com/uBlockOrigin/uAssets/blob/master/README.md#uassets).
           required: true


### PR DESCRIPTION
### Describe the issue
there is a megathread for https://github.com/uBlockOrigin/uAssets/issues/22198 but the issue template doesn't include it. all other megathreads are in the issue template. would be nice to also list it here to try to reduce duplicates

feel free to reject if spotify: ads / breakages / nuisances != ALL spotify issues