### PR TITLE
Hiding cookie notice on asket.com

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -648,6 +648,8 @@ web.magentatv.de##+js(trusted-set-local-storage-item, DTAG_GUEST_PRIVACY_FLAGS, 
 bahn.de##+js(trusted-set-cookie, CONSENTMGR, 'c1:1|c2:0|c3:0|c4:0|c5:0|c6:0|c7:0|c8:0|c9:0|c10:0|c11:0|c12:0|c13:0|c14:0|c15:0|c16:0|ts:$now$|consent:true|id:0', , , domain, .bahn.de)
 ! https://insights.assetmanagement.hsbc.com/
 insights.assetmanagement.hsbc.com##+js(trusted-click-element, .reject-all > button)
+! https://github.com/uBlockOrigin/uAssets/pull/33501
+asket.com##+js(trusted-set-cookie, CookieConsent, "{stamp:'',necessary:true,preferences:false,statistics:false,marketing:false,method:'explicit'}")
 
 !! Needs additional cookies
 
@@ -5645,7 +5647,3 @@ megateh.fi##+js(trusted-set-cookie, cookie_consent, %7B%22functional%22%3A1%2C%2
 
 ! https://forums.lanik.us/viewtopic.php?p=169877-visualcrossing-com#p169877
 visualcrossing.com##+js(trusted-set-local-storage-item, vcstate, '{"required":{"necessary":true,"functional":false,"analysis":false,"ads":false,"hasSetCookies":1}}')
-
-! Necessary
-! https://github.com/uBlockOrigin/uAssets/pull/33501
-asket.com##+js(trusted-set-cookie, CookieConsent, "{stamp:'',necessary:true,preferences:false,statistics:false,marketing:false,method:'explicit'}")

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5645,3 +5645,6 @@ megateh.fi##+js(trusted-set-cookie, cookie_consent, %7B%22functional%22%3A1%2C%2
 
 ! https://forums.lanik.us/viewtopic.php?p=169877-visualcrossing-com#p169877
 visualcrossing.com##+js(trusted-set-local-storage-item, vcstate, '{"required":{"necessary":true,"functional":false,"analysis":false,"ads":false,"hasSetCookies":1}}')
+
+
+asket.com##+js(trusted-set-cookie, CookieConsent, "{stamp:'',necessary:true,preferences:false,statistics:false,marketing:false,method:'explicit'}")

--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -5646,5 +5646,6 @@ megateh.fi##+js(trusted-set-cookie, cookie_consent, %7B%22functional%22%3A1%2C%2
 ! https://forums.lanik.us/viewtopic.php?p=169877-visualcrossing-com#p169877
 visualcrossing.com##+js(trusted-set-local-storage-item, vcstate, '{"required":{"necessary":true,"functional":false,"analysis":false,"ads":false,"hasSetCookies":1}}')
 
-
+! Necessary
+! https://github.com/uBlockOrigin/uAssets/pull/33501
 asket.com##+js(trusted-set-cookie, CookieConsent, "{stamp:'',necessary:true,preferences:false,statistics:false,marketing:false,method:'explicit'}")


### PR DESCRIPTION
### URL(s) where the issue occurs

`asket.com`

### Describe the issue

There is a cookie notice on this page that appears as the user starts to scroll. There is an overlay behind this cookie notice that persists when the cookie notice has been hidden. Because of this, the best approach is to set the necessary cookies programmatically.

### Screenshot(s)

<img width="2167" height="1093" alt="image" src="https://github.com/user-attachments/assets/8f31d55c-3130-41a1-b70f-3e265e84fe03" />


### Versions

- Browser/version: Brave 1.94.2