### PR TITLE
Use essential cookies on filmpalast.net

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5595,3 +5595,6 @@ lequipe.fr##+js(trusted-click-element, .CmpUnsubscriber .Cmp__action--yes, , 100
 
 ! https://github.com/uBlockOrigin/uAssets/issues/33124
 cmp.travelbook.de##+js(trusted-click-element, .cmp-banner button.accept-all)
+
+! essential
+filmpalast.net##+js(trusted-set-cookie, borlabs-cookie, '{"consents":{"essential":["borlabs-cookie"]},"domainPath":"filmpalast.net/","expires":"Sat, 01 Aug 9999 20:36:00 GMT","uid":"anonymous","v3":true,"version":9}')


### PR DESCRIPTION
### URL(s) where the issue occurs

`filmpalast.net`

### Describe the issue

This site has a cookie notice that cannot be hidden cosmetically because there are scroll blockers and overlays that are present on the page. This change will use a trusted-set-cookie to accept essential cookies for the site.

### Screenshot(s)

<img width="1346" height="889" alt="image" src="https://github.com/user-attachments/assets/fe872e30-a9b0-4288-9baf-d4be83ed0857" />

### Versions

- Browser/version: Brave 1.90.128