### PR TITLE
Rejecting unnecessary cookies for woocommerce

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5432,3 +5432,8 @@ hbomax.com##+js(trusted-click-element, button.btn.btn--privacy-primary, , 1000)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227343 - functional
 spmaiscultura.prefeitura.sp.gov.br##+js(trusted-set-cookie, spmaiscultura-prefs, %7B%22functional%22%3Atrue%2C%22analytics%22%3Afalse%7D)
+
+! Only Necessary
+! https://github.com/brave-experiments/cookiecrumbler-issues/issues/633
+woocommerce.com##+js(trusted-set-cookie, wccom_cookie_consent_advertising, denied)
+woocommerce.com##+js(trusted-set-cookie, wccom_cookie_consent_analytics, denied)


### PR DESCRIPTION
URL(s) where the issue occurs
`woocommerce.com`

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.88.132 (Official Build)

Fix
Added two trusted cookies to the page for advertising and analytics

Notes
Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/633