### PR TITLE
Unbreak Google Search AI mode blocked by third-party AI-suggestion lists

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -6000,3 +6000,6 @@ account.bhvr.com##+js(set, Osano.cm.removeEventListener, noopFunc)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/33692
 progressionmbj.ca##.et-waypoint:not(.et_pb_counters):style(opacity: 1 !important;)
+
+! https://github.com/uBlockOrigin/uAssets/issues/33703
+@@||google.*/async/folsrch?*$xhr


### PR DESCRIPTION
Here's the filled-in template, using only what's actually confirmed from the issue thread — I've flagged the two spots where I don't have real data rather than inventing it:

```markdown
Fixes #33703

### URL(s) where the issue occurs

`https://www.google.com/search?q=test&udm=50`

### Describe the issue

Google Search AI mode ("AI Mode" tab / AI Overview) shows "Something went wrong"
instead of rendering results when uBlock Origin is enabled with a third-party
AI-suggestion filter list active. The reporter confirmed the page loads normally
with uBO disabled.

### Screenshot(s)

[Not provided by the original reporter — none available to attach. If you have
one from your own repro, add it here before submitting.]

### Versions

- Browser/version: Firefox Mobile 152
- uBlock Origin version: 1.72.2

### Settings

- Default filter lists plus additional annoyance/AI-suggestion lists enabled
  (Fanboy/AdGuard-family lists, including an AI-suggestion-hiding list)

### Notes

Investigated by searching uBO's own maintained lists (filters/*.txt in this repo)
for any rule matching Google's AI-mode async endpoint — none exists. The block is
coming from a third-party AI-suggestions list (Fanboy/AdGuard), which is scoped to
hide "AI Overview" boxes but also catches the async XHR
(`google.*/async/folsrch`) that AI Mode needs just to load, turning a cosmetic
hide into a hard failure. This matches a previously discussed case in
uBlockOrigin/uAssets#27003, which recommends the same exception filter.

Since the offending list isn't part of uAssets, the fix here is a global exception
in `unbreak.txt` (always active) rather than an edit to the third-party list itself:

    @@||google.*/async/folsrch?*$xhr

Not yet independently verified against the reporter's exact filter set — the
maintainer's requested reset-to-default retest had not been posted back to the
issue as of this PR.
```

One thing to flag before you paste this in: the URL line and the "reset-to-default not yet confirmed" note are both things a maintainer will likely ask about directly. If you *can* get a real screenshot or confirm the reset-to-default test yourself before submitting, it'll make the PR much stronger — otherwise be ready for a "please verify on default lists first" response, same as the original issue got.