### PR TITLE
Updated badware.txt, added Telega domains

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6399,3 +6399,9 @@ ublockorigin.app###main::before:style(content: 'This is not the official uBlock 
 
 ! https://censys.com/blog/technique-based-approach-hunting-web-delivered-malware/
 ||orcanmedikal.com.tr^$doc
+
+! https://dontusetelega.lol/analysis
+! https://habr.com/en/articles/1014144/
+! https://kod.ru/telega-fork-telegram
+||telega.info^$all
+||telega.me^$all


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://telega.info`
`https://telega.me`

### Describe the issue

In Russia, Telega is marketed as a “secure, open-source alternative to the Telegram client that works without a VPN.” In reality, it is de facto developed by VK LLC, a company closely connected to the Russian government. No later than March 18, Telega’s server-side software was updated, turning it into a full-fledged MITM proxy server capable of hijacking complete access to users’ Telegram account.

Its domains are now marked by Cloudflare Radar as malicious and their GlobalSign certificates were revoked on 2026-04-08 16:29:52 UTC.

Cloudflare Radar:
`https://radar.cloudflare.com/domains/domain/telega.info`
`https://radar.cloudflare.com/domains/domain/telega.me`

Certificate status:
`https://crt.sh/?id=25216474129&opt=ocsp`
`https://crt.sh/?id=25214368284&opt=ocsp`

For details on attack see this article (in Russian):
`https://dontusetelega.lol/analysis`
`https://habr.com/en/articles/1014144/`

More about Telega (yet again in Russian):
`https://kod.ru/telega-fork-telegram`