### PR TITLE
Fixing alignment on tvtv.ca,tvtv.us

### DIFF
--- a/filters/filters-2022.txt
+++ b/filters/filters-2022.txt
@@ -3533,6 +3533,8 @@ tvtv.ca,tvtv.us##.css-1352p5e:style(height: 2400px !important;)
 tvtv.ca,tvtv.us##.css-1s6rfoz:style(height: 2400px !important;)
 tvtv.ca,tvtv.us##.css-1wm768n:style(height: 1560px !important;)
 tvtv.ca,tvtv.us##.MuiDialog-paperScrollPaper > .MuiDialogContent-root + .MuiBox-root
+tvtv.ca,tvtv.us##.css-1umi0ps:style(margin-top:0 !important;) 
+
 !#if env_mobile
 tvtv.ca,tvtv.us##.css-1wrjilj:style(margin-top: 0 !important; height: 2400px !important;)
 tvtv.ca,tvtv.us##.css-laxwha:style(height: 2400px !important;)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.tvtv.us/` and `https://www.tvtv.ca/`

Example: `https://www.tvtv.us/in/elkhart/46514/luUSA-IN13426-X`

### Describe the issue

The alignment of the channels and the actual programming is incorrect. For example, please look at my screenshots. Channel 3 should be "Local Origination Programming", but instead it is empty.

The issue with the alignment is in the table itself.
The table uses the first row of the channels column as a placeholder for the ads (108px height). Then, the other columns all have a margin-top of 108px to match.

When blocking the ads, we hide that placeholder div. However, the other columns still have the margin-top of 108px, so they will all be offset.

### Screenshot(s)

Before:
<img width="1377" height="671" alt="image" src="https://github.com/user-attachments/assets/8c827a6b-5d16-4576-8d8e-7f88ff22afe1" />




After:
<img width="1376" height="741" alt="image" src="https://github.com/user-attachments/assets/6db59920-55d7-4345-81cc-424fa08a3adb" />




### Versions

- Browser/version: 1.87.192

### Settings

I am setting the margin-top to 0 on the remaining columns to 0. This way, the blocking of the placeholder div no longer throws off the alignment of the other columns.