### PR TITLE
zhihu: click trackers

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1128,6 +1128,9 @@ gamer.com.tw##+js(href-sanitizer, body a[href^="https://ref.gamer.com.tw/redir.p
 ! https://github.com/uBlockOrigin/uAssets/pull/34042
 ||landian.news/go?url=http$doc,urlskip=?url
 landian.news##+js(href-sanitizer, body a[href^="https://www.landian.news/go?url=http"], ?url)
+! https://github.com/uBlockOrigin/uAssets/pull/34049
+||link.zhihu.com/?target=http$doc,urlskip=?target
+zhihu.com##+js(href-sanitizer, body a[href^="https://link.zhihu.com/?target=http"], ?target)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24675 - click tracking
 ||cdn.digg.com/fragments/homepage/static/view-frontpage.js


### PR DESCRIPTION
Example website: `https://www.zhihu.com/question/39154334`

External links within the article are converted into redirects. For example: `https://link.zhihu.com/?target=https%3A//github.com/uBlockOrigin/uAssets`