### PR TITLE
Hiding cookie notice on kroger.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5470,4 +5470,4 @@ elysee.fr##+js(trusted-set-cookie, tarteaucitron, !eulerian-analytics=false!inst
 weddingbee.com##+js(trusted-set-cookie, OptanonConsent, groups=C0001%3A1%2CC0002%3A0%2CC0003%3A1%2CC0004%3A0, , , domain, weddingbee.com)
 
 ! "OK"
-kroger.com##+js(trusted-click-element, .kds-Modal-closeButton)
+kroger.com##+js(trusted-set-local-storage-item, modal_terms_policy_update_notification, true)


### PR DESCRIPTION
URL(s) where the issue occurs
`kroger.com`

Describe the issue
kroger.com has a cookie popup that appears to users. This popup needs to be suppressed.

Screenshots

<img width="1550" height="892" alt="image" src="https://github.com/user-attachments/assets/a9d9d033-b9e5-4825-a819-2ac58f4911fa" />


Versions
Browser/version: Brave 1.88.136

Settings
Set a trusted local storage item to bypass the cookie popup