### PR TITLE
Hiding anti adblock annoyance on finance.kooorazoom.net

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -8228,3 +8228,6 @@ t3.chat##+js(nostif, .abort();, 1000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/34096
 parsatv.com##+js(rmnt, script, .offsetHeight)
+
+! finance.kooorazoom.net anti adblock annoyance
+finance.kooorazoom.net##+js(set, 'adBlockBlock', 1)


### PR DESCRIPTION
### URL(s) where the issue occurs

`https://finance.kooorazoom.net/`

### Describe the issue

There is an anti-adblock popup on this page that needs to be hidden so users can access the page while ads continue to be blocked.

### Screenshot(s)

<details>

<img width="1237" height="663" alt="image" src="https://github.com/user-attachments/assets/d301040d-2070-4ccc-80a7-d4d71ff1ae32" />

</details>


### Versions

- Browser/version: Brave 1.96.4