### PR TITLE
Remove posthog /flags/ block

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -2760,8 +2760,6 @@ abs-cbn.com##+js(set-session-storage-item, VR-INJECTOR-INSTANCES-MAP, $remove$)
 /ingress/*^ip=
 ! https://github.com/AdguardTeam/AdguardFilters/issues/213386
 /hog/*^ip=
-! https://github.com/uBlockOrigin/uAssets/issues/33267
-/flags/*^ip=
 
 ! https://edikted.com/
 ! https://github.com/uBlockOrigin/uAssets/issues/29131


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://console.runpod.io/deploy`

### Describe the issue

Explained in full detail here: https://github.com/uBlockOrigin/uAssets/issues/33328
tldr; blocking `/flags/` doesn't add anything towards privacy, and instead just prevents websites that use PostHog's feature flags from loading

### Screenshot(s)

<img width="2347" height="1280" alt="image" src="https://github.com/user-attachments/assets/aa909289-7fcb-4258-a2c7-93cd8bf60771" />

### Versions

- Browser/version: Firefox 151
- uBlock Origin version: 1.71.0

### Settings

- Default settings

### Notes
https://github.com/uBlockOrigin/uAssets/issues/33328