### PR TITLE
Clean up third-party update temporary file

### DIFF
--- a/tools/update-3rdparties.sh
+++ b/tools/update-3rdparties.sh
@@ -3,6 +3,7 @@
 # This script assumes a linux environment
 
 TEMPFILE=$(mktemp)
+trap 'rm -f "$TEMPFILE"' EXIT
 
 echo "*** uAssets: updating remote assets..."
 


### PR DESCRIPTION
Part of #34067.

## Summary

Register an EXIT trap for the download temporary file.
The trap removes the file on normal exit, failure, or interruption.

## Root cause

The script created one file with mktemp.
It did not remove that file at the end.

## Impact

The script no longer leaves its download file in the temporary directory.
The download and asset update behavior stays unchanged.

## Checks

- bash -n tools/update-3rdparties.sh
- git diff --check
- A mocked download failure leaves the file with the original script.
- The same failure removes the file with the updated script.