### PR TITLE
touchgal.ink: click trackers

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1131,6 +1131,9 @@ landian.news##+js(href-sanitizer, body a[href^="https://www.landian.news/go?url=
 ! https://github.com/uBlockOrigin/uAssets/pull/34049
 ||link.zhihu.com/?target=http$doc,urlskip=?target
 zhihu.com##+js(href-sanitizer, body a[href^="https://link.zhihu.com/?target=http"], ?target)
+! https://github.com/uBlockOrigin/uAssets/pull/34057
+||touchgal.ink/redirect?url=http$doc,urlskip=?url
+touchgal.ink##+js(href-sanitizer, body a[href^="/redirect?url=http"], ?url)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24675 - click tracking
 ||cdn.digg.com/fragments/homepage/static/view-frontpage.js


### PR DESCRIPTION
Example website: `https://www.touchgal.ink/a555829b?tab=resources`

After clicking the download button, the displayed link is a redirect URL. For example: `https://www.touchgal.ink/redirect?url=https%3A%2F%2Fpan.touchgal.net%2Fs%2Fwpwtv`

<img width="1481" height="959" alt="screenshot" src="https://github.com/user-attachments/assets/81cf8fb3-a2f5-4b51-af35-98fb3d1c86c8" />
