### PR TITLE
Remove tracking parameters from YouTube live streams

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1583,6 +1583,8 @@ $removeparam=adsterra_placement_id
 ||youtube.com/shorts/$doc,removeparam=si
 ://youtube.com/@*?si=$doc,removeparam=si
 ||youtube.com/post/$doc,removeparam=si
+||youtube.com/live/$doc,removeparam=si
+||youtube.com/live/$doc,removeparam=is
 ! Embedded tweets
 $removeparam=refsrc,to=twitter.com|x.com
 $removeparam=ref_src,to=twitter.com|x.com

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1580,6 +1580,7 @@ $removeparam=adsterra_placement_id
 ! https://github.com/AdguardTeam/AdguardFilters/issues/173471
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-13326533
 ||youtu.be^$removeparam=si
+||youtu.be^$removeparam=is
 ||youtube.com/shorts/$doc,removeparam=si
 ://youtube.com/@*?si=$doc,removeparam=si
 ||youtube.com/post/$doc,removeparam=si


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
https://www.youtube.com/live/9fmxAScLyeY?si=iz-tIWENKnzIaoDd
https://www.youtube.com/live/zwYkHS8jvSE?t=4870&is=CZXKIGViynCeBxWr
```

### Describe the issue

The existing filters to remove tracking parameters from YouTube share links do not cover live streams.
I have also [found a live example of use of the is parameter](https://toot.cafe/@tomayac/116557731798196446), but have limited it to live streams as I don't have examples for others and thus can't test for breakage.

### Screenshot(s)

N/A

### Versions

- Browser/version: N/A
- uBlock Origin version: N/A

### Settings

N/A

### Notes


