### PR TITLE
Update unbreak.txt with ksp.co.il

### DIFF
--- a/filters/unbreak.txt
+++ b/filters/unbreak.txt
@@ -6035,3 +6035,7 @@ book.trivago.com##+js(set, RISKX.setSid, noopFunc)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/1vkodxb/adblock_detection_on_minishortcom/
 ||imasdk.googleapis.com/js/sdkloader/ima3.js$redirect=noopjs,domain=minishort.com
+
+! ksp.co.il - breaks when cookie prompt js file is blocked
+ksp.co.il##+js(set-constant, gtag, noopFunc)
+ksp.co.il##+js(set-constant, dataLayer, emptyArr)


### PR DESCRIPTION
Added rules to handle cookie prompts and potential adblock detection.

### URL(s) where the issue occurs

https://ksp.co.il

### Describe the issue

When an adblocker blocks the cookie prompt in ksp.co.il, an error appears that lets the user know there has been an error loading the page and they should try again in 10 seconds or later

### Screenshot(s)

<details>

<img width="455" height="884" alt="image" src="https://github.com/user-attachments/assets/c97c2a11-6144-4048-936c-b0604d3c5e15" />

</details>


### Versions

- Browser/version: 151.0.7922.137, brave v1.93.136
- uBlock Origin version: 1.73.0

### Settings

tried turning on annoyance filters, and well a workaround that works is disabling the ad blocker/whitelisting the script if it gets blocked(it seems to sometimes get blocked and sometimes not get blocked)

### Notes

Good thing to know is that the website appears to be blocking foreigners, might be blocking VPN use, and it's blocking brave browser though that should be mitigated soon:tm: as relevant pull requests I created were approved in brave's adblock list repo 