### PR TITLE
fix: pinterest functionality, see pinterest.com: nuisance #32524

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -62,7 +62,7 @@ businessinsider.com##.related-posts
 ! https://github.com/uBlockOrigin/uAssets/issues/16581#issuecomment-4650988602
 /wrapperMessagingWithoutDetection.js$domain=autosport.com
 ! https://github.com/uBlockOrigin/uAssets/issues/32524#issuecomment-4712732765
-pinterest.com###__PWS_ROOT__ ~ div[class][style="z-index: 1000;"]:not([id])
+pinterest.com###__PWS_ROOT__ ~ div[class][style="z-index: 1000;"]:not([id]):has(div[role="dialog"][aria-modal="true"][aria-label=""])
 pinterest.com##body[style]:style(overflow: auto !important;)
 
 !!! Trusted scriptlets------------------------------------------------------------


### PR DESCRIPTION
#32524

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://de.pinterest.com/`


### Describe the issue

"Organize on board" and "Create a board" stopped working because of this filter:
```css
pinterest.com###__PWS_ROOT__ ~ div[class][style="z-index: 1000;"]:not([id])
```

Fixed by targeting just the cookie banner.

### Screenshot(s)

<details>
<summary>The features that need to work
</summary>

<img width="804" height="639" alt="Screenshot 2026-07-03 at 14 41 12" src="https://github.com/user-attachments/assets/10c1cefe-97cd-4857-a7a2-accdfab6bc25" />
<img width="742" height="702" alt="Screenshot 2026-07-03 at 14 41 41" src="https://github.com/user-attachments/assets/d749bce4-c7ea-4811-abbd-c35a9917ee58" />
</details>

### Versions

- Browser/version: Helium Version 0.13.6.1 (Official Build, Chromium 149.0.7827.200) (arm64)
- uBlock Origin version: uBlock Origin 1.71.0 (Helium)

### Settings

uBlock Origin: 1.71.0
Chromium: 149
filterset (summary):
 network: 183762
 cosmetic: 100039
 scriptlet: 50068
 html: 0
listset (total-discarded, last-updated):
 removed:
  adguard-generic: null
  adguard-spyware-url: null
  adguard-cookies: null
 added:
  https://raw.githubusercontent.com/gijsdev/ublock-hide-yt-shorts/master/list.txt: 28-0, 181d.17h.21m
  easylist-annoyances: 5224-37, 1d.3h.54m
  easylist-chat: 276-0, 1d.23h.29m
 default:
  user-filters: 5-0, never
  helium-annoyances: 1-0, 2h.57m
  helium-unbreak: 0-0, 2h.57m
  ublock-filters: 51768-88, 1d.1h.54m
  ublock-badware: 10215-27, 1d.1h.54m
  ublock-privacy: 4068-4, 2d.3h.22m
  ublock-unbreak: 2771-1, 1d.1h.54m
  ublock-quick-fixes: 465-0, 3h.6m
  easylist: 83326-476, 4d.2h.51m
  easyprivacy: 55894-716, 4d.2h.51m
  urlhaus-1: 48710-11, 56m
  fanboy-cookiemonster: 47017-122, 2h.54m
  ublock-cookies-easylist: 5710-45, 47m
  easylist-newsletters: 9380-29, 2d.3h.22m
  easylist-notifications: 2515-174, 2d.3h.22m
  ublock-annoyances: 4918-63, 2d.3h.22m
  plowe-0: 3507-0, 6d.1h.56m
filterset (user): [array of 5 redacted]
trustedset:
 added: [array of 11 redacted]
userSettings: [none]
hiddenSettings: [none]
supportStats:
 allReadyAfter: 2319 ms (selfie)
 maxAssetCacheWait: 274 ms
 cacheBackend: indexedDB

### Notes

The cookie modal has an empty `aria-label` that can be targeted. This might change in the future.
