### PR TITLE
fix daddylive anti-right click on players

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -251,6 +251,10 @@ hk01.com##+js(trusted-replace-argument, String.prototype.includes, 0, , conditio
 ! https://github.com/uBlockOrigin/uAssets/pull/34124
 camere-live.ro##+js(rmnt, script, "'contextmenu'")
 
+! daddylive anti right-click on player
+hamis.romponalis.st##+js(aeld, contextmenu)
+dollardescent.net##+js(aeld, contextmenu)
+
 ! END: Anti copy, right-click etc.
 
 ! START: Anti-adblock

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -251,7 +251,7 @@ hk01.com##+js(trusted-replace-argument, String.prototype.includes, 0, , conditio
 ! https://github.com/uBlockOrigin/uAssets/pull/34124
 camere-live.ro##+js(rmnt, script, "'contextmenu'")
 
-! ! https://github.com/uBlockOrigin/uAssets/pull/34161/
+! https://github.com/uBlockOrigin/uAssets/pull/34161/
 dlstreams.st,dollardescent.net,hamis.romponalis.st##+js(rmnt, script, "'contextmenu'")
 
 ! END: Anti copy, right-click etc.

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -251,9 +251,8 @@ hk01.com##+js(trusted-replace-argument, String.prototype.includes, 0, , conditio
 ! https://github.com/uBlockOrigin/uAssets/pull/34124
 camere-live.ro##+js(rmnt, script, "'contextmenu'")
 
-! daddylive anti right-click on player
-hamis.romponalis.st##+js(aeld, contextmenu)
-dollardescent.net##+js(aeld, contextmenu)
+! ! https://github.com/uBlockOrigin/uAssets/pull/34161/
+dlstreams.st,dollardescent.net,hamis.romponalis.st##+js(rmnt, script, "'contextmenu'")
 
 ! END: Anti copy, right-click etc.
 


### PR DESCRIPTION
The filters restore right-click on the site's players.

<details>
<img width="1470" height="797" alt="Screenshot 2026-08-18 225821" src="https://github.com/user-attachments/assets/a7fc7ba1-91bb-4b69-b1fd-a77c737ae422" />
<img width="1919" height="784" alt="Screenshot 2026-08-18 232437" src="https://github.com/user-attachments/assets/37357b58-ad04-40a9-9915-28db9c0ea57a" />
<img width="1919" height="840" alt="Screenshot 2026-08-18 232458" src="https://github.com/user-attachments/assets/6ae95eb6-10a1-4d5a-bd3e-835ef9bb4c57" />
</details>

Link for test: `https://dlstreams.st/watch.php?id=648`

