### PR TITLE
Update to cover share links for community posts

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1582,6 +1582,7 @@ $removeparam=adsterra_placement_id
 ||youtu.be^$removeparam=si
 ||youtube.com/shorts/$doc,removeparam=si
 ://youtube.com/@*?si=$doc,removeparam=si
+||youtube.com/post/$doc,removeparam=si
 ! Embedded tweets
 $removeparam=refsrc,to=twitter.com|x.com
 $removeparam=ref_src,to=twitter.com|x.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`http://youtube.com/post/UgkxwPgT4j_tkJE_g05RBCinsEikj8HzKeXi?si=0W0zvSglydHYCy3d`
Or any community post on any channel.

### Describe the issue

uBlock Origin's privacy list removes YouTube's si tracking parameter from youtu.be links, shorts, and profiles. However, it is not removed from share links for community posts.

### Screenshot(s)

N/A

### Versions

- Browser/version: Firefox 150.0.3
- uBlock Origin version: 1.71.1b0

### Settings

The only relevant changes are both AdGuard/uBO – URL Tracking Protection and the Actually Legitimate URL Shortener Tool are installed/enabled; I have confirmed neither is interfering.

### Notes

I have tested and this does not appear to cause any problems.
Reportedly, [YouTube is now also using a parameter named "is" for similar tracking](https://wandering.shop/@aesthr/116583648062878219), but I am unable to reproduce it and therefore have not added it to this PR.
