### PR TITLE
Fix Chess.com ad rail layout shift

### DIFF
--- a/filters/filters-2025.txt
+++ b/filters/filters-2025.txt
@@ -3529,7 +3529,7 @@ premium-unlock.rajababucox.workers.dev###final-btn:style(display: block !importa
 premium-unlock.rajababucox.workers.dev###action-btn
 
 ! https://github.com/uBlockOrigin/uAssets/issues/31282
-chess.com##body.with-und:remove-class(with-und)
+chess.com##body.with-und:style(--adWidth: 0rem !important;)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/31255
 aether.mom##+js(trusted-replace-argument, String.prototype.split, this, , condition, 'null,http')


### PR DESCRIPTION
### Changes
Replaces the Chess.com `with-und` class removal filter with a style override that sets `--adWidth: 0rem`.

### Why
Removing `with-und` causes Chess.com's client-side ad layout code and the cosmetic filter to fight over the body class. The class can be briefly re-added and removed again, which causes cumulative layout shift on board pages.

There is a public user report of this happening near the end of a game: https://x.com/tej_codes/status/2062089243955220623

Overriding `--adWidth` directly collapses the ad rail while leaving the body class stable.

### Validation
Manually validated the intended behavior with the equivalent cosmetic filter:

```txt
chess.com##body.with-und:style(--adWidth: 0rem !important;)
```
