### PR TITLE
Rejecting cookies from theweathernetwork

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -582,6 +582,8 @@ opensea.io##+js(trusted-click-element, button[data-role="necessary"])
 iteraplay.com##+js(trusted-set-local-storage-item, itera_cookie_consent, '{"strictlyNecessary":true,"analytics":false,"marketing":false,"functional":false}')
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227341
 cinemark.com.br##+js(set-cookie, cookies_config, deny)
+! https://github.com/uBlockOrigin/uAssets/pull/32262
+theweathernetwork.com##+js(trusted-click-element, #didomi-notice-disagree-button)
 
 
 !! Needs additional cookies
@@ -5426,7 +5428,3 @@ bt.dk##+js(trusted-click-element, #CybotCookiebotDialogBodyButtonDecline)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227343 - functional
 spmaiscultura.prefeitura.sp.gov.br##+js(trusted-set-cookie, spmaiscultura-prefs, %7B%22functional%22%3Atrue%2C%22analytics%22%3Afalse%7D)
-
-! Reject
-! https://github.com/brave-experiments/cookiecrumbler-issues/issues/2041
-theweathernetwork.com##+js(trusted-click-element, #didomi-notice-disagree-button)


### PR DESCRIPTION
URL(s) where the issue occurs
`https://www.theweathernetwork.com/` -- when accessing the site from the UK

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.88.132 (Official Build)

Fix
Added trusted click element to suppress the notification

Notes
Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2041