### PR TITLE
Accepting cookies on ladbible.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5553,3 +5553,7 @@ abcya.com##+js(trusted-set-local-storage-item, abcya_cb_production, '{"value":"1
 
 ! aviasales sites cookies
 aviasales.*##+js(trusted-set-cookie, cookies_policy, '{"accepted":true,"technical":true,"marketing":false}')
+
+! accept
+! https://github.com/brave-experiments/cookiecrumbler-issues/issues/743
+ladbible.com##+js(trusted-click-element, .cmp-banner .accept-all)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`ladbible.com` when browsing from the UK

### Describe the issue

There is a paywall on this page. The user is presented with two options, accept cookies or pay. To dismiss this banner, we must accept cookies and trust that other privacy rules are blocking any harmful trackers.

### Screenshot(s)

<img width="1248" height="1028" alt="image" src="https://github.com/user-attachments/assets/fb8d48b0-3a3b-4ded-9218-00222a8c092c" />

### Versions

- Browser/version: Brave 1.89.143

### Settings

Using a trusted click element to click the accept all button within the cookie popup. This will accept the cookies and set the appropriate local storage values. 

### Notes

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/743
