### PR TITLE
xiaohongshu.com: remove tracking params

### DIFF
--- a/filters/privacy-removeparam.txt
+++ b/filters/privacy-removeparam.txt
@@ -3592,6 +3592,13 @@ $removeparam=s,domain=twitter.com|x.com
 ||v.youku.com^$removeparam=spm
 ! The Register
 ||theregister.com^$removeparam=td
+! Xiaohongshu
+! https://github.com/uBlockOrigin/uAssets/pull/34015
+||xiaohongshu.com^$removeparam=app_platform
+||xiaohongshu.com^$removeparam=app_version
+||xiaohongshu.com^$removeparam=share_channel
+||xiaohongshu.com^$removeparam=share_id
+||xiaohongshu.com^$removeparam=xhsshare
 !
 ! Deezer
 ! https://github.com/AdguardTeam/AdguardFilters/pull/119475


### PR DESCRIPTION
Links shared from Xiaohongshu contain tracking parameters. My testing shows that removing these parameters has no negative impact and appears to be safe.

See also: <https://36kr.com/p/2699872874903689> (in Chinese)