### PR TITLE
bahamut: click trackers

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1122,6 +1122,9 @@ f6s.com##+js(aeld, , redirect)
 ! https://github.com/uBlockOrigin/uAssets/pull/34040
 ||douban.com/link2/?url=http$doc,urlskip=?url
 douban.com##+js(href-sanitizer, body a[href^="https://www.douban.com/link2/?url=http"], ?url)
+! https://github.com/uBlockOrigin/uAssets/pull/34041
+||ref.gamer.com.tw/redir.php?url=http$doc,urlskip=?url
+gamer.com.tw##+js(href-sanitizer, body a[href^="https://ref.gamer.com.tw/redir.php?url=http"], ?url)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24675 - click tracking
 ||cdn.digg.com/fragments/homepage/static/view-frontpage.js


### PR DESCRIPTION
Example website: `https://forum.gamer.com.tw/C.php?bsn=72822&snA=10463`

External links in posts are converted into redirects. For example: `https://ref.gamer.com.tw/redir.php?url=https%3A%2F%2Fwww.miyoushe.com%2Fsr%2Farticle%2F62904638`