### PR TITLE
sspai: click trackers

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1134,6 +1134,9 @@ zhihu.com##+js(href-sanitizer, body a[href^="https://link.zhihu.com/?target=http
 ! https://github.com/uBlockOrigin/uAssets/pull/34057
 ||touchgal.ink/redirect?url=http$doc,urlskip=?url
 touchgal.ink##+js(href-sanitizer, body a[href^="/redirect?url=http"], ?url)
+! https://github.com/uBlockOrigin/uAssets/pull/34060
+||sspai.com/link?target=http$doc,urlskip=?target
+sspai.com##+js(href-sanitizer, body a[href^="https://sspai.com/link?target=http"], ?target)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24675 - click tracking
 ||cdn.digg.com/fragments/homepage/static/view-frontpage.js


### PR DESCRIPTION
Example link: `https://sspai.com/post/112901`

Some links within the article content will be converted into redirect links. For example: `https://sspai.com/link?target=https%3A%2F%2Fwww.typeless.com%2F`