### PR TITLE
reject all additional cookies on arena.ai

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -589,7 +589,7 @@ theweathernetwork.com##+js(trusted-click-element, #didomi-notice-disagree-button
 craftelier.com##+js(trusted-set-cookie, pr-cookie-consent, [], , , domain, .craftelier.com)
 ! https://github.com/uBlockOrigin/uAssets/pull/32556
 moleson.rentalp.com##+js(trusted-set-cookie, USE_COOKIE_CONSENT_STATE, '{"firstParty":true,"thirdParty":false,"necessary":true}')
-
+arena.ai##+js(trusted-set-cookie, cookie-preferences, '{"functionality":false,"advertising":false,"analytics":false,"socialMedia":false,"lastUpdated":"$currentISODate$"}', , , reload, 1, dontOverwrite, 1)
 
 !! Needs additional cookies
 


### PR DESCRIPTION
### URL(s) where the issue occurs

`arena.ai`

### Describe the issue

it have a cookie popup. and 4 switch for additional cookie turned on by default

### Screenshot(s)

<img width="300" height="611" src="https://github.com/user-attachments/assets/047141cf-4aac-4791-9a20-f5a84fb96f52" />


### Versions

- Browser/version: firefox 148
- uBlock Origin version: 1.70.0

### Settings

- none