### PR TITLE
NSFW - Rejecting unnecessary cookies on faphouse.tv

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5432,3 +5432,7 @@ hbomax.com##+js(trusted-click-element, button.btn.btn--privacy-primary, , 1000)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227343 - functional
 spmaiscultura.prefeitura.sp.gov.br##+js(trusted-set-cookie, spmaiscultura-prefs, %7B%22functional%22%3Atrue%2C%22analytics%22%3Afalse%7D)
+
+! Reject
+! https://github.com/brave-experiments/cookiecrumbler-issues/issues/2095
+faphouse.tv##+js(trusted-set-cookie, cookie-settings, '{"all":0,"functional":0,"essentials":1,"analytical":0}')


### PR DESCRIPTION
URL(s) where the issue occurs
`faphouse.tv` - NSFW - reproducible from the UK

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.88.132 (Official Build)

Fix
Added trusted set cookie to suppress the cookie popup.

Notes
Related to this issue, however, this is not the full fix. I will also need to make a commit on ELC to hide the cookie banner that appears after rejecting cookies.
https://github.com/brave-experiments/cookiecrumbler-issues/issues/2095