### PR TITLE
update https://github.com/uBlockOrigin/uAssets/issues/32767

### DIFF
--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -972,8 +972,8 @@ vipleague.ws>>##+js(rpnt, script, brave, xxxxx)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/32767
 aha-music.com##+js(aopw, __tcfapi)
-aha-music.com##+js(set-constant, ezRewardedAds.requestAndShow, noopFunc)
-aha-music.com##+js(adjust-setTimeout, /timeout/, *, 0.02)
+aha-music.com##+js(set, ezRewardedAds.requestAndShow, noopFunc)
+aha-music.com##+js(adjust-setTimeout, timeout, *, 0.02)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/32776
 urbandictionary.com###ud-root > div[class]:has(div[class*="leaderboard"])

--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -970,6 +970,11 @@ onlyfans.to,upbolt.to##+js(nowoif, _blank)
 ! vip league brave detection
 vipleague.ws>>##+js(rpnt, script, brave, xxxxx)
 
+! https://github.com/uBlockOrigin/uAssets/issues/32767
+aha-music.com##+js(aopw, __tcfapi)
+aha-music.com##+js(set-constant, ezRewardedAds.requestAndShow, noopFunc)
+aha-music.com##+js(adjust-setTimeout, /timeout/, *, 0.02)
+
 ! https://github.com/uBlockOrigin/uAssets/issues/32776
 urbandictionary.com###ud-root > div[class]:has(div[class*="leaderboard"])
 


### PR DESCRIPTION
The filters fix https://github.com/uBlockOrigin/uAssets/issues/32767#issuecomment-4505534209 partially, in the sense that when clicking the button "Watch a short ad to identify music" the "scan" happens instantly, allowing for much easier bypass of that ad gate, even though multiple clicks are needed.

https://github.com/uBlockOrigin/uAssets/issues/32767#issuecomment-4958328847 will be fixed when this pull request is merged: https://github.com/easylist/easylist/pull/24972