### PR TITLE
weddingbee.com cookies

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5441,5 +5441,5 @@ learner.mycreds.ca##+js(trusted-set-local-storage-item, acceptedCookies, '{"perf
 ! https://github.com/hufilter/hufilter/issues/722
 nemzetisport.hu##+js(trusted-click-element, '#qc-cmp2-container #disagree-btn', , 4000)
 
-! Necessary + Functional
+! https://github.com/uBlockOrigin/uAssets/pull/32335 - Functional
 weddingbee.com##+js(trusted-set-cookie, OptanonConsent, groups=C0001%3A1%2CC0002%3A0%2CC0003%3A1%2CC0004%3A0, , , domain, weddingbee.com)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`www.weddingbee.com/find`

### Describe the issue

Users are reporting that searching doesn't work on this page. This is due to functional cookies being disabled by default on Brave. 

I did some digging through the source of this site. What is actually happening here is that the site looks at the navigator.globalPrivacyControl value and if it is true (which is the value when shields are on), sets groups C0002, C0003, c0004 to 0. If this value is false, they all get set to 1. This means functional cookies are being blocked when we haven't even seen a cookie consent.

### Versions

- Browser/version: Brave 1.88.136 (Official Build)

### Settings

Added a trusted-set-cookie to accept both the necessary and functional cookies for this site.