### PR TITLE
Clean up diff patch temporary file

### DIFF
--- a/tools/make-diffpatch.sh
+++ b/tools/make-diffpatch.sh
@@ -29,6 +29,7 @@ NEXT_PATCH_FILE="$PATCHES_DIR/$VERSION.patch"
 
 # Temporary file to receive the RCS patch data
 DIFF=$(mktemp)
+trap 'rm -f "$DIFF"' EXIT
 
 FILES=( $(git diff --name-only) )
 for FILE in "${FILES[@]}"; do
@@ -96,5 +97,3 @@ fi
 
 echo -n "$VERSION" > version
 git add version
-
-rm -f "$DIFF"


### PR DESCRIPTION
Part of #34067.

## Summary

Register an EXIT trap for the RCS diff temporary file.
Remove the normal-path cleanup at the end.
The trap now handles every exit path.

## Root cause

The script only removed the file after all commands succeeded.
The set -e option can stop the script before that cleanup.

## Impact

Early failures and interruptions no longer leave the diff file behind.
Patch generation behavior stays unchanged.

## Checks

- bash -n tools/make-diffpatch.sh
- git diff --check
- A forced Git failure leaves the file with the original script.
- The same failure removes the file with the updated script.