### PR TITLE
aftonbladet.se cookie notice blocking applies to similar websites

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5521,7 +5521,7 @@ ixolabs.ai##+js(trusted-set-cookie, ixo_cookie_consent, '{"essential":true,"anal
 
 ! Accept
 ! https://github.com/brave-experiments/cookiecrumbler-issues/issues/1996
-aftonbladet.se##+js(trusted-click-element, #notice button[title="Godkänn alla"])
+aftonbladet.se,godare.se,omni.se,svd.se##+js(trusted-click-element, #notice button[title="Godkänn alla"])
 
 ! https://github.com/uBlockOrigin/uAssets/pull/32576
 arena.ai##+js(trusted-set-cookie-reload, cookie-preferences, '{"functionality":true,"advertising":false,"analytics":false,"socialMedia":true,"lastUpdated":"99999999999999"}')


### PR DESCRIPTION
### URL(s) where the issue occurs

`godare.se`
`omni.se`
`svd.se`

### Describe the issue

godare.se, omni.se and svd.se are all owned by aftonbladet.se. They all have the same cookie dialog and need to be handled the same way

### Versions

- Browser/version: Brave 1.89.141

### Settings

- Used a trusted click element (same strategy as https://github.com/brave-experiments/cookiecrumbler-issues/issues/1996)

