### PR TITLE
Hiding cookie notice on clubic.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5589,3 +5589,6 @@ lequipe.fr##+js(trusted-click-element, .CmpUnsubscriber .Cmp__action--yes, , 100
 
 ! https://github.com/uBlockOrigin/uAssets/issues/33124
 cmp.travelbook.de##+js(trusted-click-element, .cmp-banner button.accept-all)
+
+
+clubic.com##+js(trusted-click-element, .didomi-continue-without-agreeing)


### PR DESCRIPTION
### URL(s) where the issue occurs

`clubic.com`

### Describe the issue

There is a cookie notice on this page. This cookie notice cannot be hidden cosmetically as there is an overlay and scroll blocker associated with it. Also, the cookies set when this cookie notice is dismissed have unique IDs, so the best approach is likely using a trusted-click-element on the "Continue without agreeing" button.

### Screenshot(s)

<img width="1156" height="978" alt="image" src="https://github.com/user-attachments/assets/f871b23d-3222-49bc-a2ba-9241f2a33138" />


### Versions

- Browser/version: Brave 1.90.128
