### PR TITLE
bilibili.com: remove tracking params

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -3228,7 +3228,7 @@ $uritransform=/#Echobox=[\d]{10}$//,to=iltalehti.fi|hs.fi
 ||rollercoin.com/static/img/referral_160-600.png$image,redirect=1x1.gif,important
 
 ! https://github.com/uBlockOrigin/uAssets/pull/34031
-||s1.hdslb.com/bfs/static/jinkela/video/video.*$script,replace=/vd_source:this\.vdSource/vd_source:undefined/,domain=bilibili.com
+||s1.hdslb.com/bfs/static/jinkela/video/video.$script,replace=/vd_source:this\.vdSource/vd_source:undefined/,domain=bilibili.com
 
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt

--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -3227,5 +3227,8 @@ $uritransform=/#Echobox=[\d]{10}$//,to=iltalehti.fi|hs.fi
 ! https://github.com/uBlockOrigin/uAssets/issues/33997
 ||rollercoin.com/static/img/referral_160-600.png$image,redirect=1x1.gif,important
 
+! https://github.com/uBlockOrigin/uAssets/pull/34031
+||s1.hdslb.com/bfs/static/jinkela/video/video.*$script,replace=/vd_source:this\.vdSource/vd_source:undefined/,domain=bilibili.com
+
 ! Merge in resource-abuse.txt
 !#include resource-abuse.txt


### PR DESCRIPTION
There is already a rule `||bilibili.com^$removeparam=vd_source` that can be used to remove the `vd_source` parameter. However, the parameter is automatically re-added to the URL a few seconds after video playback begins. I discovered that this is caused by the following JavaScript logic:

```js
this.$router.replace({
    query: zm(zm({
    }, this.$route.query), {
    }, {
    vd_source: this.vdSource
    }),
    hash: this.$route.hash
})
```

Therefore, we can replace `vd_source: this.vdSource` with `vd_source: undefined` to prevent this tracking parameter from being added to the address bar.