### PR TITLE
Update badware.txt - ErrTrafficv2

### DIFF
--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6271,5 +6271,11 @@ gemfellowship.org##+js(rmnt, script, TextDecoder)
 
 ! ClickFix Errtrafficv2
 ! https://urlscan.io/result/019f0fdb-f020-775c-939d-f27f2e700a44/
-! https://www.sekoia.com/blog/unveiling-errtraffic-inside-a-growing-clickfix-malware-distribution-framework#toc-3-errtraffic-campaigns:~:text=primary%20ErrTraffic%20cluster.-,%E2%80%9CBeer%E2%80%9D%20ErrTraffic%20cluster,-The%20%E2%80%9CBeer%E2%80%9D%20ErrTraffic
-/api/css.js$third-party,script
+! https://www.sekoia.com/blog/unveiling-errtraffic-inside-a-growing-clickfix-malware-distribution-framework
+! https://github.com/uBlockOrigin/uAssets/pull/33530
+/api/css.js^$3p,script
+||great-fade.sbs^$all
+||re-captcha.xyz^$all
+||gtm-tools.xyz^$all
+||cloudproxy.digital^$3p,xhr
+##html.canvas > body.wp-singular + div[popover="manual"]

--- a/filters/badware.txt
+++ b/filters/badware.txt
@@ -6268,3 +6268,8 @@ gemfellowship.org##+js(rmnt, script, TextDecoder)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/234669
 ||microsoft-update.support^$all
+
+! ClickFix Errtrafficv2
+! https://urlscan.io/result/019f0fdb-f020-775c-939d-f27f2e700a44/
+! https://www.sekoia.com/blog/unveiling-errtraffic-inside-a-growing-clickfix-malware-distribution-framework#toc-3-errtraffic-campaigns:~:text=primary%20ErrTraffic%20cluster.-,%E2%80%9CBeer%E2%80%9D%20ErrTraffic%20cluster,-The%20%E2%80%9CBeer%E2%80%9D%20ErrTraffic
+/api/css.js$third-party,script


### PR DESCRIPTION
### URL(s) where the issue occurs

` longhall.consulting`
cf https://urlscan.io/result/019f0fdb-f020-775c-939d-f27f2e700a44/

### Describe the issue

Infected Wordpress that display a fake captcha lure leading to Clickfix compromise. This endpoint is related to ErrTrafficv2 as stated by Sekoia: https://www.sekoia.com/blog/unveiling-errtraffic-inside-a-growing-clickfix-malware-distribution-framework#toc-3-errtraffic-campaigns:~:text=primary%20ErrTraffic%20cluster.-,%E2%80%9CBeer%E2%80%9D%20ErrTraffic%20cluster,-The%20%E2%80%9CBeer%E2%80%9D%20ErrTraffic

### Screenshot(s)

<img width="797" height="604" alt="image" src="https://github.com/user-attachments/assets/8e2626c7-aaf3-44aa-8699-3c4723d75976" />

### Versions

- Browser/version: Firefox 140.12.0esr 
- uBlock Origin version: uBlock Origin 1.71.0

### Settings

N/A

### Notes

I tried the commited filters and it properly block this Clickfix cluster that is still active: `/api/css.js$third-party,script`
