### PR TITLE
Rejecting cookies on tacobell.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5419,4 +5419,4 @@ dilosi.services.gov.gr##+js(trusted-set-cookie, dilosi_cookie, Accept_cookies)
 
 ! Reject
 ! https://github.com/brave-experiments/cookiecrumbler-issues/issues/1872
-tacobell.co.uk##+js(trusted-set-local-storage-item, tcmConsent,'{"purposes":{"Email":"Auto","Sms":"Auto","Functional":false,"Analytics":false,"Advertising":false},"timestamp":"2026-03-17T15:32:38.332Z","confirmed":true,"prompted":true,"updated":true}')
+tacobell.co.uk##+js(trusted-set-local-storage-item, tcmConsent,'{"purposes":{"Email":"Auto","Sms":"Auto","Functional":false,"Analytics":false,"Advertising":false},"timestamp":$now$,"confirmed":true,"prompted":true,"updated":true}')


### PR DESCRIPTION
URL(s) where the issue occurs
`https://www.tacobell.co.uk/` -- only an issue in the UK

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.88.132 (Official Build)

Settings
Added trusted local storage item to suppress the notification

Notes
https://github.com/brave-experiments/cookiecrumbler-issues/issues/1872