### PR TITLE
Clean up diff update temporary resources

### DIFF
--- a/tools/update-diffpatches.sh
+++ b/tools/update-diffpatches.sh
@@ -37,8 +37,18 @@ done
 
 PATCH_FILES=( $(ls -1v "$PATCHES_DIR"/*.patch | head -n -1) )
 
+CLEANUP_FILES=( )
+CLEANUP_DIRS=( )
+cleanup() {
+    rm -f "${CLEANUP_FILES[@]}"
+    rm -rf "${CLEANUP_DIRS[@]}"
+}
+trap cleanup EXIT
+
 NEW_PATCH_FILE=$(mktemp)
+CLEANUP_FILES+=( "$NEW_PATCH_FILE" )
 DIFF_FILE=$(mktemp)
+CLEANUP_FILES+=( "$DIFF_FILE" )
 
 for PATCH_FILE in "${PATCH_FILES[@]}"; do
 
@@ -49,6 +59,7 @@ for PATCH_FILE in "${PATCH_FILES[@]}"; do
     # This will receive a clone of an old version of the current repo
     echo "Fetching repo at $PREVIOUS_VERSION version"
     OLD_REPO=$(mktemp -d)
+    CLEANUP_DIRS+=( "$OLD_REPO" )
     git clone -q --single-branch --branch "$PREVIOUS_VERSION" --depth=1 "https://github.com/$REPO_DIR.git" "$OLD_REPO" 2>/dev/null || true
 
     # Skip if version doesn't exist
@@ -110,6 +121,3 @@ for PATCH_FILE in "${PATCH_FILES[@]}"; do
     git add -u "$PATCH_FILE"
 
 done
-
-rm -f "$DIFF_FILE"
-rm -f "$NEW_PATCH_FILE"


### PR DESCRIPTION
Part of #34067.

## Summary

Register an EXIT trap for temporary files and clone directories.
Track every path returned by mktemp.
Remove the normal-path file cleanup at the end.

## Root cause

The script only removed its two files after the loop completed.
Failures and interruptions could bypass those commands.
A failed clone also skipped the existing directory cleanup.

## Impact

The script removes temporary files on every exit path.
It also removes directories from failed clone attempts.
Diff patch generation behavior stays unchanged.

## Checks

- bash -n tools/update-diffpatches.sh
- git diff --check
- A failed clone leaves its directory with the original script.
- The updated script removes both files and the clone directory.