### PR TITLE
fix #34197

### DIFF
--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -1639,3 +1639,6 @@ javplayer.com##+js(aeld, /click|pointerup/, handleUserAction)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/34172
 /^https:\/\/engine\.[a-z]+\.[a-z]+\/\?[0-9]+$/$xhr,3p
+
+! https://github.com/uBlockOrigin/uAssets/issues/34197
+||youtubetoolkit.com/js/adblock-$script


### PR DESCRIPTION
Fixes the anti-adblock on `https://youtubetoolkit.com/`

They use two detection scripts: 
<img width="1192" height="725" alt="image" src="https://github.com/user-attachments/assets/bf849770-e598-4968-849b-5fbb14abd0e2" />


Feel free to correct it if it's not a good filter.