### PR TITLE
Block external ads on ah.nl

### DIFF
--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -750,3 +750,6 @@ viduro.top##+js(nowoif)
 ! https://github.com/uBlockOrigin/uAssets/issues/31713
 embedseek.xyz##+js(nowoif, _blank)
 ||imasdk.googleapis.com/js/sdkloader/ima3.js$script,redirect=noopjs,domain=embedseek.xyz
+
+! https://github.com/uBlockOrigin/uAssets/pull/32642
+ah.nl##div[data-testid=spotlight-ahrms-slot]:has(a:not(:matches-attr(href=/URhttps?:\/\/(www\.)?ah.nl/)))


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://ah.nl

### Describe the issue

Most banners on ah.nl are self-promotion, which are out of scope per EasyList guidelines. However, some of them are actually ads for external website (see the screenshot).

Since they link to a tracking URL (#32641) instead of to the page directly, an extended `:not(:matches-attr(...))` rule has to be used to find the ones that link outside of ah.nl

### Screenshot(s)

The banner on the left is an advertisement:

<img width="2754" height="690" alt="image" src="https://github.com/user-attachments/assets/5abdcc5e-602f-4a1c-a41a-2f4d2761486c" />

With the rule applied:

<img width="2754" height="690" alt="image" src="https://github.com/user-attachments/assets/a71c53d3-d5c3-4b3e-9bf0-9b08d5d3a260" />

### Versions

- Browser/version: Zen Browser 1.19.8b (Firefox 149.0.2)
- uBlock Origin version: 1.70.0