### PR TITLE
Hiding anti adblock warning on games360rgh.com

### DIFF
--- a/filters/annoyances-others.txt
+++ b/filters/annoyances-others.txt
@@ -8232,3 +8232,6 @@ t3.chat##+js(nostif, .abort();, 1000)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/34096
 parsatv.com##+js(rmnt, script, .offsetHeight)
+
+! games360rgh.com anti adblock annoyance
+games360rgh.com##+js(aopr, 'antiAdBlockerHandler')


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`games360rgh.com`

### Describe the issue

This site has an anti adblock popup that can be easily dismissed through disabling the function that serves the popup. This popup was reported on Brave, but is also reproducible on Firefox+uBO.

### Screenshot(s)

<img width="2204" height="1362" alt="image" src="https://github.com/user-attachments/assets/344da645-44a3-4bc4-8b8d-71c1935e4009" />


### Versions

- Browser/version: Brave 1.96.14
