### PR TITLE
Update checkout action to v7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           fi
           exit 0
       - name: Clone uAssets
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@v7
         with:
             ref: gh-pages
       - name: Copy filter lists to gh-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           fi
           exit 0
       - name: Clone uAssets
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
         with:
             ref: gh-pages
       - name: Copy filter lists to gh-pages

--- a/.github/workflows/update-3rd-party-assets.yml
+++ b/.github/workflows/update-3rd-party-assets.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Clone uAssets
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@v7
       - name: Fetch 3rd-party assets
         run: |
           ./tools/update-3rdparties.sh

--- a/.github/workflows/update-3rd-party-assets.yml
+++ b/.github/workflows/update-3rd-party-assets.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Clone uAssets
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7.0.1
       - name: Fetch 3rd-party assets
         run: |
           ./tools/update-3rdparties.sh

--- a/.github/workflows/update-easylist.yml
+++ b/.github/workflows/update-easylist.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Clone uAssets
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
       - name: Assemble Easylist assets
         run: |
           ./tools/make-easylist.sh

--- a/.github/workflows/update-easylist.yml
+++ b/.github/workflows/update-easylist.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Clone uAssets
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@v7
       - name: Assemble Easylist assets
         run: |
           ./tools/make-easylist.sh


### PR DESCRIPTION
Fixes #34065.

## Summary

All workflows now use `actions/checkout@v7`.
This replaces two `v4` references and one `v3` reference.
The `v7` tag tracks compatible version 7 releases.

## Impact

The repository now uses one checkout major version.
Future compatible version 7 releases need no manual update.
No checkout inputs changed.
No workflow permissions changed.
No workflow commands changed.

## Checks

- Parsed all three changed workflows as YAML.
- Confirmed that the official `v7` tag exists.
- Ran `git diff --check`.
- Confirmed that the diff changes only three version references.