### PR TITLE
Only necessary cookies on gx.me

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -573,6 +573,8 @@ antallaktikaonline.gr,auto-onderdelen24.nl,autoalkatreszonline24.hu,autodeler.co
 lenovo.com##+js(trusted-set-cookie, _evidon_suppress_notification_cookie, '{"date":"$currentISODate$","suppressed":true}', , , domain, .lenovo.com)
 ! https://github.com/brave-experiments/cookiecrumbler-issues/issues/2208
 fes.de##+js(trusted-set-cookie, cookie_consent, '%7B%22consent%22:true,%22options%22:%5B%5D%7D')
+! https://github.com/brave-experiments/cookiecrumbler-issues/issues/2229
+gx.me##+js(trusted-set-cookie, cookie-consent, '{"marketing":false,"necessary":true,"version":2}', , , domain, .gx.me)
 
 
 !! Needs additional cookies
@@ -5411,7 +5413,3 @@ poki.com##+js(trusted-set-local-storage-item, state/privacy/pokiAnalytics, '{"ti
 
 ! https://github.com/uBlockOrigin/uAssets/issues/32165
 politiken.dk##+js(trusted-click-element, button#CybotCookiebotDialogBodyButtonDecline)
-
-! Necessary
-! https://github.com/brave-experiments/cookiecrumbler-issues/issues/2229
-gx.me##+js(trusted-set-cookie, cookie-consent, '{"marketing":false,"necessary":true,"version":2}')


### PR DESCRIPTION
URL(s) where the issue occurs
`gx.me`

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.87.192 (Official Build)

Settings
Added trusted cookie to suppress the notification

Notes
https://github.com/brave-experiments/cookiecrumbler-issues/issues/2229