### PR TITLE
feat(filters/badware): unofficial vesktop sites

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6358,3 +6358,8 @@ ublockorigin.app###main::before:style(content: 'This is not the official uBlock 
 
 ! https://censys.com/blog/technique-based-approach-hunting-web-delivered-malware/
 ||orcanmedikal.com.tr^$doc
+
+! Vesktop - Official site: vesktop.dev
+! https://github.com/uBlockOrigin/uAssets/issues/32449
+||vesktop.$all,domain=~vesktop.dev
+||vesktop$all,domain=softonic.*


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

- `vesktop.org`
- `vesktop.softonic.com`
- `vesktop.softonic.nl`
- `vesktop.softonic.pl`
- `vesktop.en.softonic.com`

### Describe the issue

The only official download site for Vesktop (https://github.com/Vencord/Vesktop) is at https://vesktop.dev.

- `vesktop.org`, impersonates the real website
- softonic bundles PUPs with downloads
