### PR TITLE
rdse.lat popup

### DIFF
--- a/filters/filters-2026.txt
+++ b/filters/filters-2026.txt
@@ -1676,3 +1676,6 @@ spotsaver.net##+js(nowoif)
 ! https://github.com/uBlockOrigin/uAssets/issues/34236
 pixhost.*##+js(rmnt, script, AdProvider)
 pixhost.*##.content-companion
+
+! rdse.lat - popup
+rdse.lat##+js(nowoif)


### PR DESCRIPTION

<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://v1.rdse.lat/sportv`

Accessed from Brazil

### Describe the issue

Clicking the player open a popup.

### Screenshot(s)

<details><summary>Screen</summary>
<img width="1366" height="768" alt="Captura de tela de 2026-08-25 20-47-43" src="https://github.com/user-attachments/assets/c0c3ec92-3c6e-4785-a0ac-58395d3be373" />
</details>

### Versions

- Browser/version: Firefox 154.0 
- uBlock Origin version: 1.73.0

### Settings

Default

### Notes

<details><summary>Screen</summary>
<img width="916" height="253" alt="Captura de tela de 2026-08-25 20-48-43" src="https://github.com/user-attachments/assets/b8107119-cfea-44a2-8b60-feacc5fbfa44" />

