### PR TITLE
fix #33963 on Firefox Mobile

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -8736,8 +8736,8 @@ ligainsider.de##+js(acs, $, MutationObserver)
 @@||ligainsider.de^$ghide
 ligainsider.de##.new_add
 ligainsider.de##.mb-md.float-start:has(#ad-rectangle2)
-||ligainsider.de/public/desktop/js/li-probe
-||ligainsider.de/public/desktop/js/li-wall
+||ligainsider.de/public/*/js/li-probe
+||ligainsider.de/public/*/js/li-wall
 ||ligainsider.de/li-probe
 
 ! https://github.com/NanoAdblocker/NanoFilters/issues/417


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

https://ligainsider.de/

### Describe the issue

Paywall when ublock is detected

### Versions

- Browser/version: Firefox Mobile 153.0.3
- uBlock Origin version: 1.72.2

### Settings

### Notes

We need to catch the mobile path too. So i replaced desktop with a wildcard