### PR TITLE
Remove nested push from template expansion

### DIFF
--- a/tools/make-easylist.mjs
+++ b/tools/make-easylist.mjs
@@ -73,7 +73,7 @@ function expandTemplate(wd, parts) {
             if ( expandedParts.has(fpath) === false ) {
                 console.info(`  Inserting ${fpath}`);
                 out.push(
-                    out.push({ file: `${fpath}` }),
+                    { file: fpath },
                     `! *** ${repo}:${fpath} ***`,
                     fs.readFile(`${wd}/${fpath}`, { encoding: 'utf8' })
                         .then(text => fpath.includes('header') ? text : trim(text)),


### PR DESCRIPTION
Fixes #34063.

## Summary

The template expansion now adds the file marker directly.
It no longer adds the return value from a nested push call.

## Root cause

Array.push returns the new array length.
The nested call added that number to the parts array.
The assemble function ignored the number because it only uses strings.

## Impact

The intermediate parts array now contains only intended values.
The file marker, banner, and file content keep their original order.
Generated output stays unchanged.

## Checks

- node --check tools/make-easylist.mjs
- git diff --check
- Generated all seven ublock templates before and after the change.
- Compared 3,626,613 generated bytes.
- Every output file was byte-identical.