### PR TITLE
fix redecanais anti-right on player, and fullscreen when player loaded

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -6968,8 +6968,16 @@ with.is##*:style(-webkit-touch-callout: default !important; -webkit-user-select:
 ! https://github.com/uBlockOrigin/uAssets/issues/21487
 movie-web.app##+js(noeval-if, debugger)
 
-! redecanais.zip anti right-click, select, ctrl u, f12
+! redecanais anti right-click, select, ctrl u, f12
 redecanais.*,redecanaistv.*,redisex.*,xn-----0b4asja7ccgu2b4b0gd0edbjm2jpa1b1e9zva7a0347s4da2797e8qri.xn--1ck2e1b,xn--90afacv0clj6ac0dxa.xn--p1ai,xn--90afacv0cu2a3cr.xn--p1ai##+js(rmnt, script, /closeWindow\(\)|clickIE\(\)|reEnable\(\)/)
+redecanaistv.*##+js(aopw, document.oncontextmenu)
+redecanaistv.*##+js(addEventListener-defuser, contextmenu)
+redecanaistv.*##+js(remove-attr, oncontextmenu|ondragstart|onselectstart)
+redecanaistv.*##:style(user-select: auto !important;)
+! redecanais entering full screen after player loaded
+redecanaistv.*##+js(aopr, requestFullscreen)
+redecanaistv.*##+js(aopr, Element.prototype.requestFullscreen)
+redecanaistv.*##+js(aopw, document.fullscreenEnabled)
 
 ! hoca4u .com anti right-click
 hoca4u.com##+js(ra, oncontextmenu)

--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -6973,7 +6973,6 @@ redecanais.*,redecanaistv.*,redisex.*,xn-----0b4asja7ccgu2b4b0gd0edbjm2jpa1b1e9z
 redecanaistv.*##+js(aopw, document.oncontextmenu)
 redecanaistv.*##+js(addEventListener-defuser, contextmenu)
 redecanaistv.*##+js(remove-attr, oncontextmenu|ondragstart|onselectstart)
-redecanaistv.*##:style(user-select: auto !important;)
 ! redecanais entering full screen after player loaded
 redecanaistv.*##+js(aopr, requestFullscreen)
 redecanaistv.*##+js(aopr, Element.prototype.requestFullscreen)


### PR DESCRIPTION
On `https://redecanaistv.af/assistir-discovery-science-online-24-horas-ao-vivo_2f369e9c3.html` the player doesn't allow right-click, and also enters full screen when it loaded, which is in my opinion, an annoyance.

<img width="1240" height="809" alt="image" src="https://github.com/user-attachments/assets/6e110d9b-eb48-4529-ac11-9a16863a9628" />
