### PR TITLE
Added another page to aftonbladet.se cookie section

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5524,7 +5524,7 @@ ixolabs.ai##+js(trusted-set-cookie, ixo_cookie_consent, '{"essential":true,"anal
 
 ! Accept
 ! https://github.com/brave-experiments/cookiecrumbler-issues/issues/1996
-aftonbladet.se,godare.se,omni.se,svd.se##+js(trusted-click-element, #notice button[title="Godkänn alla"])
+aftonbladet.se,godare.se,omni.se,svd.se,tv.nu##+js(trusted-click-element, #notice button[title="Godkänn alla"])
 
 ! https://github.com/uBlockOrigin/uAssets/pull/32576
 arena.ai##+js(trusted-set-cookie-reload, cookie-preferences, '{"functionality":true,"advertising":false,"analytics":false,"socialMedia":true,"lastUpdated":"99999999999999"}')


### PR DESCRIPTION
### URL(s) where the issue occurs

`tv.nu`

### Describe the issue

This page shares the same cookie message as aftonbladet.se and needs the same approach applied (accepting cookie banner) to ensure page functionality.

### Versions

- Browser/version: Brave 1.89.143

### Settings

- Adding trusted set cookie (the same method of accepting the cookie banner for aftonbladet.se).