### PR TITLE
douban: click trackers

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1119,6 +1119,9 @@ donanimhaber.com##+js(href-sanitizer, body a[href^="/ExternalLinkRedirect?"][hre
 ! https://www.f6s.com/company/zomato
 f6s.com##+js(aeld, , redirect)
 ||f6s.com/redirect?url=http*$doc,urlskip=?url
+! https://github.com/uBlockOrigin/uAssets/pull/34040
+||douban.com/link2/?url=http$doc,urlskip=?url
+douban.com##+js(href-sanitizer, body a[href^="https://www.douban.com/link2/?url=http"], ?url)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24675 - click tracking
 ||cdn.digg.com/fragments/homepage/static/view-frontpage.js


### PR DESCRIPTION
Example website: `https://www.douban.com/search?cat=1002&q=MyGO%21%21%21%21%21`

The search results on the right are all redirect links; for example: `https://www.douban.com/link2/?url=https%3A%2F%2Fmovie.douban.com%2Fsubject%2F36352095%2F&query=MyGO%21%21%21%21%21&cat_id=1002&type=search&pos=0`