### PR TITLE
Hiding cookie banner on craftelier.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -585,6 +585,8 @@ iteraplay.com##+js(trusted-set-local-storage-item, itera_cookie_consent, '{"stri
 cinemark.com.br##+js(set-cookie, cookies_config, deny)
 ! https://github.com/uBlockOrigin/uAssets/pull/32262
 theweathernetwork.com##+js(trusted-click-element, #didomi-notice-disagree-button)
+! https://github.com/uBlockOrigin/uAssets/pull/32538
+craftelier.com##+js(trusted-set-cookie, pr-cookie-consent, [], , , domain, .craftelier.com)
 
 
 !! Needs additional cookies
@@ -5503,6 +5505,3 @@ scandinavianoutdoor.fi##+js(trusted-set-local-storage-item, cookieconsent, {"con
 
 ! Essential only
 ixolabs.ai##+js(trusted-set-cookie, ixo_cookie_consent, '{"essential":true,"analytics":false,"functional":false}')
-
-! Reject
-craftelier.com##+js(trusted-set-cookie, pr-cookie-consent, '[]')

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5503,3 +5503,6 @@ scandinavianoutdoor.fi##+js(trusted-set-local-storage-item, cookieconsent, {"con
 
 ! Essential only
 ixolabs.ai##+js(trusted-set-cookie, ixo_cookie_consent, '{"essential":true,"analytics":false,"functional":false}')
+
+! Reject
+craftelier.com##+js(trusted-set-cookie, pr-cookie-consent, '[]')


### PR DESCRIPTION
URL(s) where the issue occurs
`craftelier.com`

Describe the issue
craftelier.com has a cookie popup that appears to users. This popup needs to be suppressed.

Screenshots
<img width="1204" height="1001" alt="image" src="https://github.com/user-attachments/assets/29608f72-4827-40ce-b683-5b2d579fbaef" />

Versions
Browser/version: Brave 1.88.138

Settings
Set a trusted cookie to bypass the cookie popup