### PR TITLE
Removing ref from search-redirection URLs on Audible causes problems

### DIFF
--- a/filters/privacy-removeparam.txt
+++ b/filters/privacy-removeparam.txt
@@ -1572,7 +1572,7 @@ $removeparam=sub_rt,to=comemo.nikkei.com|diehardtales.com|greenplanet.kaneka.co.
 ||walmart.com^$removeparam=from
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-10267760
 ||audible.$removeparam=ref
-@@/search-redirection$doc,removeparam,domain=audible.*
+@@||audible.*/search-redirection$doc,removeparam=ref
 ! https://github.com/AdguardTeam/AdguardFilters/issues/185385
 ||camcam.cc^$removeparam=ref
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-10238857

--- a/filters/privacy-removeparam.txt
+++ b/filters/privacy-removeparam.txt
@@ -1572,6 +1572,7 @@ $removeparam=sub_rt,to=comemo.nikkei.com|diehardtales.com|greenplanet.kaneka.co.
 ||walmart.com^$removeparam=from
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-10267760
 ||audible.$removeparam=ref
+@@/search-redirection$doc,removeparam,domain=audible.*
 ! https://github.com/AdguardTeam/AdguardFilters/issues/185385
 ||camcam.cc^$removeparam=ref
 ! https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-10238857


### PR DESCRIPTION


<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://www.audible.com/`

### Describe the issue

When clicking on a "series" link in the Audible search, the user is redirected through `https://www.audible.com/search-redirection?keywords=&k=dungeon+crawler+carl+series&ref=web_search_suggested_srs_1_1 [...]`; removing `ref` from that URL causes the user to be sent to the wrong page, resulting in an error.

### Screenshot(s)



### Versions

- Browser/version: Firefox 152.0.6
- uBlock Origin version: 1.72.3b3
### Settings

- "AdGuard/uBO – URL Tracking Protection" enabled

### Notes

See https://github.com/DandelionSprout/adfilt/discussions/163#discussioncomment-17663616
This is the same fix I added to Legit URL in https://github.com/DandelionSprout/adfilt/commit/c1d777dd3f686a4f4f7f702d3f5476b2d05b6148
It's the same problematic filter in both lists, but I confirmed the patch works for "AdGuard/uBO – URL Tracking Protection" with Legit URL disabled.