### PR TITLE
Suppressing cookie popup on bt.dk

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5416,3 +5416,7 @@ politiken.dk##+js(trusted-click-element, button#CybotCookiebotDialogBodyButtonDe
 
 ! https://github.com/uBlockOrigin/uAssets/issues/32234
 dilosi.services.gov.gr##+js(trusted-set-cookie, dilosi_cookie, Accept_cookies)
+
+! Only Necessary
+! https://github.com/brave-experiments/cookiecrumbler-issues/issues/912
+bt.dk##+js(trusted-click-element, #CybotCookiebotDialogBodyButtonDecline)


### PR DESCRIPTION
URL(s) where the issue occurs
`https://www.bt.dk/`

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.88.132 (Official Build)

Settings
Added trusted click element to suppress the notification

Notes
Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/912