### PR TITLE
Hiding cookie notice on theguardian.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5583,3 +5583,7 @@ eventim.ro##+js(trusted-click-element, #cmpwrapper >>> .cmpboxbtnyes, , 1000)
 
 ! https://github.com/uBlockOrigin/uAssets/pull/33067
 lequipe.fr##+js(trusted-click-element, .CmpUnsubscriber .Cmp__action--yes, , 1000)
+
+theguardian.com##+js(trusted-set-cookie, consentDate, $currentISODate$, domain=www.theguardian.com)
+theguardian.com##+js(trusted-set-cookie, consentUUID, 00000000-0000-0000-0000-000000000000000000, domain=www.theguardian.com)
+theguardian.com##+js(trusted-set-local-storage-item, gu.prefs.engagementBannerLastClosedAt, '{"value":"$currentISODate$"}')


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`theguardian.com`

### Describe the issue

There is a cookie notice on this page that should be hidden. When you reject this cookie notice, there is also a "rejection hurts... please enable cookies" message that appears. This should also be hidden.

### Screenshot(s)

<img width="1219" height="1195" alt="image" src="https://github.com/user-attachments/assets/1a68229a-81ca-4a09-8ade-351033914784" />

<img width="1262" height="1222" alt="image" src="https://github.com/user-attachments/assets/53d51848-21b1-46c2-a327-4033c6695ef1" />


### Versions

- Browser/version: Brave 1.90.124

### Notes

This is in response to numerous user reports on Brave. I am open to applying a different blocking approach if there is a more appropriate solution here.
