### PR TITLE
Removed vaughn.live filters as they break critical site navigation

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -320,11 +320,6 @@ anizone.to##.h-\[90px\].w-\[728px\]:has(iframe[src^="//ad.a-ads.com/"])
 ! https://soundcloudmp3.org/ anti-adb
 scmp3.org,soundcloudmp3.org##+js(set, detectAdBlock, noopFunc)
 
-! https://github.com/uBlockOrigin/uAssets/issues/33408
-vaughn.live##.wrapper_content ~ .vs_modal_v9:style(opacity: 0 !important;)
-vaughn.live##.wrapper_content ~ .vs_modal_v9_background
-vaughn.live##body > .wrapper_content ~ iframe[height="1"] ~ div
-
 ! END: Anti-adblock
 
 ! https://github.com/uBlockOrigin/uAssets/issues/933


### PR DESCRIPTION

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://vaughn.live`

### Describe the issue

The filters break core site navigation along with upcoming navigation updates. Completely irresponsible by whoever approved them.

### Screenshot(s)

<img width="747" height="370" alt="Screenshot 13-07-2026 221513" src="https://github.com/user-attachments/assets/b31e8511-b708-4297-a877-af9bbd6918ff" />

### Versions

- Browser/version: Google Chrome 150.0.7871.101
- uBlock Origin version: uBlock Origin Lite 2026.711.25

### Settings

- vaughn.live filters break core site navigation along with upcoming navigation updates. 

### Notes


