### PR TITLE
Fixing scroll block on home-appliances.philips

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5604,3 +5604,5 @@ cmp.travelbook.de##+js(trusted-click-element, .cmp-banner button.accept-all)
 
 ! https://www.antena3.ro/emisiuni/subiectiv/cum-s-a-razbunat-traian-basescu-pe-razvan-dumitrescu-pentru-un-interviu-ce-vrea-sorin-blejnar-de-la-188976.html - video breakage
 antena3.ro##+js(trusted-click-element, #onetrust-accept-btn-handler, , 1000)
+
+home-appliances.philips##+js(trusted-click-element, [data-cy="accept-functional-cookies-btn"])


### PR DESCRIPTION
### URL(s) where the issue occurs

`home-appliances.philips`

### Describe the issue

This page is not usable or scrollable. This is because the cookie notice is cosmetically hidden, but there remains an overlay. In order to get rid of the overlay and restore functionality to the page, we need to set a trusted click element to action the dialog.

### Screenshot(s)

<img width="1367" height="922" alt="image" src="https://github.com/user-attachments/assets/de0528b3-f544-4019-95a6-00b3187b236f" />


### Versions

- Browser/version: Brave 1.90.128

### Notes
- This fix is in response to numerous reports of scroll being blocked in the page on Brave
