### PR TITLE
Hiding popup on pinterest.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5468,3 +5468,7 @@ elysee.fr##+js(trusted-set-cookie, tarteaucitron, !eulerian-analytics=false!inst
 
 ! https://github.com/uBlockOrigin/uAssets/pull/32335 - Functional
 weddingbee.com##+js(trusted-set-cookie, OptanonConsent, groups=C0001%3A1%2CC0002%3A0%2CC0003%3A1%2CC0004%3A0, , , domain, weddingbee.com)
+
+! Reject
+! https://github.com/brave-experiments/cookiecrumbler-issues/issues/2048
+pinterest.com##+js(trusted-click-element, .unzjra button:first-child)


### PR DESCRIPTION
### URL(s) where the issue occurs

`pinterest.com`

### Describe the issue

pinterest.com has a cookie popup that appears to users. This popup needs to be suppressed.

### Screenshots
<img width="1647" height="918" alt="image" src="https://github.com/user-attachments/assets/4039aafc-d4e9-4542-ac06-49dbbdb95290" />


### Versions

- Browser/version: Brave 1.88.136

### Settings

Set a trusted click element on the "Reject All" setting in the cookie popup

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/2048