### PR TITLE
Hiding cookie notice on silknet.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5528,3 +5528,6 @@ arena.ai##+js(trusted-set-cookie-reload, cookie-preferences, '{"functionality":t
 
 ! https://github.com/uBlockOrigin/uAssets/issues/32634
 videohelper.com##+js(trusted-set-cookie, starter-cookie-data, hasAckowledged)
+
+! https://github.com/uBlockOrigin/uAssets/pull/32653
+silknet.com##+js(trusted-set-cookie, validCookies, general)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`silknet.com`

### Describe the issue

Cookie notice appears on the page. If the cookie notice is hidden cosmetically, the page functionality is broken and the user cannot interact with any elements on the page.

### Versions

- Browser/version: Brave 1.89.141

### Settings

Added a trusted set cookie to hide the div without breaking the page.