### PR TITLE
Address Unsubscribe issues on https://github.com/brave/brave-browser/issues/53588

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1503,8 +1503,6 @@ $removeparam=adjust_campaign
 $removeparam=ir_campaignid
 $removeparam=ir_adid
 $removeparam=ir_partnerid
-! https://github.com/brave/brave-browser/issues/34578
-$removeparam=_kx
 ! AT Internet
 ! https://github.com/brave/brave-browser/issues/32488
 $removeparam=at_campaign


### PR DESCRIPTION
https://github.com/brave/brave-browser/issues/53588

> It turns out that, like the https://github.com/brave/brave-browser/issues/10151, it's necessary for unsubscribe links to work.

Safer to remove, Will be removed from brave-core also.

