### PR TITLE
[NSFW] gay.bingo ad leftovers 

### DIFF
--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -1617,3 +1617,6 @@ bergwelten.com##+js(nostif, /adblock|Error|getComputedStyle/)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/34154
 ||waldnet.nl/assets/js/abd.js
+
+! gay.bingo ad leftovers
+gay.bingo##div[data-title="Advertisement"]


### PR DESCRIPTION
Hides these leftovers from `gay.bingo`:

<img width="1918" height="966" alt="Screenshot 2026-08-18 142545" src="https://github.com/user-attachments/assets/dd57c38a-bc91-4efd-ba09-653654bca910" />
