### PR TITLE
Hiding cookie notice on ispazio.net

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -618,6 +618,8 @@ admind-ai.com##+js(trusted-set-local-storage-item, admind_cookie_consent_v1, '{"
 tirerack.com##+js(trusted-click-element, #meru-cm button.meru-cc__bn[aria-label="Reject All"], , 2000)
 ! https://github.com/uBlockOrigin/uAssets/issues/33101
 handyhuellen.de,smartphonehoesjes.nl,ploonk.fr##+js(trusted-set-local-storage-item, mage_consent, '{"timestamp":$now$,"data":{"functional":true,"marketing":false}}')
+! https://github.com/uBlockOrigin/uAssets/pull/33130
+ispazio.net##+js(trusted-set-cookie, isp_consent, '{"v":1,"ts":$now$,"f":0,"e":0,"m":0,"a":0}')
 
 !! Needs additional cookies
 
@@ -5589,6 +5591,3 @@ lequipe.fr##+js(trusted-click-element, .CmpUnsubscriber .Cmp__action--yes, , 100
 
 ! https://github.com/uBlockOrigin/uAssets/issues/33124
 cmp.travelbook.de##+js(trusted-click-element, .cmp-banner button.accept-all)
-
-! https://github.com/uBlockOrigin/uAssets/pull/33130
-ispazio.net##+js(trusted-set-cookie, isp_consent, '{"v":1,"ts":1780335328422,"f":0,"e":0,"m":0,"a":0}')

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5592,3 +5592,6 @@ cmp.travelbook.de##+js(trusted-click-element, .cmp-banner button.accept-all)
 
 ! https://github.com/uBlockOrigin/uAssets/pull/33130
 ispazio.net##+js(trusted-set-cookie, isp_consent, '{"v":1,"ts":1780335328422,"f":0,"e":0,"m":0,"a":0}')
+
+
+clubic.com##+js(trusted-click-element, .didomi-continue-without-agreeing)

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5592,6 +5592,3 @@ cmp.travelbook.de##+js(trusted-click-element, .cmp-banner button.accept-all)
 
 ! https://github.com/uBlockOrigin/uAssets/pull/33130
 ispazio.net##+js(trusted-set-cookie, isp_consent, '{"v":1,"ts":1780335328422,"f":0,"e":0,"m":0,"a":0}')
-
-
-clubic.com##+js(trusted-click-element, .didomi-continue-without-agreeing)

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5589,3 +5589,6 @@ lequipe.fr##+js(trusted-click-element, .CmpUnsubscriber .Cmp__action--yes, , 100
 
 ! https://github.com/uBlockOrigin/uAssets/issues/33124
 cmp.travelbook.de##+js(trusted-click-element, .cmp-banner button.accept-all)
+
+
+ispazio.net##+js(trusted-set-cookie, isp_consent, '{"v":1,"ts":1780335328422,"f":0,"e":0,"m":0,"a":0}')

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5590,5 +5590,5 @@ lequipe.fr##+js(trusted-click-element, .CmpUnsubscriber .Cmp__action--yes, , 100
 ! https://github.com/uBlockOrigin/uAssets/issues/33124
 cmp.travelbook.de##+js(trusted-click-element, .cmp-banner button.accept-all)
 
-
+! https://github.com/uBlockOrigin/uAssets/pull/33130
 ispazio.net##+js(trusted-set-cookie, isp_consent, '{"v":1,"ts":1780335328422,"f":0,"e":0,"m":0,"a":0}')


### PR DESCRIPTION
### URL(s) where the issue occurs

`ispazio.net`

### Describe the issue

This page has a cookie notice that cannot be cosmetically removed because of css classes that are also present, blocking scroll and click of page elements. We will need to set a cookie to reject cookies and ensure this cookie notice is not displayed.

### Screenshot(s)

<img width="1164" height="865" alt="image" src="https://github.com/user-attachments/assets/40f7c6da-1118-4bf9-bd5f-24598411f3c8" />

### Versions

- Browser/version: Brave 1.90.128
