### PR TITLE
fix: #34177

### DIFF
--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -1369,7 +1369,6 @@ talksport.com##+js(nostif, ()=>, 1000)
 
 ! https://chzzk.naver.com - anti-adblock. Login is required.
 chzzk.naver.com##+js(spoof-css, .banner_ad_wrapper, display, block)
-chzzk.naver.com##+js(no-xhr-if, /(veta.naver.com\/vas|veta.naver.com\/gfp|veta.naver.com\/call)/ method:OPTIONS)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/33505
 greeksubsmovies.net##+js(rmnt, script, offsetHeight)
@@ -1626,3 +1625,8 @@ bergwelten.com##+js(nostif, /adblock|Error|getComputedStyle/)
 
 ! https://javplayer.com popup
 javplayer.com##+js(aeld, /click|pointerup/, handleUserAction)
+
+! https://github.com/uBlockOrigin/uAssets/issues/34177
+||nam.veta.naver.com/gfp/v1$xhr,method=options,redirect=noopjson,domain=chzzk.naver.com
+||nam.veta.naver.com/call$xhr,method=options,redirect=noopjson,domain=chzzk.naver.com
+||nam.veta.naver.com/vas$xhr,method=options,redirect=noopjson,domain=chzzk.naver.com


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://chzzk.naver.com/`

The issue is specifically shows up when trying to watch the active live from any streamer.
For the actual url syntax, `https://chzzk.naver.com/live/{channelId}` where 'channelId' differs by each streamer.

### Describe the issue

#34177. Adblock detection.

### Screenshot(s)

- Main Computer: 
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/798b2106-f05e-460e-b404-5a7258533bc3" />

- Sandbox:
<img width="2034" height="1094" alt="image" src="https://github.com/user-attachments/assets/4cb8235e-1469-46ec-85ca-b269ace4be2d" />


### Versions

Main Computer

- Browser/version: ungoogled-chromium / 151.0.7922.137 (Official Build, ungoogled-chromium) (64-bit)
- uBlock Origin version: 1.73.0

Sandbox

- Browser/version: Microsoft Edge / 151.0.4129.93 (Official build) (64-bit)
- uBlock Origin version: 1.73.0

### Settings

Main Computer (tried my best to match the default configurations, also disabled the user filters even though it's listed):
```yaml
uBlock Origin: 1.73.0
Chromium: 151
filterset (summary):
 network: 181266
 cosmetic: 43529
 scriptlet: 37450
 html: 0
listset (total-discarded, last-updated):
 removed:
  user-filters: null
 default:
  ublock-filters: 53015-87, 1h.7m
  ublock-badware: 10189-17, 1h
  ublock-privacy: 4128-4, now Δ
  ublock-unbreak: 2802-1, 1h
  ublock-quick-fixes: 491-0, now Δ
  easylist: 85657-481, now Δ
  easyprivacy: 56369-742, 1h
  urlhaus-1: 47545-11, 1h
  plowe-0: 3522-0, 1h
filterset (user): [array of 17 redacted]
trustedset:
 added: [array of 1 redacted]
userSettings:
 advancedUserEnabled: true
 suspendUntilListsAreLoaded: true
 userFiltersTrusted: true
hiddenSettings: [none]
supportStats:
 allReadyAfter: 257 ms (selfie)
 maxAssetCacheWait: 71 ms
 cacheBackend: indexedDB
popupPanel:
 blocked: 1
 network:
  pstatic.net: 1
 extended:
  ##+js(prevent-xhr, /(veta.naver.com\/vas|veta.naver.com\/gfp|vet…
  ##+js(spoof-css, .banner_ad_wrapper, display, block)
  ##+js(trusted-set-local-storage-item, homeSkinCollapsedUntil, 99…
  ##+js(prevent-clipboard-write, /^mshta |^msiexec |^(bash <<<|cur…
```

Windows Sandbox:
```yml
uBlock Origin: 1.73.0
Chromium: 151
filterset (summary):
 network: 181436
 cosmetic: 43535
 scriptlet: 37450
 html: 0
listset (total-discarded, last-updated):
 default:
  user-filters: 0-0, never
  ublock-filters: 53015-177, 59m
  ublock-badware: 10189-41, 1h
  ublock-privacy: 4128-8, 1h
  ublock-unbreak: 2802-0, 53m Δ
  ublock-quick-fixes: 491-0, 53m Δ
  easylist: 85813-21, 53m Δ
  easyprivacy: 56369-742, 1h
  urlhaus-1: 47560-6, 1h
  plowe-0: 3522-343, 1h
filterset (user): [empty]
userSettings: [none]
hiddenSettings: [none]
supportStats:
 allReadyAfter: 343 ms (selfie)
 maxAssetCacheWait: 49 ms
 cacheBackend: indexedDB
popupPanel:
 blocked: 64
 network:
  naver.com: 57
  imasdk.googleapis.com: 6
  pstatic.net: 1
 extended:
  ##+js(prevent-xhr, /(veta.naver.com\/vas|veta.naver.com\/gfp|vet…
  ##+js(spoof-css, .banner_ad_wrapper, display, block)
  ##+js(trusted-set-local-storage-item, homeSkinCollapsedUntil, 99…
  ##+js(prevent-clipboard-write, /^mshta |^msiexec |^(bash <<<|cur…
  ##.banner_ad_wrapper
```

### Notes

This PR fixes issue #34177, which tried to bypass CHZZK's `isXhrTampered()` check. Main notes are listed inside issue, so please check the issue first.