### PR TITLE
Bypass adblock detection on wispbyte.com

### DIFF
--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -1039,3 +1039,6 @@ www.deeplol.gg##a[id^="add_to_Banner"]
 www.deeplol.gg###billboard
 www.deeplol.gg###desktop-takeover
 www.deeplol.gg###summoner_content_box div[class^="sc-"]:not(.bigTooltip, .diamond, [class*="flex"], [class*="master"], [class*="wrapper"], [id], [disabled], [style], [height], [width], [size]):has(> a[id^="add_to_Banner"])
+
+! https://github.com/uBlockOrigin/uAssets/issues/33031
+||wispbyte.com/client/scripts/wisp-guard.js$script


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`wispbyte.com`

### Describe the issue
Fixes #33031 
- wispbyte.com loads a script that detects adblockers, which redirects the page to `https://wispbyte.com/client/disable-adblocker` when an adblocker is detected
- The script url is hosted at this url `https://wispbyte.com/client/scripts/wisp-guard.js`
- To reproduce, login to wispbyte and visit the dashboard, it should instantly redirect you
- This PR should cause the site to work without issues and not redirect or crash as there is nothing checking if the script loads fine

### Screenshot(s)

<img width="883" height="1034" alt="Image" src="https://github.com/user-attachments/assets/ebde5d9c-f8eb-48b0-95d4-278ab36016dd" />

### Versions

- Browser/version: Brave 1.88.134
- uBlock Origin version: 1.71.0

### Settings

<img width="799" height="615" alt="image" src="https://github.com/user-attachments/assets/131aa918-838c-466c-b927-74150b7ac072" />
Every single filter list is enabled except regional ones, and AdGuard Tracking Protection filter in custom ones

### Notes
