### PR TITLE
Fix async file operations in validator

### DIFF
--- a/tools/validate/validate.js
+++ b/tools/validate/validate.js
@@ -80,11 +80,8 @@ const jsonSetMapReplacer = (k, v) => {
 const writeFile = async (fname, data) => {
     const dir = path.dirname(fname);
     await fs.mkdir(dir, { recursive: true });
-    const promise = fs.writeFile(fname, data);
-    writeOps.push(promise);
-    return promise;
+    await fs.writeFile(fname, data);
 };
-const writeOps = [];
 
 /******************************************************************************/
 
@@ -281,7 +278,7 @@ async function processList(parser, text, lineto, fpath) {
             badHostnames.forEach(v => {
                 log(`${lineno}  ${v}`);
             });
-            writeFile(fpath, stdOutput.join('\n'));
+            await writeFile(fpath, stdOutput.join('\n'));
         }
     }
     toProgressString(0);
@@ -308,12 +305,12 @@ async function main() {
     const text = await fs.readFile(infile, { encoding: 'utf8' });
     await processList(parser, text, lineto, partialResultPath);
 
-    writeFile(`${outdir}/${infileParts.name}.results.txt`, stdOutput.join('\n'));
-    writeFile(`${outdir}/${infileParts.name}.dns.results.txt`, JSON.stringify(validatedHostnames, jsonSetMapReplacer, 1));
+    await Promise.all([
+        writeFile(`${outdir}/${infileParts.name}.results.txt`, stdOutput.join('\n')),
+        writeFile(`${outdir}/${infileParts.name}.dns.results.txt`, JSON.stringify(validatedHostnames, jsonSetMapReplacer, 1)),
+    ]);
 
-    fs.rm(partialResultPath);
-
-    await Promise.all(writeOps);
+    await fs.rm(partialResultPath, { force: true });
 }
 
 main();


### PR DESCRIPTION
Fixes #34061.

## Summary

The validator now waits for each partial result write.
It waits for both final result writes in parallel.
It removes the partial result only after all writes finish.
The removal uses the force option.

## Root cause

The writeFile helper added each write after an earlier await.
Promise.all could inspect writeOps before those writes entered the array.
The partial file removal also ran without await.

## Impact

The validator now completes all output writes before it exits.
A missing partial result file no longer causes ENOENT.
Pending writes cannot recreate the partial file after cleanup.
The output paths and formats stay unchanged.

## Checks

- node --check tools/validate/validate.js
- git diff --check
- The original lifecycle test exits with ENOENT.
- The fixed lifecycle test exits with status zero.
- Both final files exist after the fixed test.
- The partial file does not exist after the fixed test.

The lifecycle test uses a temporary directory.
It disables external DNS queries in the ignored build copy.