### PR TITLE
hiding neoxsoftworks.eu ad popup

### DIFF
--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -517,4 +517,4 @@ desifakes.com##+js(rmnt, script, navigator.userAgent)
 pitube.net##+js(rmnt, script, /request|_0x/)
 
 ! https://neoxsoftworks.eu/ - ad popup
-neoxsoftworks.eu##+js(trusted-set-session-storage-item, adblockDismissed, 1)
+neoxsoftworks.eu##+js(set-session-storage-item, adblockDismissed, 1)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://neoxsoftworks.eu/`

### Describe the issue

When using the site with an adblocker, the site detects the adblocker and prompts the user to disable it.

### Screenshot(s)
<img width="1043" height="977" alt="Screenshot 2026-03-30 at 12 02 10 PM" src="https://github.com/user-attachments/assets/71838c6a-6c8c-4679-8558-532c50f5be46" />
<img width="589" height="175" alt="Screenshot 2026-03-30 at 11 49 41 AM" src="https://github.com/user-attachments/assets/84187a24-9099-4ef1-a76e-872175224949" />

### Versions

- Browser/version: Brave 1.88.136

### Settings

Added a session storage variable to this site that sets the adblockDismissed value to 1, so that it bypasses the adblock check.
