### PR TITLE
fix #33041

### DIFF
--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -1045,3 +1045,6 @@ www.deeplol.gg###summoner_content_box div[class^="sc-"]:not(.bigTooltip, .diamon
 
 ! https://github.com/uBlockOrigin/uAssets/issues/33031
 ||wispbyte.com/client/scripts/wisp-guard.js$script
+
+! https://github.com/uBlockOrigin/uAssets/issues/33041
+||vidfast.pro^$popup,domain=cinekada.com


### PR DESCRIPTION
### URL(s) where the issue occurs
`https://cinekada.com/movies/the-dark-knight/`

### Describe the issue
When watching a movie on cinekada.com, clicking on the video player opens a popup tab to sites such as aliexpress.com or trip.com. The popup is triggered by a third-party video player (vidfast.pro) which hijacks click events to open unwanted tabs. No explicit filter rule exists to block this popup behavior from vidfast.pro on cinekada.com.

### Screenshot(s)
<!-- Console analysis showing click events triggered on vidfast.pro video element -->
Console analysis showing click events are triggered on the vidfast.pro video element when clicking on cinekada.com:
<img width="590" height="388" alt="image" src="https://github.com/user-attachments/assets/1d2f19fb-3cee-4596-9818-150f4a06b499" />


### Versions
- Browser/version: Chrome 146
- uBlock Origin Lite version: 2026.507.2008

### Settings
- Default settings

### Notes
Investigated using browser devtools. The video on cinekada.com is served via vidfast.pro player. Console analysis confirmed that click events on the video element trigger window.open() calls to third-party ad sites. Existing vidfast.pro rules in filters-2025.txt and filters-general.txt do not cover this specific popup behavior on cinekada.com. Although the popup may currently be blocked by other existing rules, there is no explicit rule targeting this behavior. Adding an explicit $popup rule scoped to cinekada.com ensures the behavior remains blocked even if other rules are updated in the future.

Additionally, since vidfast.pro is used as a third-party player on multiple streaming sites, similar popup behavior may occur on other domains using this player. A broader rule such as ||vidfast.pro^$popup could be considered in the future.

Thank you for reviewing this contribution.