### PR TITLE
Add filter for video ad on klix.ba

### DIFF
--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -489,3 +489,6 @@ splay.id##+js(nowoif, maddenwiped)
 chichi-pui.com##:not(:matches-path(/fanza/)) section:has(> div.c-section-title-button > a[href^="/fanza/"])
 chichi-pui.com##:not(:matches-path(/fanza/)) 
 chichi-pui.com##:not(:matches-path(/fanza/)) .p-image-cards__item:has(> a.gtm-event-click)
+
+! https://www.klix.ba/ (Video Ad)
+www.klix.ba###video-wallpaper:remove()


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.klix.ba/`

### Describe the issue

Video ad on the front page.

### Screenshot(s)

### Versions

- Browser/version: Waterfox 6.6.9
- uBlock Origin version: 1.70.0

### Settings

### Notes
