### PR TITLE
Update annoyances-cookies.txt

### DIFF
--- a/filters/annoyances-cookies.txt
+++ b/filters/annoyances-cookies.txt
@@ -968,9 +968,6 @@ coinbase.com##+js(trusted-set-cookie, cm_eu_preferences, {%22consent%22:[%22nece
 ! https://go-e.com/en/ - Functional
 go-e.com##+js(trusted-set-cookie, gdpr, {%22version%22:%221.0_tracking%22%2C%22options%22:{%22typo3%22:true%2C%22gdpr%22:true%2C%22openstreetmap%22:true%2C%22vimeo%22:true%2C%22youtube%22:true%2C%22recaptcha%22:true%2C%22googlemaps%22:true%2C%22tracking%22:false}})
 
-! https://github.com/uBlockOrigin/uAssets/issues/2054
-f1racing.pl##+js(trusted-click-element, [href="/x-set-cookie/"])
-
 ! https://www.starcar.de/ - External media
 starcar.de##+js(trusted-set-cookie, privacy_consent, %7B%22essentials%22%3Atrue%2C%22statistics%22%3Afalse%2C%22marketing%22%3Afalse%2C%22maps%22%3Atrue%2C%22youtube%22%3Atrue%7D)
 


### PR DESCRIPTION
The website has been down since March 2026:


> The domain f1racing.pl has been parked with ddregistrar.pl