### PR TITLE
pinterest.com: block signup wall on sent/shared pin pages

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -8034,3 +8034,9 @@ ya.ru,yandex.*##.b-page[style*="padding-right:"]:style(overflow-y: auto !importa
 doordash.com##div[class^=sc-][aria-hidden="true"] + div[class^="sc-"][style*="border: medium; margin-top: var(--usage-space-medium);"]
 doordash.com##div[class^="StyledStackChildren-"]:has(> div[data-testid="appDownload"]:first-child + button[data-testid="appDownloadButton"]:last-child)
 doordash.com##+js(trusted-set-local-storage-item, appDownloadPromptDismissedV3Ttl, {"value":"99999999999999"\,"expiresAt":99999999999999})
+
+! pinterest.com: signup wall on sent/shared pin pages
+pinterest.*##div:has(> div[aria-modal="true"][role="dialog"])
+pinterest.*##div.asf_Xx[role="dialog"]
+pinterest.*###credential_picker_container
+pinterest.*##body:style(overflow: auto !important;)

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -8035,7 +8035,7 @@ doordash.com##div[class^=sc-][aria-hidden="true"] + div[class^="sc-"][style*="bo
 doordash.com##div[class^="StyledStackChildren-"]:has(> div[data-testid="appDownload"]:first-child + button[data-testid="appDownloadButton"]:last-child)
 doordash.com##+js(trusted-set-local-storage-item, appDownloadPromptDismissedV3Ttl, {"value":"99999999999999"\,"expiresAt":99999999999999})
 
-! pinterest.com: signup wall on sent/shared pin pages
+! https://github.com/uBlockOrigin/uAssets/issues/32524
 pinterest.*##div:has(> div[aria-modal="true"][role="dialog"])
 pinterest.*##div.asf_Xx[role="dialog"]
 pinterest.*###credential_picker_container

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -8040,3 +8040,4 @@ pinterest.*##div:has(> div[aria-modal="true"][role="dialog"])
 pinterest.*##div.asf_Xx[role="dialog"]
 pinterest.*###credential_picker_container
 pinterest.*##body:style(overflow: auto !important;)
+pinterest.*##div[data-test-id="bottom-right-upsell"]


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://www.pinterest.com/pin/70437488970747/sent/`

### Describe the issue

When visiting a Pinterest "sent" (shared) pin URL while not logged in, a full-screen signup wall modal blocks the entire page content. The modal has `z-index: 10001`, `position: fixed`, and covers the viewport with a dark overlay (`rgba(0, 0, 0, 0.6)`). It also locks body scrolling via `overflow: hidden` on the body element.

Additionally, a cookie consent dialog (`.asf_Xx[role="dialog"]`) and Google credential picker (`#credential_picker_container`) overlay the page.

Existing Pinterest filters in `annoyances-others.txt` cover `giftWrap`, `FullPageModal__scroller`, `GrowthUnauthPinImage`, and localStorage-based counters, but do not cover the signup wall on `/sent/` pages.

### Filters added

```
pinterest.*##div:has(> div[aria-modal="true"][role="dialog"])
pinterest.*##div.asf_Xx[role="dialog"]
pinterest.*###credential_picker_container
pinterest.*##body:style(overflow: auto !important;)
```

### Notes

- The signup wall is a `div` with class `Fm_EPH` but this class is shared with the content grid (`data-test-id="grid"`), so using `.Fm_EPH` as a selector breaks the page. The `:has()` selector targets only the parent of the `aria-modal` dialog.
- Tested in Firefox (headless, Playwright) - filters successfully hide the wall while keeping pin content, images, and feed fully visible and scrollable.
- The `body:style()` filter overrides the inline `overflow: hidden` that Pinterest sets when the modal is active.

Fixes #32524