### PR TITLE
Rejecting cookies from poki.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5403,3 +5403,8 @@ wistia.com##+js(trusted-set-local-storage-item, wistia_cookie_consent, '{"ad_sto
 
 ! https://github.com/uBlockOrigin/uAssets/issues/32149
 frandroid.com##+js(trusted-click-element, button[id="didomi-notice-agree-button"])
+
+! Reject
+! https://github.com/brave-experiments/cookiecrumbler-issues/issues/711
+poki.com##+js(trusted-set-local-storage-item, state/privacy/familyModeCookieConsentShown, '{"time":$now$,"value":"true"}')
+poki.com##+js(trusted-set-local-storage-item, state/privacy/pokiAnalytics, '{"time":$now$,"value":"false"}')


### PR DESCRIPTION
URL(s) where the issue occurs
`https://poki.com/`

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.87.191 (Official Build)
uBlock Origin version: uBlock Origin Lite 2026.301.2014

Settings
Added trusted cookie to suppress the notification and reject non-essential cookies

Notes
Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/711