### PR TITLE
New parameters for YouTube and GOG

### DIFF
--- a/filters/privacy-removeparam.txt
+++ b/filters/privacy-removeparam.txt
@@ -3607,6 +3607,14 @@ $removeparam=s,domain=twitter.com|x.com
 ! GamesPlanet
 ||gamesplanet.com^$removeparam=ref
 !
+! YouTube
+! Removes tracking parameter from the shared links
+||youtu.be^$removeparam=?si
+!
+! GOG
+! Removes tracking parameter from the links included in their e-mail newsletters
+||gog.com^$removeparam=smclient
+!
 ! Special rules for AdGuard websites' test pages. The only purpose of these
 ! rules is to make test pages work so that users could verify that AdGuard
 ! is properly working.


### PR DESCRIPTION
I've added a two new parameters for `youtu.be` and `gog.com` which remove tracking IDs specific to a person who shared the video/clicked on a link in the e-mail newsletter. Both were tested and work just fine.