### PR TITLE
Rejecting cookies from humanartistrycampaign.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5432,3 +5432,6 @@ hbomax.com##+js(trusted-click-element, button.btn.btn--privacy-primary, , 1000)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227343 - functional
 spmaiscultura.prefeitura.sp.gov.br##+js(trusted-set-cookie, spmaiscultura-prefs, %7B%22functional%22%3Atrue%2C%22analytics%22%3Afalse%7D)
+
+! Reject
+humanartistrycampaign.com##+js(trusted-click-element, button[data-hook="consent-banner-decline-all-button"])


### PR DESCRIPTION
URL(s) where the issue occurs
`https://www.humanartistrycampaign.com/`

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed.

Versions
Browser/version: Brave 1.88.132 (Official Build)

Fix
Added trusted click element to suppress the cookie popup.