### PR TITLE
Add anti right-click rule for camere-live.ro

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -248,6 +248,9 @@ hk01.com##+js(trusted-replace-argument, String.prototype.includes, 0, , conditio
 ! https://github.com/uBlockOrigin/uAssets/issues/34089
 ||tvzonehd.com/anti-copy.js
 
+! camere-live.ro anti right-click
+camere-live.ro##+js(aeld, contextmenu)
+
 ! END: Anti copy, right-click etc.
 
 ! START: Anti-adblock

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -248,8 +248,8 @@ hk01.com##+js(trusted-replace-argument, String.prototype.includes, 0, , conditio
 ! https://github.com/uBlockOrigin/uAssets/issues/34089
 ||tvzonehd.com/anti-copy.js
 
-! camere-live.ro anti right-click
-camere-live.ro##+js(aeld, contextmenu)
+! https://github.com/uBlockOrigin/uAssets/pull/34124
+camere-live.ro##+js(rmnt, script, "'contextmenu'")
 
 ! END: Anti copy, right-click etc.
 


### PR DESCRIPTION
Allows right-click on `https://camere-live.ro/`.

By default, it shows this on right-click:
<img width="519" height="249" alt="image" src="https://github.com/user-attachments/assets/d54717b2-b0b6-45f3-94d4-86ced163620a" />
