### PR TITLE
fix #34201

### DIFF
--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -1644,4 +1644,4 @@ javplayer.com##+js(aeld, /click|pointerup/, handleUserAction)
 ||youtubetoolkit.com/js/adblock-
 
 ! https://github.com/uBlockOrigin/uAssets/issues/34201
-||antiadblockcore.com^$script,domain=pahe.ink
+||antiadblockcore.com^

--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -1642,3 +1642,6 @@ javplayer.com##+js(aeld, /click|pointerup/, handleUserAction)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/34197
 ||youtubetoolkit.com/js/adblock-
+
+! https://github.com/uBlockOrigin/uAssets/issues/34201
+||antiadblockcore.com^$script,domain=pahe.ink


### PR DESCRIPTION
The site uses anti-adblock scripts from `antiadblockcore.com`:
<img width="1919" height="757" alt="image" src="https://github.com/user-attachments/assets/a4b97162-e7d5-4fcb-b9cc-2a39eca30a39" />

Feel free to improve the filter, if needed.