### PR TITLE
unbreak fuelfinder.dk

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -5966,3 +5966,7 @@ amboss.com##+js(set, ambossAnalytics.getUserAttribution, noopFunc)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/32955
 proxyorb.com##+js(aeld, load, dataset.ready, elements, script[src^="https://www.googletagmanager.com/gtag/js?id="])
+
+! https://github.com/uBlockOrigin/uAssets/issues/33003
+fuelfinder.dk###adblock-message
+fuelfinder.dk###site-wrapper:style(display: block !important; opacity: 1 !important;)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://fuelfinder.dk/`

### Describe the issue

Site is inaccessible - "Access denied - please turn off adblocker."
https://github.com/uBlockOrigin/uAssets/issues/33003

### Versions

- Browser/version: Chromium Version 127.0.6533.99 
- uBlock Origin version: uBlock Origin 1.64.0