### PR TITLE
csdn: click trackers

### DIFF
--- a/filters/privacy.txt
+++ b/filters/privacy.txt
@@ -1137,6 +1137,8 @@ touchgal.ink##+js(href-sanitizer, body a[href^="/redirect?url=http"], ?url)
 ! https://github.com/uBlockOrigin/uAssets/pull/34060
 ||sspai.com/link?target=http$doc,urlskip=?target
 sspai.com##+js(href-sanitizer, body a[href^="https://sspai.com/link?target=http"], ?target)
+! https://github.com/uBlockOrigin/uAssets/pull/34090
+||link.csdn.net^$urlskip=?target
 
 ! https://github.com/uBlockOrigin/uAssets/issues/24675 - click tracking
 ||cdn.digg.com/fragments/homepage/static/view-frontpage.js


### PR DESCRIPTION
Example webpage: `https://blog.csdn.net/nyist_zxp/article/details/120031279`

Although the browser displays it as a direct link, clicking it redirects the user to an intermediate page. For example: `https://link.csdn.net/?from_id=120031279&target=https%3A%2F%2Fmxlinux.org%2F`