### PR TITLE
Badware - Add studio-blender.com

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6311,4 +6311,4 @@ ublockorigin.app###main::before:style(content: 'This is not the official uBlock 
 ||plus.rustfacepunch.com^$all
 
 ! https://www.virustotal.com/gui/url/8764b4533420b416e4718b0d5190cb7219b88da55814d0f6f746b20de63e0028
-||studio-blender.com/^$all
+||studio-blender.com^$all


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://studio-blender.com/`

### Describe the issue

Domain pretends to be blender.org (real).
The download provided by studio-blender.com contains malware.

### Screenshot(s)

n/a

### Versions

- Browser/version: n/a
- uBlock Origin version: n/a

### Settings

- Update badware list

### Notes

https://www.virustotal.com/gui/url/8764b4533420b416e4718b0d5190cb7219b88da55814d0f6f746b20de63e0028
