### PR TITLE
unbreak: add toongo.io to wgplayer game player exceptions

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -4170,9 +4170,9 @@ pcwelt.de#@#a[href^="https://pvn.saturn.de/"]
 ! https://github.com/uBlockOrigin/uAssets/issues/23767
 ! https://www.reddit.com/r/uBlockOrigin/comments/1iybutj/adblock_detected_at_skywareinventory/
 @@||scylla.wgplayer.com/f_webp/$image
-@@||universal.wgplayer.com/tag/$script,domain=atarisalon.com|brightygames.com|sisigames.com|yoho.games
-@@||wgplayer.com/*/wgAds.$script,domain=atarisalon.com|brightygames.com|pastelkattogames.com|sisigames.com|yoho.games
-@@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=atarisalon.com|brightygames.com|sisigames.com|yoho.games
+@@||universal.wgplayer.com/tag/$script,domain=atarisalon.com|brightygames.com|sisigames.com|toongo.io|yoho.games
+@@||wgplayer.com/*/wgAds.$script,domain=atarisalon.com|brightygames.com|pastelkattogames.com|sisigames.com|toongo.io|yoho.games
+@@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=atarisalon.com|brightygames.com|sisigames.com|toongo.io|yoho.games
 brightygames.com,yoho.games##^html > head > meta[property="og:url"]:not([content*="/games/"], [content*="/play/"]):upward(1) > script:has-text(wgplayer)
 sisigames.com##^#index-games:upward(html) > head > script:has-text(wgplayer)
 ! videos


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`toongo.io`

### Describe the issue

toongo.io uses wgplayer for its game player. The ||wgplayer.com^ block prevents games from loading on the site. I had to allow wgplayer on toongo.io so it would stop breaking games. 

### Screenshot(s)

### Versions

- Browser/version: Brave 1.91.168
- uBlock Origin version: 1.71.0

### Settings

### Notes