### PR TITLE
Update annoyances-others.txt

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -17,9 +17,6 @@ cine.to##+js(aopr, oncontextmenu)
 
 desbloqueador.*##+js(aopr, document.oncontextmenu)
 
-megapastes.com##+js(aopr, document.oncontextmenu)
-megapastes.com##+js(aopr, document.onselectstart)
-
 ! https://github.com/uBlockOrigin/uAssets/issues/1453
 s0urce.io##+js(aeld, /^(contextmenu|copy)$/)
 


### PR DESCRIPTION
`megapastes.com`

The link is now redirecting to some malware site:
<img width="943" height="651" alt="image" src="https://github.com/user-attachments/assets/bfd0e66c-3a60-45c3-8703-7edabfebec05" />

