### PR TITLE
Hiding cookie notice on express.de

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -2275,7 +2275,7 @@ elisa.ee##+js(trusted-click-element, cds-button[id="cookie-allow-necessary-et"],
 
 ! accept (consent wall) 
 ! cdn.privacy-mgmt.com / rockhard.de 
-baseendpoint.brigitte.de,baseendpoint.gala.de,baseendpoint.haeuser.de,baseendpoint.stern.de,baseendpoint.urbia.de,cmp.tag24.de,cmp-sp.handelsblatt.com,cmpv2.berliner-zeitung.de,golem.de,gamestar.de,rockhard.de>>,consent.t-online.de,cmp-sp.handelsblatt.com##+js(trusted-click-element, button[title*="Zustimmen" i], ,  1000)
+baseendpoint.brigitte.de,baseendpoint.gala.de,baseendpoint.haeuser.de,baseendpoint.stern.de,baseendpoint.urbia.de,cmp.tag24.de,cmp-sp.handelsblatt.com,cmpv2.berliner-zeitung.de,golem.de,gamestar.de,rockhard.de>>,consent.t-online.de,cmp-sp.handelsblatt.com,express.de##+js(trusted-click-element, button[title*="Zustimmen" i], ,  1000)
 
 ! I agree (consent wall)
 ! cdn.privacy-mgmt.com = www.btc-echo.de

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -2275,7 +2275,8 @@ elisa.ee##+js(trusted-click-element, cds-button[id="cookie-allow-necessary-et"],
 
 ! accept (consent wall) 
 ! cdn.privacy-mgmt.com / rockhard.de 
-baseendpoint.brigitte.de,baseendpoint.gala.de,baseendpoint.haeuser.de,baseendpoint.stern.de,baseendpoint.urbia.de,cmp.tag24.de,cmp-sp.handelsblatt.com,cmpv2.berliner-zeitung.de,golem.de,gamestar.de,rockhard.de>>,consent.t-online.de,cmp-sp.handelsblatt.com,express.de##+js(trusted-click-element, button[title*="Zustimmen" i], ,  1000)
+baseendpoint.brigitte.de,baseendpoint.gala.de,baseendpoint.haeuser.de,baseendpoint.stern.de,baseendpoint.urbia.de,cmp.tag24.de,cmp-sp.handelsblatt.com,cmpv2.berliner-zeitung.de,golem.de,gamestar.de,consent.t-online.de,cmp-sp.handelsblatt.com,consent2.express.de##+js(trusted-click-element, button[title*="Zustimmen" i], ,  1000)
+rockhard.de>>##+js(trusted-click-element, button[title*="Zustimmen" i], ,  1000)
 
 ! I agree (consent wall)
 ! cdn.privacy-mgmt.com = www.btc-echo.de


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`express.de`

### Describe the issue
This site has a cookie notice that needs to be hidden. This cookie notice needs to be accepted in order for the site to function properly.

### Screenshot(s)
<img width="1223" height="902" alt="image" src="https://github.com/user-attachments/assets/f8d6cfff-4d62-40da-bdd8-7e88242b7a3f" />


### Versions

- Browser/version: Brave v1.93.64

### Notes

There is already several sites using the same filter rule to accept this type of cookie notice. I have added this domain to that list and this removes the cookie notice effectively from my testing.
