### PR TITLE
Only accepting necessary cookies for PostNL

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5434,3 +5434,6 @@ hbomax.com##+js(trusted-click-element, button.btn.btn--privacy-primary, , 1000)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/227343 - functional
 spmaiscultura.prefeitura.sp.gov.br##+js(trusted-set-cookie, spmaiscultura-prefs, %7B%22functional%22%3Atrue%2C%22analytics%22%3Afalse%7D)
+
+! Only Necessary
+postnl.nl##+js(trusted-set-cookie, CookiePermissionInfo, '{"Version":9999,"LastModifiedDate":$now$,"ExpirationDate":$now$,"Allow":true,"CategoryPermission":[{"Category":"Cat.8","Permission":true},{"Category":"Cat.9","Permission":true},{"Category":"Cat.7","Permission":false},{"Category":"Cat.10","Permission":false},{"Category":"Cat.11","Permission":false},{"Category":"Cat.12","Permission":false}]}')


### PR DESCRIPTION
URL(s) where the issue occurs
`postnl.nl`

Describe the issue
Cookie popup is loaded on page load. It needs to be suppressed. Using a cosmetic filter will not work because the page will not scroll until the cookie has been set correctly.

Versions
Browser/version: Brave 1.88.132 (Official Build)

Fix
Added trusted set cookie to satisfy this cookie popup. Note, the version of the cookie just needs to be greater than or equal to the current cookie wall version (3). I set this to 99 so that we will not have to adjust this in the near future.