### PR TITLE
Add 'Free 51GB Data' Phishing Sites to badware.txt

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6560,3 +6560,64 @@ ublockorigin.app###main::before:style(content: 'This is not the official uBlock 
 ||goldbergcoins.com^$all
 ||erahitopupikloss.com^$all
 ||asionamedrafter.com^$all
+
+! Phishing
+! https://github.com/hagezi/dns-blocklists/issues/10046
+! https://github.com/hagezi/dns-blocklists/issues/10069
+! https://github.com/Phishing-Database/phishing/pull/1145
+! https://github.com/Phishing-Database/phishing/commit/ed07005a81eda89b9e4ba32fed3bfcc7ff1bd4b7
+! https://github.com/Phishing-Database/phishing/commit/471f615b1c29a2035d00598ac80293a5b87cce79
+! https://github.com/Phishing-Database/phishing/pull/1146
+||1gc2r.top^$all
+||5b8tv.top^$all
+||879cv.top^$all
+||87yik.xyz^$all
+||bt8rc.top^$all
+||c1b2f.top^$all
+||dihg.top^$all
+||dquj.top^$all
+||dzou.top^$all
+||eujn.top^$all
+||ezno.top^$all
+||f1453.top^$all
+||fvmk.top^$all
+||gr12x.top^$all
+||h1ttv.top^$all
+||hy2238.top^$all
+||hy7322.top^$all
+||ij7gv.top^$all
+||iokd9.top^$all
+||iwrf.top^$all
+||jaui.top^$all
+||jcs11.top^$all
+||levu.top^$all
+||ljuf.top^$all
+||nurc.top^$all
+||omiw.top^$all
+||ozpu.top^$all
+||slru.top^$all
+||syfo.top^$all
+||t87bb.top^$all
+||tcxv8.top^$all
+||tiyp.top^$all
+||vsxd.top^$all
+||woex.top^$all
+||xcv9r.top^$all
+||y8699.top^$all
+||yfav.top^$all
+||ajdi.top^$all
+||bg12g.top^$all
+||ejlr.top^$all
+||hfex.top^$all
+||hhac.top^$all
+||jaei.top^$all
+||ljek.top^$all
+||mlci.top^$all
+||ojis.top^$all
+||vayv.top^$all
+||y7577.top^$all
+! Phishing tracker
+||tj.16gift.com^$all
+! Images related to phishing are served here
+||599cdn.com/Philippines/*
+||cdnmi.com^$all


### PR DESCRIPTION
Added multiple phishing domains to the badware filter list.

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
Various phishing emails, Facebook posts and FB Messenger shared posts.

### Describe the issue

Various phishing posts are being shared and circulated online, most notably on Facebook and FB Messenger, on May 1, 2026 during the Labor Day event in the Philippines. The posts and the malicious websites claim to provide free mobile data credits in exchange of the user's mobile number.

<details>

<img width="721" height="901" alt="Image" src="https://github.com/user-attachments/assets/249f6388-09cf-4248-b970-fc8ce9eaaea6" />

</details>

The malicious websites are designed to mimic a Philippine telecommunications company, DITO `dito.ph`, complete with design elements and fake Facebook comments. It also mentions the other Philippine telcos such as Globe and Smart.

<details>

<img width="1668" height="1030" alt="Image" src="https://github.com/user-attachments/assets/c884f367-33af-4cd6-9b57-6fa068d30d67" />

</details>

In tests the websites seem not to send any information to any server at all.

<details>

<img width="627" height="693" alt="Screenshot_20260502_053657" src="https://github.com/user-attachments/assets/09e6ada9-1518-4e66-bbbf-f61566621fdc" />

</details>

It shows a fake progress bar and fake comment input field.

<details>

<img width="1665" height="1031" alt="Screenshot_20260502_055250" src="https://github.com/user-attachments/assets/31238fdc-0715-46f8-a93e-01134c6f9771" />

<img width="552" height="569" alt="Screenshot_20260502_053730" src="https://github.com/user-attachments/assets/9435d323-4278-444d-87c0-c4e6af56f776" />

</details>

Interacting with the website causes many JavaScript errors.

<details>

<img width="1664" height="1031" alt="Screenshot_20260502_054013" src="https://github.com/user-attachments/assets/7ea4c06f-7b92-4e61-b9ca-ebf0e5e8e9cf" />

</details>

It also uses cookies and local storage to store benign data.

<details>

<img width="1612" height="205" alt="Screenshot_20260502_054634" src="https://github.com/user-attachments/assets/298c7aa2-485c-426f-9ce0-8d86686dff48" />

<img width="1166" height="753" alt="Screenshot_20260502_054701" src="https://github.com/user-attachments/assets/095a5eb0-3a96-40f1-a777-f7237d573168" />

</details>

The share buttons and links redirect to `fb-messenger://share/?link=` protocol

Inspecting the source code reveals various comments in Russian.

<details>

<img width="884" height="1028" alt="Screenshot_20260502_063910" src="https://github.com/user-attachments/assets/147e99ea-6819-44c5-873a-c5dd577d6ae3" />

</details>

It also loads an external script `single.php` which contains ads redirection codes:

<details>

<img width="1257" height="622" alt="Screenshot_20260502_064045" src="https://github.com/user-attachments/assets/f06f48c3-d896-47d8-adf9-365fc577160c" />

</details>

The ads redirection routine leads to `go.php` which then redirects to random ads. As of this writing it redirects to `cdn.lcwss.com`. Notice that it tracks the IP address of the user.

<details>

<img width="1668" height="219" alt="Screenshot_20260502_055520" src="https://github.com/user-attachments/assets/92d099a9-6ee8-48cd-81ff-236eb95ff3ce" />

</details>

The usual subdomain used for these malicious domains are `labor-day-51gb-free1` and `labor-day-51gb-free8`. However, any random subdomain is an alias to the same malicious content.

<details>

<img width="1668" height="1027" alt="Image" src="https://github.com/user-attachments/assets/fea117ad-e1d3-4fe0-9ab0-917c2d1240a5" />

</details>


### Versions

- Browser/version: Firefox 150.0.1
- uBlock Origin version: 1.70

### Settings

Default settings

### Notes

These malicious domains are also submitted and documented here:
https://github.com/hagezi/dns-blocklists/issues/10046
https://github.com/hagezi/dns-blocklists/issues/10069
https://github.com/Phishing-Database/phishing/pull/1145
https://github.com/Phishing-Database/phishing/commit/ed07005a81eda89b9e4ba32fed3bfcc7ff1bd4b7
https://github.com/Phishing-Database/phishing/commit/471f615b1c29a2035d00598ac80293a5b87cce79
https://github.com/Phishing-Database/phishing/pull/1146