### PR TITLE
Hiding cookie notice on moleson.rentalp.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5514,3 +5514,6 @@ scandinavianoutdoor.fi##+js(trusted-set-local-storage-item, cookieconsent, {"con
 
 ! Essential only
 ixolabs.ai##+js(trusted-set-cookie, ixo_cookie_consent, '{"essential":true,"analytics":false,"functional":false}')
+
+! Necessary only
+moleson.rentalp.com##+js(trusted-set-cookie, USE_COOKIE_CONSENT_STATE, '{"firstParty":true,"thirdParty":false,"necessary":true}')

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -587,6 +587,8 @@ cinemark.com.br##+js(set-cookie, cookies_config, deny)
 theweathernetwork.com##+js(trusted-click-element, #didomi-notice-disagree-button)
 ! https://github.com/uBlockOrigin/uAssets/pull/32538
 craftelier.com##+js(trusted-set-cookie, pr-cookie-consent, [], , , domain, .craftelier.com)
+! https://github.com/uBlockOrigin/uAssets/pull/32556
+moleson.rentalp.com##+js(trusted-set-cookie, USE_COOKIE_CONSENT_STATE, '{"firstParty":true,"thirdParty":false,"necessary":true}')
 
 
 !! Needs additional cookies
@@ -5514,6 +5516,3 @@ scandinavianoutdoor.fi##+js(trusted-set-local-storage-item, cookieconsent, {"con
 
 ! Essential only
 ixolabs.ai##+js(trusted-set-cookie, ixo_cookie_consent, '{"essential":true,"analytics":false,"functional":false}')
-
-! Necessary only
-moleson.rentalp.com##+js(trusted-set-cookie, USE_COOKIE_CONSENT_STATE, '{"firstParty":true,"thirdParty":false,"necessary":true}')


### PR DESCRIPTION
URL(s) where the issue occurs
`moleson.rentalp.com`

Describe the issue
moleson.rentalp.com has a cookie popup that appears to users. This popup needs to be suppressed.

Screenshots
<img width="1378" height="877" alt="image" src="https://github.com/user-attachments/assets/3cddcb26-a24d-4e69-8e15-4536e3cf9d7d" />


Versions
Browser/version: Brave 1.89.132

Settings
Set a trusted cookie to bypass the cookie popup