### PR TITLE
Fixing talksport.com cookie selection

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5075,7 +5075,7 @@ wrc.com##+js(trusted-set-cookie, OptanonConsent, groups=C0001%3A1%2CC0002%3A0%2C
 wrc.com##+js(trusted-set-cookie, OptanonAlertBoxClosed, $currentDate$, , , domain, .wrc.com)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/27915
-talksport.com##+js(trusted-click-element, button.allow-cookies-once)
+talksport.com##+js(trusted-click-element, button.accept-all)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/28030
 hukumonline.com##+js(trusted-set-cookie, hol_CookiePreferences, '{"necessary":true,"analytics":false,"advertising":false}')


### PR DESCRIPTION
### URL(s) where the issue occurs

`talksport.com` - when visiting from the UK

### Describe the issue

The cookie message needs to be accepted to get past the paywall. There was already a trusted click element, but it looks like the site has updated and this is no longer applicable

### Versions

- Browser/version: Brave 1.88.136

### Settings

Updated the trusted-click-element for this page

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/906
