### PR TITLE
feat(filters/badware): only allow aliucord.com

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6358,3 +6358,7 @@ ublockorigin.app###main::before:style(content: 'This is not the official uBlock 
 
 ! https://censys.com/blog/technique-based-approach-hunting-web-delivered-malware/
 ||orcanmedikal.com.tr^$doc
+
+! Aliucord - Official site: aliucord.com
+! https://github.com/uBlockOrigin/uAssets/issues/32447
+||aliucord.$all,domain=~aliucord.com


### PR DESCRIPTION
This targets aliucord.org which is badware

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://aliucord.org`

### Describe the issue

https://aliucord.com is the only official website for https://github.com/Aliucord (of which I am a member), and `aliucord.org` is an unauthorized impersonation that could distribute malware in the future.

### Notes

Currently, only `aliucord.org` is known of, but my changes block all `aliucord.*` domains that aren't aliucord.com