### PR TITLE
Remove getthispdf rules

### DIFF
--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -703,14 +703,6 @@ dstat.space##.p-4:has(> div[id^="banner-list-"])
 ! https://github.com/uBlockOrigin/uAssets/issues/32440
 weebcentral.com##div[class][style]:has(> div.notranslate > iframe[sandbox*="allow-popups"])
 
-! https://github.com/uBlockOrigin/uAssets/issues/32452
-getthispdf.com##+js(rmnt, script, /popunder/i)
-getthispdf.com##+js(nostif, /detect|bait/i)
-getthispdf.com##+js(rpnt, script, loadAdPlacements();)
-getthispdf.com##+js(rmnt, script, checkBait)
-getthispdf.com##+js(nostif, ++;break;}}}}})
-getthispdf.com##+js(set, __adBlockState, undefined)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/30024#issuecomment-4193302125
 forum.ixbt.com##+js(trusted-set-cookie-reload, s, '180,,4,,a')
 


### PR DESCRIPTION
Removed filter rules for getthispdf.com

The site has closed.

<img width="915" height="853" alt="image" src="https://github.com/user-attachments/assets/8a5ed7d1-0479-4da3-bd5d-194471e0bb1f" />



