### PR TITLE
Update ubo-link-shorteners.txt with ubg timer rule

### DIFF
--- a/filters/ubo-link-shorteners.txt
+++ b/filters/ubo-link-shorteners.txt
@@ -1943,3 +1943,6 @@ paste4free.site##+js(nano-sib, secondsLeft)
 paste4free.site##a[href*="?key="][target="_blank"]
 playpaste.net##.flex-center > [href*="rapidshare"]
 ||comradegoodsfloor.com^
+
+! Bypass forced countdown timers on the ubg network
+cloud.unblockedgames.world##+js(nano-sib, /count|verify|isCompleted/, , 0)


### PR DESCRIPTION

### URL(s) where the issue occurs

`https://cloud.unblockedgames.world/?sid=a3Y4azk3STZ5RVphb1c0d0pkeDllaWVjc3NTd1dyeHJZSlNRUkszSnJFSGphampKSXNSZWwrcG5LYTJEYkE2UkZIZjJJc3VDQ1hhdW9jVTJmTTFzU29PMlFKZ0MzTmhvSC9NWEh6a0Z2T2ZFZS9aM1I0N1dHWGlOWDNJU1lIZEZ0Zm5zbVBNRFFVRlNQSDNKT0NFemNFVkZ5TFduRlA1M2c3S0k0Q3o3TVlyclczOTMzQXRiN3lnTURPZlN4a1E2M3BTWDN6TmFaREwzdXhvSlNZTjhaNTRlOGZBaEdqVDh1eHc0K3ZSOXk0MktuRUJjZ0ZmSDJNWlppYmxvTVlvVA==`

### Describe the issue

This page contains forced timers for all the steps before enabling the button to redirect. to make users artificially forced to wait multiple times to proceed.

### Versions

- Browser/version: Firefox 149
- uBlock Origin version: 1.70.0

### Settings

- The site uses JavaScript `setInterval` timers to force the user to wait before a redirect button becomes clickable. By injecting `nano-sib` and `/count|verify|isCompleted/`, we can override the interval delay to 0. This successfully fast-forwards the timer and allows immediate progression without breaking the page logic.


