### PR TITLE
Rejecting unnecessary cookies from samsungcloud

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5411,3 +5411,8 @@ poki.com##+js(trusted-set-local-storage-item, state/privacy/pokiAnalytics, '{"ti
 
 ! https://github.com/uBlockOrigin/uAssets/issues/32165
 politiken.dk##+js(trusted-click-element, button#CybotCookiebotDialogBodyButtonDecline)
+
+! Reject
+! https://github.com/brave-experiments/cookiecrumbler-issues/issues/2047
+samsungcloud.com##+js(trusted-set-cookie, _cookie_accepted, true)
+samsungcloud.com##+js(trusted-set-local-storage-item, _f_cookies, false)


### PR DESCRIPTION
URL(s) where the issue occurs
`https://www.samsungcloud.com/` (when visiting from UK, and potentially other countries)

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.87.192(Official Build)

Settings
Added trusted cookie (when you reject cookies, the _cookie_accepted flag is set to true) to suppress the notification and then set the local storage item to reject non-essential cookies. 

Notes
I've seen multiple user reports for this issue (some from community posts outside of Github as well)
Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2047