### PR TITLE
update https://github.com/uBlockOrigin/uAssets/pull/34246

### DIFF
--- a/filters/filters-general.txt
+++ b/filters/filters-general.txt
@@ -3916,8 +3916,8 @@ elamigosgamez.net##h3.my-4:has-text(/^Advertising/)
 ||adme2.click^
 
 ! https://github.com/uBlockOrigin/uAssets/pull/34246
-rdse.lat##+js(aeld, click, pop_)
-rdse.lat##+js(nowoif)
+rdse.*##+js(aeld, click, pop_)
+rdse.*##+js(nowoif)
 
 ! NOTE: Thai
 ! https://github.com/uBlockOrigin/uAssets/issues/29831


### PR DESCRIPTION


<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://v1.rdse.lol/sportv`

### Describe the issue

Constantly changing the domain.
The popup reappeared.
Changing `lat` to `*` solves the problem.

### Versions

- Browser/version: Firefox 155.0.1
- uBlock Origin version: 1.74.0

### Settings

Default
