### PR TITLE
polyfill.io Update badware.txt

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6247,3 +6247,8 @@ top##body > center + .A + .post
 ! https://github.com/uBlockOrigin/uAssets/issues/33119
 ||robtips50kj.blogspot.com^$all
 ||checkmyapp.store^$all
+
+
+! https://www.bleepingcomputer.com/news/security/polyfillio-javascript-supply-chain-attack-impacts-over-100k-sites/
+! https://x.com/keita_roboin/status/2061326355292447015
+||polyfill.io^$all

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -4641,11 +4641,13 @@ app##center#yangchen > iframe#external-frame[src="https://im136.mom/"]:not([clas
 ||officialkmspico.com^$doc
 
 ! https://github.com/uBlockOrigin/uAssets/pull/24255
+! https://github.com/uBlockOrigin/uAssets/pull/33127
 ! https://sansec.io/research/polyfill-supply-chain-attack
 ! https://www.bleepingcomputer.com/news/security/polyfillio-javascript-supply-chain-attack-impacts-over-100k-sites/
 ! https://www.bleepingcomputer.com/news/security/polyfillio-bootcdn-bootcss-staticfile-attack-traced-to-1-operator/
 ! https://www.v2ex.com/t/950163
 ! https://www.silentpush.com/blog/triad-nexus-funnull/
+||polyfill.io^$all
 ||googie-anaiytics.com^$all
 ||bootcdn.net^$all
 ||bootcss.com^$all
@@ -6247,8 +6249,3 @@ top##body > center + .A + .post
 ! https://github.com/uBlockOrigin/uAssets/issues/33119
 ||robtips50kj.blogspot.com^$all
 ||checkmyapp.store^$all
-
-
-! https://www.bleepingcomputer.com/news/security/polyfillio-javascript-supply-chain-attack-impacts-over-100k-sites/
-! https://x.com/keita_roboin/status/2061326355292447015
-||polyfill.io^$all


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://polyfill.io/`

### Describe the issue

Polyfill.io has a history of serving malicious JavaScript after a change in ownership. While many websites have migrated away from the service, some sites may still reference Polyfill.io resources.

I would like to propose adding filter rules to block requests to Polyfill.io and related domains to help protect users from legacy integrations and prevent connections to infrastructure that is no longer considered trustworthy.

### Screenshot(s)

N/A

### Versions

* Browser/version: Firefox 151.0.2
* uBlock Origin version: 1.71.0

### Settings

* Default settings

### Notes

Polyfill.io was acquired by a Chinese company and, in 2024, security researchers reported that the service had been serving malicious code to a subset of visitors. Reported behavior included redirects to scam and fraudulent websites under certain conditions.

Although the service is now largely disabled and many websites have removed their dependencies, legacy references may still exist. Adding filter rules for Polyfill.io and related domains would provide additional protection for users visiting websites that continue to load these resources.
https://x.com/keita_roboin/status/2061326355292447015
