### PR TITLE
Suppressing cookie popup on la7.it

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5418,3 +5418,7 @@ dilosi.services.gov.gr##+js(trusted-set-cookie, dilosi_cookie, Accept_cookies)
 ! Only Necessary
 ! https://github.com/brave-experiments/cookiecrumbler-issues/issues/912
 bt.dk##+js(trusted-click-element, #CybotCookiebotDialogBodyButtonDecline)
+
+! Reject
+https://github.com/brave-experiments/cookiecrumbler-issues/issues/2230
+la7.it##+js(trusted-click-element, #btn_donotaccept)


### PR DESCRIPTION
URL(s) where the issue occurs
`la7.it`

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.88.132 (Official Build)

Fix
Added trusted click element to suppress the notification

Notes
Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2230