### PR TITLE
Suppressing cookie banner on opensea.io

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -575,6 +575,8 @@ lenovo.com##+js(trusted-set-cookie, _evidon_suppress_notification_cookie, '{"dat
 fes.de##+js(trusted-set-cookie, cookie_consent, '%7B%22consent%22:true,%22options%22:%5B%5D%7D')
 ! https://github.com/brave-experiments/cookiecrumbler-issues/issues/2229
 gx.me##+js(trusted-set-cookie, cookie-consent, '{"marketing":false,"necessary":true,"version":2}', , , domain, .gx.me)
+! https://github.com/uBlockOrigin/uAssets/pull/32241
+opensea.io##+js(trusted-click-element, button[data-role="necessary"])
 
 
 !! Needs additional cookies
@@ -5416,7 +5418,3 @@ politiken.dk##+js(trusted-click-element, button#CybotCookiebotDialogBodyButtonDe
 
 ! https://github.com/uBlockOrigin/uAssets/issues/32234
 dilosi.services.gov.gr##+js(trusted-set-cookie, dilosi_cookie, Accept_cookies)
-
-! Reject
-https://github.com/brave-experiments/cookiecrumbler-issues/issues/2012
-opensea.io##+js(trusted-click-element, button[data-role="necessary"])


### PR DESCRIPTION
URL(s) where the issue occurs
`opensea.io` -- reproducible in Europe

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.88.132 (Official Build)

Settings
Added trusted click element to suppress the notification

Notes
Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2012