### PR TITLE
Block imgur.gg analytics (p.imgur.gg)

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -3132,3 +3132,6 @@ webex.com##+js(no-xhr-if, svc.webex.com/metrics)
 
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt
+
+! imgur.gg analytics domain
+||p.imgur.gg^


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://imgur.gg/`

### Describe the issue

`p.imgur.gg` serves multiple javascript files to capture various analytics