### PR TITLE
Hiding anti adblock notice on hdstreamverse.xyz

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -8231,5 +8231,5 @@ t3.chat##+js(nostif, .abort();, 1000)
 ! https://github.com/uBlockOrigin/uAssets/issues/34096
 parsatv.com##+js(rmnt, script, .offsetHeight)
 
-! hdstreamverse.xyz anti adblock annoyance
-||hdstreamverse.xyz/wp-content/plugins/adblock-detector/adblock-detector.js
+! https://github.com/uBlockOrigin/uAssets/pull/34292
+/wp-content/plugins/adblock-detector/*$script

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -8230,3 +8230,6 @@ t3.chat##+js(nostif, .abort();, 1000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/34096
 parsatv.com##+js(rmnt, script, .offsetHeight)
+
+! hdstreamverse.xyz anti adblock annoyance
+||hdstreamverse.xyz/wp-content/plugins/adblock-detector/adblock-detector.js


### PR DESCRIPTION
### URL(s) where the issue occurs

`hdstreamverse.xyz`

### Describe the issue

This site contains an anti-adblock notice that is easily removed with a network filter, blocking the script that serves the notice to users. This site has been reported to Brave, but the notice is also visible on Firefox+uBO.

### Screenshot(s)

<img width="1381" height="755" alt="image" src="https://github.com/user-attachments/assets/d17e3e51-8efc-4c03-9274-f9eca18e4ac2" />


### Versions

- Browser/version: Brave 1.96.14