### PR TITLE
Fix xhamster massive spam requests on videos [NSFW]

### DIFF
--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -213,3 +213,10 @@ igniteseurope.com##+js(no-xhr-if, igniteseurope.com/stats/)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/1vewpo7/how_to_stop_injectscriptadjustjs_spam/
 kick.com##+js(no-fetch-if, litix.io)
+
+! https://github.com/uBlockOrigin/uAssets/issues/23538#issuecomment-5306904084
+xhamster.com##+js(no-xhr-if, /(?:hpyjmp|marzaent)\.com\/api\/models\/ts/)
+xhamster.com##+js(no-fetch-if, /(?:hpyjmp|marzaent)\.com\/api\/models\/ts/)
+||hpyjmp.com^$3p,important,domain=xhamster.com
+||marzaent.com^$3p,important,domain=xhamster.com
+||juneworewyjyna.com^

--- a/filters/resource-abuse.txt
+++ b/filters/resource-abuse.txt
@@ -215,8 +215,6 @@ igniteseurope.com##+js(no-xhr-if, igniteseurope.com/stats/)
 kick.com##+js(no-fetch-if, litix.io)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/23538#issuecomment-5306904084
-xhamster.com##+js(no-xhr-if, /(?:hpyjmp|marzaent)\.com\/api\/models\/ts/)
-xhamster.com##+js(no-fetch-if, /(?:hpyjmp|marzaent)\.com\/api\/models\/ts/)
-||hpyjmp.com^$3p,important,domain=xhamster.com
-||marzaent.com^$3p,important,domain=xhamster.com
+xhamster.com##+js(no-xhr-if, /hpyjmp|marzaent/)
+xhamster.com##+js(no-fetch-if, /hpyjmp|marzaent/)
 ||juneworewyjyna.com^


### PR DESCRIPTION
These filters fix spam requests made by `xhamster.com` when you enter a video and/or after clicking the play button.

They spam a few `marzaent.com` in like the first second of the page, and then a lot of `hpyjmp.com` every second.

In addition, `juneworewyjyna.com` seems to be an ad server, it's already in AdGuard Base list:
https://github.com/user-attachments/assets/61328359-07a0-4ece-9f70-20b576ee2fcf


<details>

<img width="1590" height="826" alt="Screenshot 2026-08-16 174720" src="https://github.com/user-attachments/assets/62162187-22ca-44f9-a188-ecd8a07c7cd1" />
<img width="1583" height="824" alt="Screenshot 2026-08-17 185834" src="https://github.com/user-attachments/assets/81e1de8a-77e4-44e5-bfa6-085a5bfa5ea0" />
<img width="1583" height="960" alt="image" src="https://github.com/user-attachments/assets/98404f49-dcc8-470e-869c-ed21de3460f1" />

</details>
