### PR TITLE
Hiding cookie notice on aftonbladet.se

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5516,3 +5516,7 @@ scandinavianoutdoor.fi##+js(trusted-set-local-storage-item, cookieconsent, {"con
 
 ! Essential only
 ixolabs.ai##+js(trusted-set-cookie, ixo_cookie_consent, '{"essential":true,"analytics":false,"functional":false}')
+
+! Accept
+! https://github.com/brave-experiments/cookiecrumbler-issues/issues/1996
+aftonbladet.se##+js(trusted-click-element, #notice button[title="Godkänn alla"])


### PR DESCRIPTION
URL(s) where the issue occurs
aftonbladet.se

Describe the issue
aftonbladet.se has a cookie popup that appears to users. This popup needs to be suppressed. This has been reported to Brave multiple times now.

Screenshots
<img width="1288" height="875" alt="image" src="https://github.com/user-attachments/assets/35221ecb-4e40-4a5e-b4bf-d1b3ac2aec65" />

Versions
Browser/version: Brave 1.89.132

Settings
Use a trusted click event to accept the cookies on this page. This is the most reasonable solution I found, as most cookies have to be accepted for this page, or the user is given a paywall. I am open to other solutions if there is a better one.

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1996