### PR TITLE
Hiding cookie notice on lequipe.fr

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5580,3 +5580,5 @@ tlc.com##+js(trusted-click-element, .btn.btn-primary)
 
 ! https://www.eventim.ro/event/alifantis-mirica-gemini-2-0-casa-de-cultura-a-sindicatelor-21322560/ - maps breakage
 eventim.ro##+js(trusted-click-element, #cmpwrapper >>> .cmpboxbtnyes, , 1000)
+
+lequipe.fr##+js(trusted-click-element, .CmpUnsubscriber .Cmp__action--yes)

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5582,4 +5582,4 @@ tlc.com##+js(trusted-click-element, .btn.btn-primary)
 eventim.ro##+js(trusted-click-element, #cmpwrapper >>> .cmpboxbtnyes, , 1000)
 
 ! https://github.com/uBlockOrigin/uAssets/pull/33067
-lequipe.fr##+js(trusted-click-element, .CmpUnsubscriber .Cmp__action--yes)
+lequipe.fr##+js(trusted-click-element, .CmpUnsubscriber .Cmp__action--yes, , 1000)

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5581,4 +5581,5 @@ tlc.com##+js(trusted-click-element, .btn.btn-primary)
 ! https://www.eventim.ro/event/alifantis-mirica-gemini-2-0-casa-de-cultura-a-sindicatelor-21322560/ - maps breakage
 eventim.ro##+js(trusted-click-element, #cmpwrapper >>> .cmpboxbtnyes, , 1000)
 
+! https://github.com/uBlockOrigin/uAssets/pull/33067
 lequipe.fr##+js(trusted-click-element, .CmpUnsubscriber .Cmp__action--yes)


### PR DESCRIPTION
### URL(s) where the issue occurs

`lequipe.fr` - when accessing from the UK

### Describe the issue

This site has a cookie notice that must be accepted in order to use the page. This PR uses a trusted-click-element to click the accept button, allowing the user to access the page.

### Screenshot(s)

<img width="1273" height="1081" alt="image" src="https://github.com/user-attachments/assets/597803d0-0dfb-4d42-b734-468cebfcb324" />


### Versions

- Browser/version: Brave - 1.90.124

### Notes

Fixes https://github.com/brave-experiments/cookiecrumbler-issues/issues/1450