### PR TITLE
Block everything from 599cdn.com

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6563,7 +6563,7 @@ top##body > center + .A + .post
 ||16gift.com^$all
 ||top/single.php|$script,1p
 ! https://github.com/Phishing-Database/phishing/pull/1153
-||599cdn.com^$all
+||599cdn.com^
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/231089
 ! https://www.virustotal.com/gui/url/6540275734722cd9f29adcde38f3ebe4dbe0047218a101bc1487c3802d835545

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6562,7 +6562,8 @@ top##body > center + .A + .post
 ||labor-day-*.top^$doc
 ||16gift.com^$all
 ||top/single.php|$script,1p
-||599cdn.com/Philippines/ph*.jpg$image,domain=top
+! https://github.com/Phishing-Database/phishing/pull/1153
+||599cdn.com^$all
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/231089
 ! https://www.virustotal.com/gui/url/6540275734722cd9f29adcde38f3ebe4dbe0047218a101bc1487c3802d835545


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

Seen in phishing sites. Here are some of the examples:

```
esewa378.jkca.top
klaim-dana-kaget5.mhbe.top
free11.vbh66.xyz
gcash1.tc73.xyz
```

### Describe the issue

Phishing sites such as the ones described in https://github.com/Phishing-Database/phishing/pull/1153 and https://github.com/hagezi/dns-blocklists/issues/10046 are using a banner image from `https://599cdn.com/` with a path from a target country such as `https://599cdn.com/Philippines/ph05101.jpg`, `https://599cdn.com/bangladesh/b2026.jpg`, `https://599cdn.com/Indonesia/gopay01.jpg`, etc. Some images are also year specific like `https://599cdn.com/2026/ramadan.jpg`.

The images' messaging are usually about giving free mobile data credits targeted during a local public holiday and special events.

Searching 599cdn.com using urlscan.io reveals all related links that embeds these banner images: https://urlscan.io/search/#599cdn.com

The almost exclusive use of this domain in serving phishing related assets and the lack of other information about its legitimate CDN functions suggests that it is safe to block all assets from this domain.

### Screenshot(s)

<img width="1672" height="941" alt="ph05101" src="https://github.com/user-attachments/assets/e8f6725c-d331-4f66-8440-b053cfd5e838" />
<img width="1024" height="617" alt="b2026" src="https://github.com/user-attachments/assets/2c291e06-9eb6-4440-b08d-9919b0d71cb7" />
<img width="2048" height="1170" alt="gopay01" src="https://github.com/user-attachments/assets/89619c4e-534a-4edb-9fee-6e2de6d4bc5b" />
<img width="1633" height="980" alt="ramadan" src="https://github.com/user-attachments/assets/6747b14a-0fc0-48d3-b713-aa0282d9b573" />


### Versions

- Browser/version: Firefox 150.0.2
- uBlock Origin version: 1.70.0

### Settings

- Default settings and lists

