### PR TITLE
landian: click trackers

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1125,6 +1125,9 @@ douban.com##+js(href-sanitizer, body a[href^="https://www.douban.com/link2/?url=
 ! https://github.com/uBlockOrigin/uAssets/pull/34041
 ||ref.gamer.com.tw/redir.php?url=http$doc,urlskip=?url
 gamer.com.tw##+js(href-sanitizer, body a[href^="https://ref.gamer.com.tw/redir.php?url=http"], ?url)
+! https://github.com/uBlockOrigin/uAssets/pull/34042
+||landian.news/go?url=http$doc,urlskip=?url
+landian.news##+js(href-sanitizer, body a[href^="https://www.landian.news/go?url=http"], ?url)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24675 - click tracking
 ||cdn.digg.com/fragments/homepage/static/view-frontpage.js


### PR DESCRIPTION
Example website: `https://www.landian.news/archives/114254.html`

External links within the article are converted into redirects. For example: `https://www.landian.news/go?url=https://developers.cloudflare.com/changelog/post/2026-08-07-mesh-container-image/`