### PR TITLE
 Fix hymnary.org soft anti-adb

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -397,7 +397,7 @@ jelonka.com##+js(trusted-set-local-storage-item, jelonka_news_ad_access_gate_sof
 ! https://www.reddit.com/r/uBlockOrigin/comments/1vcb1va/metacritic_adblock_nag/
 metacritic.com##+js(trusted-set-session-storage-item, BT_AM_SOFTWALL_DISMISSED, {"element":"continue-to-site"})
 
-! hymnary.org anti-adb
+! https://github.com/uBlockOrigin/uAssets/pull/34169
 hymnary.org##div#blockbanner
 
 ! END: Anti-adblock

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -397,6 +397,9 @@ jelonka.com##+js(trusted-set-local-storage-item, jelonka_news_ad_access_gate_sof
 ! https://www.reddit.com/r/uBlockOrigin/comments/1vcb1va/metacritic_adblock_nag/
 metacritic.com##+js(trusted-set-session-storage-item, BT_AM_SOFTWALL_DISMISSED, {"element":"continue-to-site"})
 
+! hymnary.org anti-adb
+hymnary.org##div#blockbanner
+
 ! END: Anti-adblock
 
 ! https://github.com/uBlockOrigin/uAssets/issues/933


### PR DESCRIPTION
<img width="1919" height="117" alt="image" src="https://github.com/user-attachments/assets/6574bc42-b1d5-45c1-931b-eecc12c82fa2" />

The filter hides this soft anti-adblock on: `https://hymnary.org/text/o_come_all_ye_faithful_joyful_and_triump`